### PR TITLE
Okular on a Linux machine to view PDFs. 

### DIFF
--- a/viewPDF.py
+++ b/viewPDF.py
@@ -30,7 +30,11 @@ class View_pdfCommand(sublime_plugin.WindowCommand):
 			# Search in the GUI: under Settings|Options...
 			# Under "Set inverse search command-line", set:
 			# sublime_text "%f":%l
-			viewercmd = ["SumatraPDF", "-reuse-instance"]		
+			viewercmd = ["SumatraPDF", "-reuse-instance"]
+		elif s == "Linux":
+			# for inverse search: Settings|Configure Okular|Editor ...
+			# Under "Command" set: sublime_text" "%f":%l
+			viewercmd = ["okular", "--unique"]					
 		else:
 			sublime.error_message("Platform as yet unsupported. Sorry!")
 			return	


### PR DESCRIPTION
I use Okular on a Linux machine to view my LaTex-PDFs while editing. Thus, I added the "Linux" case for viewing the PDF.
