### PR TITLE
Prevent hanging on build errors on Linux

### DIFF
--- a/LaTeX.sublime-build
+++ b/LaTeX.sublime-build
@@ -117,7 +117,7 @@
 		// backward/forward search, forcing compilation (e.g. even if no bib file is found)
 		// and producing pdf rather than dvi output
 		"cmd": ["latexmk", 
-				"-e", "\\$pdflatex = 'pdflatex %O -synctex=1 %S'",
+				"-e", "\\$pdflatex = 'pdflatex %O -interaction=nonstopmode -synctex=1 %S'",
 				"-f", "-pdf"],
 
 		// Paths to TeX binaries; needed as GUI apps do not inherit


### PR DESCRIPTION
Change linux build command to use "-interaction=nonstopmode" like OS X
does. This prevents hanging in the build process when, e.g., an include
file is missing.
