### PR TITLE
Multi-file cite completion

### DIFF
--- a/latex_cite_completions.py
+++ b/latex_cite_completions.py
@@ -36,7 +36,7 @@ def find_bib_files(rootdir, src, bibfiles):
             bibfiles.append(bf)
 
     # search through input tex files recursively
-    for f in re.findall(r'\\input\{[^\}]+\}',src_content):
+    for f in re.findall(r'\\(?:input|include)\{[^\}]+\}',src_content):
         input_f = re.search(r'\{([^\}]+)', f).group(1)
         find_bib_files(dir_name, input_f, bibfiles)
 


### PR DESCRIPTION
Added support for multi-file cite completion. Cite completion determines the tex root and recursively searches all referenced tex source (all \input commands) and determines the cite completion suggestions from all referenced bib files (not just the current file).

This partially addresses the multi-file issues in #54.
