### PR TITLE
Project File Support for TEXroot

### DIFF
--- a/getTeXRoot.py
+++ b/getTeXRoot.py
@@ -6,7 +6,17 @@ import os.path, re
 
 # Contributed by Sam Finn
 
-def get_tex_root(texFile):
+def get_tex_root(view):
+	root = os.path.abspath(view.settings().get('TEXroot'))
+	try:
+		if os.path.isfile(root):
+			print "Main file defined in project settings : " + root
+			return root
+	except:
+		pass
+
+
+	texFile = view.file_name()
 	for line in open(texFile, "rU").readlines():
 		if not line.startswith('%'):
 			root = texFile

--- a/jumpToPDF.py
+++ b/jumpToPDF.py
@@ -11,9 +11,7 @@ class jump_to_pdfCommand(sublime_plugin.TextCommand):
 			return
 		quotes = "\""
 		srcfile = texFile + u'.tex'
-		root = self.view.settings().get('TEXroot')
-		if not root:
-			root = getTeXRoot.get_tex_root(self.view.file_name())
+		root = getTeXRoot.get_tex_root(self.view)
 		print "!TEX root = ", root
 		rootName, rootExt = os.path.splitext(root)
 		pdffile = rootName + u'.pdf'

--- a/latex_cite_completions.py
+++ b/latex_cite_completions.py
@@ -115,13 +115,7 @@ class LatexCiteCompletions(sublime_plugin.EventListener):
         completions = ["TEST"]
 
         #### GET COMPLETIONS HERE #####
-        # first search sublime-project file settings for TEXroot
-        root = view.settings().get('TEXroot')
-
-        if not root:
-            # Find tex root and search all tex source referenced
-            # TEX root is the current file itself if no TEX root is specified
-            root = getTeXRoot.get_tex_root(view.file_name())
+        root = getTeXRoot(view)
 
         print "TEX root: " + root
         bib_files = []

--- a/latex_ref_completions.py
+++ b/latex_ref_completions.py
@@ -129,13 +129,7 @@ class LatexRefCompletions(sublime_plugin.EventListener):
         # stop matching at FIRST } after \label{
         view.find_all(r'\\label\{([^\{\}]+)\}', 0, '\\1', completions)
 
-        # first search sublime-project file settings for TEXroot
-        root = view.settings().get('TEXroot')
-
-        if not root:
-            # Find tex root and search all tex source referenced
-            # TEX root is the current file itself if no TEX root is specified
-            root = getTeXRoot.get_tex_root(view.file_name())
+        root = getTeXRoot(view)
 
         print "TEX root: " + root
         find_labels_in_files(os.path.dirname(root), root, completions)

--- a/makePDF.py
+++ b/makePDF.py
@@ -370,9 +370,9 @@ class make_pdfCommand(sublime_plugin.WindowCommand):
 			self.proc = None
 		
 		view = self.window.active_view()
-		self.file_name = view.settings().get('TEXroot')
-		if not self.file_name:
-			self.file_name = getTeXRoot.get_tex_root(view.file_name())
+		
+		self.file_name = getTeXRoot.get_tex_root(view)
+
 		# self.file_name = view.file_name()
 		self.tex_base, self.tex_ext = os.path.splitext(self.file_name)
 		# On OSX, change to file directory, or latexmk will spew stuff into root!

--- a/viewPDF.py
+++ b/viewPDF.py
@@ -15,9 +15,8 @@ class View_pdfCommand(sublime_plugin.WindowCommand):
 			sublime.error_message("%s is not a TeX source file: cannot view." % (os.path.basename(view.fileName()),))
 			return
 		quotes = ""# \"" MUST CHECK WHETHER WE NEED QUOTES ON WINDOWS!!!
-		root = view.settings().get('TEXroot')
-		if not root:
-			root = getTeXRoot.get_tex_root(view.file_name())
+		root = getTeXRoot.get_tex_root(view)
+
 		rootFile, rootExt = os.path.splitext(root)
 		pdfFile = quotes + rootFile + '.pdf' + quotes
 		s = platform.system()


### PR DESCRIPTION
I have used the changes of @cwwwu in Pull Request #69 as a base but moved all operations about getting the main file to getTexRoot.py

Now you can define your Main file by adding `%TEXroot =`  or one of the following example project files: 

```
{
    "folders":
    [
        {
            // Relative or absolute Path to the folder which contains the whole project
            "path": "/"
        }
    ],
    "settings": 
    {
         // Relative Path to the Main Latex File as seen from the project root
         // or absolute path of the mainfile (if you don't want to use a folder)
         "TEXroot" : "ElMasch.tex"
    }
}
```

I have tested it on different projects and it seem to work quite well. 
