### PR TITLE
New way of getting the TEX root (without Config file or Comments in .tex-files)

### DIFF
--- a/getTeXRoot.py
+++ b/getTeXRoot.py
@@ -33,13 +33,13 @@ def get_tex_root(view):
 			break
 		else:
 			# We have a comment match; check for a TEX root match
-			if re.match(r"%\s*!TEX\s+root *= *",line):
+			mroot = re.match(r"%\s*!TEX\s+root *= *(.*(tex|TEX))\s*$",line)
+			if mroot:
 				# we have a TEX root match 
 				# Break the match into path, file and extension
 				# Create TEX root file name
 				# If there is a TEX root path, use it
 				# If the path is not absolute and a src path exists, pre-pend it
-				mroot = re.match(r"%\s*!TEX\s+root *= *(.*tex)\s*$",line)
 				(texPath, texName) = os.path.split(texFile)
 				(rootPath, rootName) = os.path.split(mroot.group(1))
 				root = os.path.join(texPath,rootPath,rootName)


### PR DESCRIPTION
Hey there!

I have a new way of getting the TEXroot:
1. Get the current opened folder in Sublime Text
2. Search all .tex-files
3. Search in each file for "\begin{document}"
4. If it's found, this must be the mainfile

Requirements for this solution: you can not work with a single file, you have to open a folder in sublime text

I think something like this would be a nice solution. But it's on you to decide if you want something like this.

Happy TeXing and Coding phyton!
