### PR TITLE
New Command: Jump to Include/Input (Second try...)

### DIFF
--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -29,6 +29,12 @@ LaTeX Package keymap for Linux
 			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"}],
 		"command": "latex_env_closer"},
 
+
+	{	"keys": ["ctrl+l", "i"],
+		"context": [
+			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"}],
+		"command": "jumpt_to_file"}
+
 	// Complete reference or citation
 	// ctrl+l,ctrl+space suggests ST2's standard autocompletion keybinding, but for LaTeX;
 	// ctrl+l,x suggests "cross" references, which both cites and refs are 

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -29,6 +29,11 @@ LaTeX Package keymap for OS X
 			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"}],
 		"command": "latex_env_closer"},
 
+	{ 	"keys": ["super+l","i"], 
+		"context":  [
+			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"}],
+		"command": "jump_to_include"},
+
 	// Complete reference or citation
 	// cmd+l,ctrl+space suggests ST2's standard autocompletion keybinding, but for LaTeX;
 	// cmd+l,x suggests "cross" references, which both cites and refs are 

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -29,6 +29,11 @@ LaTeX Package keymap for Windows
 			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"}],
 		"command": "latex_env_closer"},
 
+	{ 	"keys": ["ctrl+l","i"], 
+		"context":  [
+			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"}],
+		"command": "jump_to_include"},
+
 	// Complete reference or citation
 	// ctrl+l,ctrl+space suggests ST2's standard autocompletion keybinding, but for LaTeX;
 	// ctrl+l,x suggests "cross" references, which both cites and refs are 

--- a/jumpToInclude.py
+++ b/jumpToInclude.py
@@ -1,0 +1,19 @@
+import sublime, sublime_plugin, re, os.path
+
+class jump_to_includeCommand(sublime_plugin.TextCommand):
+	def run(self, edit, **args):
+		view = self.view
+		selLine = view.substr(view.line(view.sel()[0]))
+		match = re.match(r"\\in(?:clude|put)\{([a-zA-Z\._/\\]+)\}", selLine)
+		if not match:
+			sublime.status_message("Is your cursor on a line with a \input or \include statement?")
+			return
+
+		rootDirName = sublime.active_window().folders()[0]
+		file = os.path.join(rootDirName, match.groups()[0] + ".tex")
+		if not os.path.isfile(file):
+			sublime.status_message("File " + file + "not found.")
+			return
+
+		view.window().open_file(file, sublime.TRANSIENT)
+		return


### PR DESCRIPTION
This command allows you to place the cursor over a `\include{}` or `\input{}` macro and hit `C+l, i` to jump to the included file.

Let me know if you plan to merge this pull request so I can write some documentation!