### PR TITLE
Allow \ref and \cite to include multiple comma-separated entries

### DIFF
--- a/latex_cite_completions.py
+++ b/latex_cite_completions.py
@@ -390,6 +390,12 @@ class LatexCiteCommand(sublime_plugin.TextCommand):
 
         #### END COMPLETIONS HERE ####
 
+        # only match the str between the last comma and cursor point
+        last_comma_pos = prefix.rfind(',')
+        if last_comma_pos > 0:
+            prefix = prefix[last_comma_pos + 1:]
+        else:
+            last_comma_pos = 0
         # filter against keyword, title, or author
         if prefix:
             completions = [comp for comp in completions if prefix.lower() in "%s %s %s" \
@@ -404,11 +410,18 @@ class LatexCiteCommand(sublime_plugin.TextCommand):
                 return
 
             last_brace = "}" if not preformatted else ""
-            cite = "\\cite" + fancy_cite + "{" + completions[i][0] + last_brace
+            if last_comma_pos == 0:
+                # it's the first entry, allow to repalce the whole thing
+                cite = "\\cite" + fancy_cite + "{" + completions[i][0]
+                new_point_a = point - len(expr)
+            else:
+                # only replace the current entry
+                cite = completions[i][0]
+                new_point_a = point - len(prefix)
 
             print "selected %s:%s by %s" % completions[i] 
             # Replace cite expression with citation
-            expr_region = sublime.Region(point-len(expr),point)
+            expr_region = sublime.Region(new_point_a, point)
             ed = view.begin_edit()
             view.replace(ed, expr_region, cite)
             view.end_edit(ed)

--- a/latex_ref_completions.py
+++ b/latex_ref_completions.py
@@ -221,6 +221,12 @@ class LatexRefCommand(sublime_plugin.TextCommand):
             pre_snippet = "\\ref{"
             post_snippet = "}"
 
+        # only match the str between the last comma and cursor point
+        last_comma_pos = prefix.rfind(',')
+        if last_comma_pos > 0:
+            prefix = prefix[last_comma_pos + 1:]
+        else:
+            last_comma_pos = 0
         if not preformatted:
             # Replace ref_blah with \ref{blah
             expr_region = sublime.Region(point - len(expr), point)
@@ -228,7 +234,7 @@ class LatexRefCommand(sublime_plugin.TextCommand):
             ed = view.begin_edit()
             view.replace(ed, expr_region, pre_snippet + prefix)
             # save prefix begin and endpoints points
-            new_point_a = point - len(expr) + len(pre_snippet)
+            new_point_a = point - len(expr) + len(pre_snippet) + last_comma_pos
             new_point_b = new_point_a + len(prefix)
             view.end_edit(ed)
 
@@ -263,7 +269,7 @@ class LatexRefCommand(sublime_plugin.TextCommand):
             if i<0:
                 return
 
-            ref = completions[i] + post_snippet
+            ref = completions[i]
             
 
             print "selected %s" % completions[i] 


### PR DESCRIPTION
Currently, the \ref and \cite commands only allow one entry. However, occasionally, you want to put multiple comma-separated entries into one \ref or \cite command. For example,
\cite{foo,bar}

Caveat: no white space is currently allowed after a comma. While this is legal LaTex syntax, adding the support requires many more lines with regular expression. So I decide to postpone it.
