### PR TITLE
MacPorts fix: Add /opt/local/bin to path on OS X

### DIFF
--- a/LaTeX.sublime-build
+++ b/LaTeX.sublime-build
@@ -39,7 +39,7 @@
 		// Paths to TeX binaries; needed as GUI apps do not inherit
 		// the profile. MUST EXPLICITLY PRE/APPEND $PATH!
 		// This is preconfigured for MacTeX (2009 and up I guess)
-		"path": "$PATH:/usr/texbin:/usr/local/bin",
+		"path": "$PATH:/usr/texbin:/usr/local/bin:/opt/local/bin",
 		
 		// DO NOT MESS WITH THE FOLLOWING!!!
 		"file_regex": "^(...*?):([0-9]+): ([0-9]*)([^\\.]+)"


### PR DESCRIPTION
Binaries for Tex Live and latexmk installs performed via MacPorts live in /opt/local/bin. 

Adding this directory to the path on OS X allows usage of LaTexTools with MacPorts based installs without need for further modifications.
