### PR TITLE
Fix a bug in jump_to_pdf when called from command pannel

### DIFF
--- a/LaTeX.sublime-commands
+++ b/LaTeX.sublime-commands
@@ -1,5 +1,5 @@
 [
 	{ "caption": "LaTeXTools: View PDF", "command": "view_pdf"},
-	{ "caption": "LaTeXTools: Jump to PDF", "command": "jump_to_pdf"},
+	{ "caption": "LaTeXTools: Jump to PDF", "command": "jump_to_pdf", "args": {"from_keybinding": false}},
 	{ "caption": "LaTeXTools: Toggle focus (PDF/editor)", "command": "toggle_focus"}
 ]

--- a/jumpToPDF.py
+++ b/jumpToPDF.py
@@ -20,7 +20,10 @@ class jump_to_pdfCommand(sublime_plugin.TextCommand):
 		# If the PDF viewer window is already visible, s/he probably wants to sync, or s/he would have no
 		# need to invoke the command. And if it is not visible, the natural way to just bring up the
 		# window without syncing is by using the system's window management shortcuts.
-		from_keybinding = args["from_keybinding"]
+		try:
+			from_keybinding = args["from_keybinding"]
+		except:
+			from_keybinding	= False
 		if from_keybinding:
 			keep_focus = False
 			forward_sync = True


### PR DESCRIPTION
_Jump To PDF_ is not working when called from the _Command Panel_.
The reason : in **LaTeX.sublime-commands** the argument `from_keybinding` is missing.
I have added also a exception handling when 'from_keybinding' is checked in **jumpToPDF.py**.