### PR TITLE
Adding Steady Forward Sync

### DIFF
--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -59,6 +59,10 @@ LaTeX Package keymap for Linux
 		"context":  [
 			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"}],
 		"command": "toggle_fwdsync"},
+	{ 	"keys": ["ctrl+l","t","m"],
+		"context":  [
+			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"}],
+		"command": "toggle_steady_sync"},
 	{ 	"keys": ["ctrl+l","t","?"],
 		"context":  [
 			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"}],

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -58,6 +58,10 @@ LaTeX Package keymap for OS X
 		"context":  [
 			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"}],
 		"command": "toggle_fwdsync"},
+	{ 	"keys": ["super+l","t","m"],
+		"context":  [
+			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"}],
+		"command": "toggle_steady_sync"},
 	{ 	"keys": ["super+l","t","?"],
 		"context":  [
 			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"}],

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -58,6 +58,10 @@ LaTeX Package keymap for Windows
 		"context":  [
 			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"}],
 		"command": "toggle_fwdsync"},
+	{ 	"keys": ["ctrl+l","t","m"],
+		"context":  [
+			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"}],
+		"command": "toggle_steady_sync"},
 	{ 	"keys": ["ctrl+l","t","?"],
 		"context":  [
 			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"}],

--- a/Default.sublime-mousemap
+++ b/Default.sublime-mousemap
@@ -1,0 +1,8 @@
+[
+	{
+		"button" : "button1",
+		"count" : 1,
+		"press_command": "drag_select",		
+		"command" : "steady_sync_callback"
+	}	
+]

--- a/LaTeXTools Preferences.sublime-settings
+++ b/LaTeXTools Preferences.sublime-settings
@@ -9,6 +9,9 @@
 	// Sync PDF to current editor position after building (true) or not 
 	"forward_sync":	true,
 
+	//Perform steady sync between editor and position after building
+	"steady_sync" : true,
+
 	// Settings that are specific to Linux platforms
 	"linux": {
 		// Command to invoke Python 2. Useful if you have both Python 2 and Python 3 on your system,

--- a/jumpToPDF.py
+++ b/jumpToPDF.py
@@ -20,7 +20,7 @@ class jump_to_pdfCommand(sublime_plugin.TextCommand):
 		# If the PDF viewer window is already visible, s/he probably wants to sync, or s/he would have no
 		# need to invoke the command. And if it is not visible, the natural way to just bring up the
 		# window without syncing is by using the system's window management shortcuts.
-		from_keybinding = "from_keybinding" in args and args["from_keybinding"]
+		from_keybinding = args.get("from_keybinding", False)
 		if from_keybinding:
 			keep_focus = False
 			forward_sync = True

--- a/jumpToPDF.py
+++ b/jumpToPDF.py
@@ -20,7 +20,7 @@ class jump_to_pdfCommand(sublime_plugin.TextCommand):
 		# If the PDF viewer window is already visible, s/he probably wants to sync, or s/he would have no
 		# need to invoke the command. And if it is not visible, the natural way to just bring up the
 		# window without syncing is by using the system's window management shortcuts.
-		from_keybinding = args["from_keybinding"]
+		from_keybinding = "from_keybinding" in args and args["from_keybinding"]
 		if from_keybinding:
 			keep_focus = False
 			forward_sync = True

--- a/steady_sync.py
+++ b/steady_sync.py
@@ -1,0 +1,33 @@
+import sublime, sublime_plugin
+
+class SteadySyncCallbackCommand(sublime_plugin.TextCommand):
+
+    def run(self, edit, **args):
+        print "Run"
+        # Check if steady sync is enabled
+        s = sublime.load_settings("LaTeXTools Preferences.sublime-settings")
+        if s.get("steady_sync", True):
+            if self.view.is_scratch() or not self.view.file_name():
+                return
+            # get the file name and try to open the pdf viewer
+            file_name = self.view.file_name()
+            scope = self.view.scope_name(self.view.sel()[0].a)
+            base_scope_name = scope.split()[0]
+
+            if base_scope_name == "text.tex.latex":
+                print "Latex"
+                self.view.run_command("jump_to_pdf")
+
+class toggle_steady_syncCommand(sublime_plugin.TextCommand):
+    def run(self, edit, **args):
+        s = sublime.load_settings("LaTeXTools Preferences.sublime-settings")
+        prefs_forward_sync = s.get("steady_sync", True)
+
+        if self.view.settings().get("steady_sync",prefs_forward_sync):
+            self.view.settings().set("steady_sync", False)
+            sublime.status_message("Do not steady sync PDF (keep current position) on mouse click")
+            print "Do not steady sync PDF"
+        else:
+            self.view.settings().set("steady_sync", True)
+            sublime.status_message("Steady sync PDF on mouse click")
+            print "Steady sync PDF"


### PR DESCRIPTION
This commit provides the possibility to perform a steady
forward sycning between the PDF file and the LaTeX sources
on mouse click. If the current source file is a LaTeX source
and the option steady_sync is on (by default = true) then it
will automatically open the PDF file.

In addition there is a new toggle command to switch the setting
on or off using

```
    ctrl+l, t, m(mouse)
    super+l, t, m(mouse)
```
