### PR TITLE
Table snippet, fig: needs to be tab:

### DIFF
--- a/table.sublime-snippet
+++ b/table.sublime-snippet
@@ -2,7 +2,7 @@
 	<content><![CDATA[
 \begin{table}[${1:tb}]
 	\caption{${2:caption here}}
-	\label{${3:fig:figurename}}
+	\label{${3:tab:tablename}}
 	\begin{center}
 		\begin{tabular}{${4:l|cc}}
 		\hline


### PR DESCRIPTION
The correct label identifier for tables is tab: and not fig:
