### PR TITLE
Add support for \texttt{} snippet

### DIFF
--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -87,7 +87,10 @@ LaTeX Package keymap for Linux
 		"context":  [
 			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"}],
 		"command": "insert_snippet", "args": {"name":"Packages/LaTeXTools/Text underline.sublime-snippet"}},
-
+	{ "keys": ["ctrl+l","ctrl+t"],  
+		"context":  [
+			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"}],
+		"command": "insert_snippet", "args": {"name":"Packages/LaTeXTools/Text monospace.sublime-snippet"}},
 
 
 

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -86,7 +86,10 @@ LaTeX Package keymap for OS X
 		"context":  [
 			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"}],
 		"command": "insert_snippet", "args": {"name":"Packages/LaTeXTools/Text underline.sublime-snippet"}},
-
+	{ "keys": ["super+l","super+t"],  
+		"context":  [
+			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"}],
+		"command": "insert_snippet", "args": {"name":"Packages/LaTeXTools/Text monospace.sublime-snippet"}},
 
 
 

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -86,7 +86,10 @@ LaTeX Package keymap for Windows
 		"context":  [
 			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"}],
 		"command": "insert_snippet", "args": {"name":"Packages/LaTeXTools/Text underline.sublime-snippet"}},
-
+	{ "keys": ["ctrl+l","ctrl+t"],  
+		"context":  [
+			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"}],
+		"command": "insert_snippet", "args": {"name":"Packages/LaTeXTools/Text monospace.sublime-snippet"}},
 
 
 

--- a/Text monospace.sublime-snippet
+++ b/Text monospace.sublime-snippet
@@ -1,0 +1,9 @@
+<snippet>
+    <description>Monospace text</description>
+    <content><![CDATA[
+\\texttt{${1:$SELECTION}}
+]]></content>
+    <!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
+    <!-- <tabTrigger>hello</tabTrigger> -->
+    <scope>text.tex.latex</scope>
+</snippet>


### PR DESCRIPTION
New keybinding, `C-l,C-t` gives `\texttt{blah}`
