### PR TITLE
Support for biblatex bibliographies

### DIFF
--- a/latex_cite_completions.py
+++ b/latex_cite_completions.py
@@ -32,6 +32,7 @@ def find_bib_files(rootdir, src, bibfiles):
 
     src_content = re.sub("%.*","",src_file.read())
     bibtags =  re.findall(r'\\bibliography\{[^\}]+\}', src_content)
+    bibtags += re.findall(r'\\addbibresource\{[^\}]+.bib\}', src_content)
 
     # extract absolute filepath for each bib file
     for tag in bibtags:


### PR DESCRIPTION
Biblatex has a slightly different command, and includes the extension. This change simply matches that and adds it to the list of files to search.

This minor change does NOT however support the other bibliography formats that biblatex supports, and definitely not biber's remote bibliographies.
