### PR TITLE
linux build command: avoid "custom build file" message

### DIFF
--- a/LaTeX.sublime-build
+++ b/LaTeX.sublime-build
@@ -119,7 +119,7 @@
 		// backward/forward search, forcing compilation (e.g. even if no bib file is found)
 		// and producing pdf rather than dvi output
 		"cmd": ["latexmk", "-cd",
-				"-e", "\\$pdflatex='%E -interaction=nonstopmode -synctex=1 %S %O'",
+				"-e", "\\$pdflatex = '%E -interaction=nonstopmode -synctex=1 %S %O'",
 				"-f", "-pdf"],
 
 		// Paths to TeX binaries; needed as GUI apps do not inherit


### PR DESCRIPTION
Added spaces around the equal sign to the Linux build command, to avoid the message: "You are using a custom LaTeX.sublime-build file (in User maybe?). Cannot select engine using a %!TEX program directive."
