### PR TITLE
Added additional backup types for {journal} in the cite_panel_format.

### DIFF
--- a/latex_cite_completions.py
+++ b/latex_cite_completions.py
@@ -1,5 +1,5 @@
 # ST2/ST3 compat
-from __future__ import print_function 
+from __future__ import print_function
 import sublime
 if sublime.version() < '3000':
     # we are on ST2 and Python 2.X
@@ -89,6 +89,29 @@ def find_bib_files(rootdir, src, bibfiles):
         find_bib_files(rootdir, input_f, bibfiles)
 
 
+
+def _add_entries(entry, keywords, titles, years, authors, journals):
+    """populates the lists for display from the bibtex entries"""
+
+    keywords.append(entry["keyword"])
+    titles.append(entry["title"])
+    years.append(entry["year"])
+    # For author, if there is an editor, that's good enough
+    authors.append(entry["author"] or entry["editor"] or "????")
+    journals.append(entry["journal"] or entry["booktitle"] or entry["institution"] or entry["publisher"]
+                    or entry["school"] or entry["eprint"] or "????")
+
+
+def _clear_entries(types):
+    """returns a new blank dictionary for the entries"""
+
+    entry = {"keyword": ""}
+    for t in types:
+        entry[t] = ""
+
+    return entry
+
+
 def get_cite_completions(view, point, autocompleting=False):
     line = view.substr(sublime.Region(view.line(point).a, point))
     # print line
@@ -158,7 +181,7 @@ def get_cite_completions(view, point, autocompleting=False):
         # Replace cite_blah with \cite{blah
         pre_snippet = "\cite" + fancy_cite + "{"
         # The "latex_tools_replace" command is defined in latex_ref_cite_completions.py
-        view.run_command("latex_tools_replace", {"a": point-len(expr), "b": point, "replacement": pre_snippet + prefix})        
+        view.run_command("latex_tools_replace", {"a": point-len(expr), "b": point, "replacement": pre_snippet + prefix})
         # save prefix begin and endpoints points
         new_point_a = point - len(expr) + len(pre_snippet)
         new_point_b = new_point_a + len(prefix)
@@ -216,9 +239,12 @@ def get_cite_completions(view, point, autocompleting=False):
     # # Note: year can be provided without quotes or braces (yes, I know...)
     # yp = re.compile(r'\byear\s*=\s*(?:\{+|"|\b)\s*(\d+)[\}"]?,?', re.IGNORECASE)
 
+    types = ['author', 'title', 'year', 'editor', 'journal', 'eprint', 'booktitle', 'institution', 'publisher', 'school']
+    typeString = r'|'.join(types)
+
     # This may speed things up
     # So far this captures: the tag, and the THREE possible groups
-    multip = re.compile(r'\b(author|title|year|editor|journal|eprint)\s*=\s*(?:\{|"|\b)(.+?)(?:\}+|"|\b)\s*,?\s*\Z',re.IGNORECASE)
+    multip = re.compile(r'\b(' + typeString + ')\s*=\s*(?:\{|"|\b)(.+?)(?:\}+|"|\b)\s*,?\s*\Z', re.IGNORECASE)
 
     for bibfname in bib_files:
         # # THIS IS NO LONGER NEEDED as find_bib_files() takes care of it
@@ -229,7 +255,7 @@ def get_cite_completions(view, point, autocompleting=False):
         # bibfname = os.path.normpath(os.path.join(texfiledir, bibfname))
         # print repr(bibfname)
         try:
-            bibf = codecs.open(bibfname,'r','UTF-8', 'ignore')  # 'ignore' to be safe
+            bibf = codecs.open(bibfname, 'r', 'UTF-8', 'ignore')  # 'ignore' to be safe
         except IOError:
             print ("Cannot open bibliography file %s !" % (bibfname,))
             sublime.status_message("Cannot open bibliography file %s !" % (bibfname,))
@@ -244,14 +270,9 @@ def get_cite_completions(view, point, autocompleting=False):
         authors = []
         years = []
         journals = []
-        #
-        entry = {   "keyword": "", 
-                    "title": "",
-                    "author": "", 
-                    "year": "", 
-                    "editor": "",
-                    "journal": "",
-                    "eprint": "" }
+
+        entry = _clear_entries(types)
+
         for line in bib:
             line = line.strip()
             # Let's get rid of irrelevant lines first
@@ -264,24 +285,14 @@ def get_cite_completions(view, point, autocompleting=False):
             if line[0] == "@":
                 # First, see if we can add a record; the keyword must be non-empty, other fields not
                 if entry["keyword"]:
-                    keywords.append(entry["keyword"])
-                    titles.append(entry["title"])
-                    years.append(entry["year"])
-                    # For author, if there is an editor, that's good enough
-                    authors.append(entry["author"] or entry["editor"] or "????")
-                    journals.append(entry["journal"] or entry["eprint"] or "????")
+                    _add_entries(entry, keywords, titles, years, authors, journals)
                     # Now reset for the next iteration
-                    entry["keyword"] = ""
-                    entry["title"] = ""
-                    entry["year"] = ""
-                    entry["author"] = ""
-                    entry["editor"] = ""
-                    entry["journal"] = ""
-                    entry["eprint"] = ""
+                    entry = _clear_entries(types)
+
                 # Now see if we get a new keyword
                 kp_match = kp.search(line)
                 if kp_match:
-                    entry["keyword"] = kp_match.group(1) # No longer decode. Was: .decode('ascii','ignore')
+                    entry["keyword"] = kp_match.group(1)  # No longer decode. Was: .decode('ascii','ignore')
                 else:
                     print ("Cannot process this @ line: " + line)
                     print ("Previous record " + entry)
@@ -296,11 +307,8 @@ def get_cite_completions(view, point, autocompleting=False):
             continue
 
         # at the end, we are left with one bib entry
-        keywords.append(entry["keyword"])
-        titles.append(entry["title"])
-        years.append(entry["year"])
-        authors.append(entry["author"] or entry["editor"] or "????")
-        journals.append(entry["journal"] or entry["eprint"] or "????")
+        _add_entries(entry, keywords, titles, years, authors, journals)
+
 
         print ( "Found %d total bib entries" % (len(keywords),) )
 
@@ -344,7 +352,7 @@ def get_cite_completions(view, point, autocompleting=False):
 # Based on html_completions.py
 # see also latex_ref_completions.py
 #
-# It expands citations; activated by 
+# It expands citations; activated by
 # cite<tab>
 # citep<tab> and friends
 #
@@ -352,7 +360,7 @@ def get_cite_completions(view, point, autocompleting=False):
 #
 # cite_sec
 #
-# to select all citation keywords starting with "sec". 
+# to select all citation keywords starting with "sec".
 #
 # There is only one problem: if you have a keyword "sec:intro", for instance,
 # doing "cite_intro:" will find it correctly, but when you insert it, this will be done


### PR DESCRIPTION
I like to use this format:

```
"cite_panel_format": ["{author_short} {year} - {title_short} ({keyword})","{journal}"]
```

rather than the default:

```
"cite_panel_format": ["{author_short} {year} - {title_short} ({keyword})","{title}"]
```

because I think it's redundant to show the title at the top and the title again just below.  Of course this capability is already provided but the "{journal}" type only includes journal articles and so doesn't show any relevant information  for other types.  I added a few more types as described below.
- Just like {author} already falls back on editor for books, {journal} now refers to the journal name for articles but falls back to: booktitle (conferences), institution (tech reports), publisher (books), and school (thesis or dissertation).
- Also simplified some of the code relating to this change so that the same code wasn't being called in multiple places and it would be easier to maintain without introducing errors.
- Other lines are highlighted because my editor auto-removed trailing whitespace
