### PR TITLE
Show building in status bar, show build panel follows preference

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -307,6 +307,8 @@ The following options are currently available (defaults in parentheses):
   * `python2` (`""`, i.e. empty string): name of the Python 2 executable. This is useful for systems that ship with both Python 2 and Python 3. The forward/backward search used with Evince require Python 2.
   * `sublime` (`sublime-text`): name of the ST executable. Ubuntu supports both `sublime-text` and `subl`; other distros may vary.
   * `sync_wait` (1.5): when you ask LaTeXTools to do a forward search, and the PDF file is not yet open (for example, right after compiling a tex file for the first time), LaTeXTools first launches evince, then waits a bit for it to come up, and then it performs the forward search. This parameter controls how long LaTeXTools should wait. If you notice that your machine opens the PDF, then sits there doing nothing, and finally performs the search, you can decrease this value to 1.0 or 0.5; if instead the PDF file comes up but the forward search does not seem to happen, increase it to 2.0.
+- "show_panel_on_build": if `true`, show the build panel when building. Overrides global setting in Preferences.sublime-settings.
+- "show_build_status" : if `true`, prints the building status in the status bar. Automatically disappears 2sec after finished build.
 
 Troubleshooting
 ---------------

--- a/README.markdown
+++ b/README.markdown
@@ -307,8 +307,8 @@ The following options are currently available (defaults in parentheses):
   * `python2` (`""`, i.e. empty string): name of the Python 2 executable. This is useful for systems that ship with both Python 2 and Python 3. The forward/backward search used with Evince require Python 2.
   * `sublime` (`sublime-text`): name of the ST executable. Ubuntu supports both `sublime-text` and `subl`; other distros may vary.
   * `sync_wait` (1.5): when you ask LaTeXTools to do a forward search, and the PDF file is not yet open (for example, right after compiling a tex file for the first time), LaTeXTools first launches evince, then waits a bit for it to come up, and then it performs the forward search. This parameter controls how long LaTeXTools should wait. If you notice that your machine opens the PDF, then sits there doing nothing, and finally performs the search, you can decrease this value to 1.0 or 0.5; if instead the PDF file comes up but the forward search does not seem to happen, increase it to 2.0.
-- "show_panel_on_build": if `true`, show the build panel when building. Overrides global setting in Preferences.sublime-settings.
-- "show_build_status" : if `true`, prints the building status in the status bar. Automatically disappears 2sec after finished build.
+- `show_panel_on_build`: if `true`, show the build panel when building. Overrides global setting in Preferences.sublime-settings.
+- `show_build_status` : if `true`, prints the building status in the status bar. Automatically disappears 2sec after finished build.
 
 Troubleshooting
 ---------------

--- a/makePDF.py
+++ b/makePDF.py
@@ -148,7 +148,7 @@ class CmdThread ( threading.Thread ):
 				content.append("")
 				content.extend(errors)
 			else:
-				content.append("Texification succeeded: no errors!")
+				content.append("Texification succeeded!")
 				content.append("")
 			if warnings:
 				if errors:
@@ -216,10 +216,11 @@ class make_pdfCommand(sublime_plugin.WindowCommand):
 		# Obtain parameters values
 		global_settings = sublime.load_settings("LaTeXTools Preferences.sublime-settings")
 		show_panel_on_build = global_settings.get('show_panel_on_build', view.settings().get('show_panel_on_build', True))
-		show_build_status = global_settings.get('show_build_status', view.settings().get('show_build_status', False))
+		self.show_build_status = global_settings.get('show_build_status', view.settings().get('show_build_status', False))
+		print("Show panel:", show_panel_on_build)
 
 		# Put in the status that we are building
-		if show_build_status:
+		if self.show_build_status:
 			self.set_status("Building...")
 
 		# Output panel: from exec.py
@@ -352,7 +353,7 @@ class make_pdfCommand(sublime_plugin.WindowCommand):
 		# self.output_view.end_edit(edit)
 		self.output_view.run_command("do_finish_edit")
 
-		if show_build_status:
+		if self.show_build_status:
 			# Built has finished!
 			self.set_status("Build finished")
 

--- a/makePDF.py
+++ b/makePDF.py
@@ -1,8 +1,8 @@
 # ST2/ST3 compat
-from __future__ import print_function 
+from __future__ import print_function
 import sublime
 if sublime.version() < '3000':
-    # we are on ST2 and Python 2.X
+	# we are on ST2 and Python 2.X
 	_ST3 = False
 	import getTeXRoot
 	import parseTeXlog
@@ -31,11 +31,11 @@ DEBUG = False
 # Encoding: especially useful for Windows
 # TODO: counterpart for OSX? Guess encoding of files?
 def getOEMCP():
-    # Windows OEM/Ansi codepage mismatch issue.
-    # We need the OEM cp, because texify and friends are console programs
-    import ctypes
-    codepage = ctypes.windll.kernel32.GetOEMCP()
-    return str(codepage)
+	# Windows OEM/Ansi codepage mismatch issue.
+	# We need the OEM cp, because texify and friends are console programs
+	import ctypes
+	codepage = ctypes.windll.kernel32.GetOEMCP()
+	return str(codepage)
 
 
 
@@ -84,7 +84,7 @@ class CmdThread ( threading.Thread ):
 			self.caller.output(" ".join(cmd))
 			self.caller.proc = None
 			return
-		
+
 		# restore path if needed
 		if self.caller.path:
 			os.environ["PATH"] = old_path
@@ -96,7 +96,7 @@ class CmdThread ( threading.Thread ):
 		proc.wait() # TODO: if needed, must use tempfiles instead of stdout/err
 
 		# if DEBUG:
-		# 	self.caller.output(out)
+		#   self.caller.output(out)
 
 		# Here the process terminated, but it may have been killed. If so, do not process log file.
 		# Since we set self.caller.proc above, if it is None, the process must have been killed.
@@ -104,7 +104,7 @@ class CmdThread ( threading.Thread ):
 		if not self.caller.proc:
 			print (proc.returncode)
 			self.caller.output("\n\n[User terminated compilation process]\n")
-			self.caller.finish(False)	# We kill, so won't switch to PDF anyway
+			self.caller.finish(False)   # We kill, so won't switch to PDF anyway
 			return
 		# Here we are done cleanly:
 		self.caller.proc = None
@@ -116,7 +116,7 @@ class CmdThread ( threading.Thread ):
 		# 12-10-27 NO! We actually do need rb, because MikTeX on Windows injects Ctrl-Z's in the
 		# log file, and this just causes Python to stop reading the file.
 
-		# OK, this seems solid: first we decode using the self.caller.encoding, 
+		# OK, this seems solid: first we decode using the self.caller.encoding,
 		# then we reencode using the default locale's encoding.
 		# Note: we get this using ST2's own getdefaultencoding(), not the locale module
 		# We ignore bad chars in both cases.
@@ -133,9 +133,9 @@ class CmdThread ( threading.Thread ):
 		# byte array (? whatever read() returns), this does not happen---we only break at \n, etc.
 		# However, we must still decode the resulting lines using the relevant encoding.
 		# 121101 -- moved splitting and decoding logic to parseTeXlog, where it belongs.
-		
+
 		# Note to self: need to think whether we don't want to codecs.open this, too...
-		data = open(self.caller.tex_base + ".log", 'rb').read()		
+		data = open(self.caller.tex_base + ".log", 'rb').read()
 
 		errors = []
 		warnings = []
@@ -144,18 +144,18 @@ class CmdThread ( threading.Thread ):
 			(errors, warnings) = parseTeXlog.parse_tex_log(data)
 			content = ["",""]
 			if errors:
-				content.append("There were errors in your LaTeX source") 
+				content.append("There were errors in your LaTeX source")
 				content.append("")
 				content.extend(errors)
 			else:
 				content.append("Texification succeeded: no errors!")
-				content.append("") 
+				content.append("")
 			if warnings:
 				if errors:
 					content.append("")
-					content.append("There were also warnings.") 
+					content.append("There were also warnings.")
 				else:
-					content.append("However, there were warnings in your LaTeX source") 
+					content.append("However, there were warnings in your LaTeX source")
 				content.append("")
 				content.extend(warnings)
 		except Exception as e:
@@ -187,7 +187,7 @@ class CmdThread ( threading.Thread ):
 class make_pdfCommand(sublime_plugin.WindowCommand):
 
 	def run(self, cmd="", file_regex="", path=""):
-		
+
 		# Try to handle killing
 		if hasattr(self, 'proc') and self.proc: # if we are running, try to kill running process
 			self.output("\n\n### Got request to terminate compilation ###")
@@ -196,7 +196,7 @@ class make_pdfCommand(sublime_plugin.WindowCommand):
 			return
 		else: # either it's the first time we run, or else we have no running processes
 			self.proc = None
-		
+
 		view = self.window.active_view()
 
 		self.file_name = getTeXRoot.get_tex_root(view)
@@ -206,7 +206,7 @@ class make_pdfCommand(sublime_plugin.WindowCommand):
 
 		self.tex_base, self.tex_ext = os.path.splitext(self.file_name)
 		tex_dir = os.path.dirname(self.file_name)
-		
+
 		# Extra paths
 		self.path = path
 			
@@ -215,7 +215,7 @@ class make_pdfCommand(sublime_plugin.WindowCommand):
 			self.output_view = self.window.get_output_panel("exec")
 
 		# Dumb, but required for the moment for the output panel to be picked
-        # up as the result buffer
+		# up as the result buffer
 		self.window.get_output_panel("exec")
 
 		self.output_view.settings().set("result_file_regex", "^([^:\n\r]*):([0-9]+):?([0-9]+)?:? (.*)$")
@@ -239,7 +239,7 @@ class make_pdfCommand(sublime_plugin.WindowCommand):
 					# Sanity checks
 					if "texify" == self.make_cmd[0]:
 						sublime.error_message("Sorry, cannot select engine using a %!TEX program directive on MikTeX.")
-						return 
+						return
 					if not ("$pdflatex = '%E" in self.make_cmd[3]):
 						sublime.error_message("You are using a custom LaTeX.sublime-build file (in User maybe?). Cannot select engine using a %!TEX program directive.")
 						return
@@ -253,11 +253,11 @@ class make_pdfCommand(sublime_plugin.WindowCommand):
 		if view.is_dirty():
 			print ("saving...")
 			view.run_command('save') # call this on view, not self.window
-		
+
 		if self.tex_ext.upper() != ".TEX":
 			sublime.error_message("%s is not a TeX source file: cannot compile." % (os.path.basename(view.file_name()),))
 			return
-		
+
 		s = platform.system()
 		if s == "Darwin":
 			self.encoding = "UTF-8"
@@ -267,9 +267,9 @@ class make_pdfCommand(sublime_plugin.WindowCommand):
 			self.encoding = "UTF-8"
 		else:
 			sublime.error_message("Platform as yet unsupported. Sorry!")
-			return	
+			return
 		print (self.make_cmd + [self.file_name])
-		
+
 		os.chdir(tex_dir)
 		CmdThread(self).start()
 		print (threading.active_count())
@@ -283,12 +283,12 @@ class make_pdfCommand(sublime_plugin.WindowCommand):
 		sublime.set_timeout(functools.partial(self.do_output, data), 0)
 
 	def do_output(self, data):
-        # if proc != self.proc:
-        #     # a second call to exec has been made before the first one
-        #     # finished, ignore it instead of intermingling the output.
-        #     if proc:
-        #         proc.kill()
-        #     return
+		# if proc != self.proc:
+		#     # a second call to exec has been made before the first one
+		#     # finished, ignore it instead of intermingling the output.
+		#     if proc:
+		#         proc.kill()
+		#     return
 
 		# try:
 		#     str = data.decode(self.encoding)
@@ -309,8 +309,8 @@ class make_pdfCommand(sublime_plugin.WindowCommand):
 		strdata = strdata.replace('\r\n', '\n').replace('\r', '\n')
 
 		selection_was_at_end = (len(self.output_view.sel()) == 1
-		    and self.output_view.sel()[0]
-		        == sublime.Region(self.output_view.size()))
+			and self.output_view.sel()[0]
+				== sublime.Region(self.output_view.size()))
 		self.output_view.set_read_only(False)
 		# Move this to a TextCommand for compatibility with ST3
 		self.output_view.run_command("do_output_edit", {"data": strdata, "selection_was_at_end": selection_was_at_end})
@@ -319,7 +319,7 @@ class make_pdfCommand(sublime_plugin.WindowCommand):
 		# if selection_was_at_end:
 		#     self.output_view.show(self.output_view.size())
 		# self.output_view.end_edit(edit)
-		self.output_view.set_read_only(True)	
+		self.output_view.set_read_only(True)
 
 	# Also from exec.py
 	# Set the selection to the start of the output panel, so next_result works
@@ -342,14 +342,14 @@ class make_pdfCommand(sublime_plugin.WindowCommand):
 
 
 class DoOutputEditCommand(sublime_plugin.TextCommand):
-    def run(self, edit, data, selection_was_at_end):
-        self.view.insert(edit, self.view.size(), data)
-        if selection_was_at_end:
-            self.view.show(self.view.size())
+	def run(self, edit, data, selection_was_at_end):
+		self.view.insert(edit, self.view.size(), data)
+		if selection_was_at_end:
+			self.view.show(self.view.size())
 
 class DoFinishEditCommand(sublime_plugin.TextCommand):
-    def run(self, edit):
-        self.view.sel().clear()
-        reg = sublime.Region(0)
-        self.view.sel().add(reg)
-        self.view.show(reg)
+	def run(self, edit):
+		self.view.sel().clear()
+		reg = sublime.Region(0)
+		self.view.sel().add(reg)
+		self.view.show(reg)


### PR DESCRIPTION
Show the building process in the status bar. Depends on Show_build_status parameter, set in LatexTools settings.

Can now disable automatic popup of build results, based on the parameter set in global settings or LatexTools settings. Combines well with forked BuildOnSave, allowing for hidden build panel, appearing only when errors are present during the building process.

(cleaned indentation as well)