### PR TITLE
trying some other encodes

### DIFF
--- a/getTeXRoot.py
+++ b/getTeXRoot.py
@@ -46,7 +46,15 @@ def get_tex_root(view):
 	else:
 		# This works on ST2 and ST3, but does not automatically convert line endings.
 		# We should be OK though.
-		lines = codecs.open(texFile, "r", "UTF-8")
+		encodings = ['utf-8', 'iso-8859-1', 'windows-1252']
+		for e in encodings:
+			try:
+				lines = codecs.open(texFile, "r", e)
+			except UnicodeDecodeError:
+				print('Got unicode error with %s , trying different encoding' % e)
+			else:
+				print('Opening the file with encoding:  %s ' % e)
+				continue 				
 		is_file = True
 
 	for line in lines:


### PR DESCRIPTION
Compiling a latex code with iso-8859-1 encoding and got the following error:

``` python
Unable to auto detect encoding, using fallback encoding Western (Windows 1252)
Traceback (most recent call last):
  File "/opt/sublime_text_3/sublime_plugin.py", line 524, in run_
    return self.run(**args)
  File "/home/arthurbailao/.config/sublime-text-3/Packages/LaTeXTools/makePDF.py", line 202, in run
    self.file_name = getTeXRoot.get_tex_root(view)
  File "/home/arthurbailao/.config/sublime-text-3/Packages/LaTeXTools/getTeXRoot.py", line 52, in get_tex_root
    for line in lines:
  File "X/codecs.py", line 692, in __next__
  File "X/codecs.py", line 623, in __next__
  File "X/codecs.py", line 536, in readline
  File "X/codecs.py", line 482, in read
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xe7 in position 47: invalid continuation byte
```
