### PR TITLE
Support relative specification of TEXroot in project file in addition to existing behaviour

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -116,7 +116,14 @@ The ST Build command takes care of the following:
 
 **Multi-file documents** are supported as follows. If the first line in the current file consists of the text `%!TEX root = <master file name>`, then tex & friends are invoked on the specified master file, instead of the current one. Note: the only file that gets saved automatically is the current one. Also, the master file name **must** have a `.tex` extension, or it won't be recognized.
 
-There is also support for project files; this is to be documented.
+You can also configure this using project files. This is more flexible, as you can have different tex roots for the same tex files, for example when including the same tex into different documents, by configuring different project files. To configure your tex root using a project file, load up the files you want to edit, then do Project | Save Project As. Now edit the resultant .sublime-project file and add the tex root in the settings section. LaTeXTools will try to handle it as a path relative to the currently edited tex file, but absolute paths will also work.
+
+    {
+        "settings" : 
+        {
+            "TEXroot": "/full/path/to/your_main.tex"
+        }
+    }
 
 **TeX engine selection** is supported, but *only* if you are running TeXlive (any platform). Sorry, MiKTeX support is not there yet. If the first line of the current file consists of the text `%!TEX program = <program>`, where `program` is `pdflatex`, `lualatex` or `xelatex`, the corresponding engine is selected. If no such directive is specified, `pdflatex` is the default. Multi-file documents are supported: the directive must be in the *root* (i.e. master) file. Also, for compatibility with TeXshop, you can use `TS-program` instead of `program`. **Note**: this functionality requires changes in your `LaTeX.sublime-build` file. If you copied the default file to the `User` directory and modified it, you will not get this functionality. In this case, copy the new default file to `User` and apply your personalizations again. I know this is not ideal; I will put a better system in place in the near future.
 

--- a/getTeXRoot.py
+++ b/getTeXRoot.py
@@ -20,16 +20,28 @@ import codecs
 # Contributed by Sam Finn
 
 def get_tex_root(view):
-	try:
-		root = os.path.abspath(view.settings().get('TEXroot'))
-		if os.path.isfile(root):
-			print("Main file defined in project settings : " + root)
-			return root
-	except:
-		pass
 
-
+	# this is the absolute path name of the file being edited
 	texFile = view.file_name()
+
+	# relative TEXroot handling by cpbotha
+	# get directory containing the tex file
+	cur_file_dir = os.path.dirname(view.file_name())
+	# get the spec from the project settings (can return None)
+	texroot = view.settings().get('TEXroot')
+
+	if texroot is not None:
+		if not os.path.isabs(texroot):
+			# it's a relative path specification
+			# mash it up with the dir, then get its absolute version
+			texroot = os.path.abspath(os.path.join(cur_file_dir, texroot))
+
+		if os.path.isfile(texroot):
+			print("Main file defined in project settings : " + texroot)
+			return texroot
+
+	# couldn't find it in the project, falling back to % !TEXroot = ... syntax
+
 	root = texFile
 	if texFile is None:
 		# We are in an unnamed, unsaved file.

--- a/getTeXRoot.py
+++ b/getTeXRoot.py
@@ -26,7 +26,7 @@ def get_tex_root(view):
 
 	# relative TEXroot handling by cpbotha
 	# get directory containing the tex file
-	cur_file_dir = os.path.dirname(view.file_name())
+	cur_file_dir = os.path.dirname(texFile)
 	# get the spec from the project settings (can return None)
 	texroot = view.settings().get('TEXroot')
 


### PR DESCRIPTION
This is a small change that enables users to specify TEXroot in their project files relative to the tex file that is being edited. The old behaviour remains unchanged, so existing users won't notice the difference.

I've also added a paragraph to the README documenting TEXroot specification in the project file. This was a todo.