### PR TITLE
Fixed command output in makePDF.py

### DIFF
--- a/makePDF.py
+++ b/makePDF.py
@@ -81,7 +81,7 @@ class CmdThread ( threading.Thread ):
 		except:
 			self.caller.output("\n\nCOULD NOT COMPILE!\n\n")
 			self.caller.output("Attempted command:")
-			self.caller.output(" ".join(cmd))
+			self.caller.output(subprocess.list2cmdline(cmd))
 			self.caller.proc = None
 			return
 		


### PR DESCRIPTION
`" ".join(cmd)` may be different from the command it really runs.
It may mislead users who have problem compiling the tex file, so I suggest replace the code with `subprocess.list2cmdline(cmd)`
