### PR TITLE
csquotes' \enquote command key binding and completion trigger.

### DIFF
--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -119,6 +119,10 @@ LaTeX Package keymap for Linux
 		"context":  [
 			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"}],
 		"command": "insert_snippet", "args": {"name":"Packages/LaTeXTools/Text monospace.sublime-snippet"}},
+	{ "keys": ["ctrl+l","ctrl+q"],  
+		"context":  [
+			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"}],
+		"command": "insert_snippet", "args": {"name":"Packages/LaTeXTools/Text enquote.sublime-snippet"}},
 
 
 

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -120,6 +120,10 @@ LaTeX Package keymap for OS X
 		"context":  [
 			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"}],
 		"command": "insert_snippet", "args": {"name":"Packages/LaTeXTools/Text monospace.sublime-snippet"}},
+	{ "keys": ["super+l","super+q"],  
+		"context":  [
+			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"}],
+		"command": "insert_snippet", "args": {"name":"Packages/LaTeXTools/Text enquote.sublime-snippet"}},
 
 
 

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -101,7 +101,7 @@ LaTeX Package keymap for Windows
 			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"}],
 		"command": "insert_snippet", "args": {"name":"Packages/LaTeXTools/Wrap in environment.sublime-snippet"}},
 
-	// Wrap selected text in emph, bold or underline
+	// Wrap selected text in emph, bold, monospace, underline or enquote
 	{ "keys": ["ctrl+l","ctrl+e"],  
 		"context":  [
 			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"}],
@@ -118,7 +118,10 @@ LaTeX Package keymap for Windows
 		"context":  [
 			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"}],
 		"command": "insert_snippet", "args": {"name":"Packages/LaTeXTools/Text monospace.sublime-snippet"}},
-
+	{ "keys": ["ctrl+l","ctrl+q"],  
+		"context":  [
+			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"}],
+		"command": "insert_snippet", "args": {"name":"Packages/LaTeXTools/Text enquote.sublime-snippet"}},
 
 
 

--- a/LaTeX.sublime-completions
+++ b/LaTeX.sublime-completions
@@ -8,6 +8,7 @@
                 { "trigger": "em", "contents": "\\emph{$1}$0"},
                 { "trigger": "tt", "contents": "\\texttt{$1}$0"},
                 { "trigger": "un", "contents": "\\underline{$1}$0"},
+                { "trigger": "enq", "contents": "\\enquote{$1}$0"},
 
                 { "trigger": "bs", "contents": "\\bigskip"},
                 { "trigger": "ms", "contents": "\\medskip"},

--- a/Text enquote.sublime-snippet
+++ b/Text enquote.sublime-snippet
@@ -1,0 +1,9 @@
+<snippet>
+    <description>Enquote text</description>
+    <content><![CDATA[
+\\enquote{${1:$SELECTION}}
+]]></content>
+    <!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
+    <!-- <tabTrigger>hello</tabTrigger> -->
+    <scope>text.tex.latex</scope>
+</snippet>


### PR DESCRIPTION
Added a key binding and a completion trigger for csquotes' \enquote command.

    \enquote{text}

csquotes offers a simple command to set text between quotes so you can waive more cryptic commands like 

    ``text''
    \glqq text\grqq
    \frqq text\flqq
    etc.

For more information about csquotes see: [CTAN doc](http://www.ctan.org/pkg/csquotes)