### PR TITLE
fix jump to pdf from command palette

### DIFF
--- a/jumpToPDF.py
+++ b/jumpToPDF.py
@@ -32,7 +32,7 @@ class jump_to_pdfCommand(sublime_plugin.TextCommand):
 		# need to invoke the command. And if it is not visible, the natural way to just bring up the
 		# window without syncing is by using the system's window management shortcuts.
 		# As for focusing, we honor the toggles / prefs.
-		from_keybinding = args["from_keybinding"]
+		from_keybinding = args.get("from_keybinding")
 		if from_keybinding:
 			forward_sync = True
 		print (from_keybinding, keep_focus, forward_sync)


### PR DESCRIPTION
Currently when calling Jump to PDF from the command palette in ST3 it has this error (and nothing happens)

```
Traceback (most recent call last):
  File "C:\Program Files (x86)\Sublime Text 3\sublime_plugin.py", line 549, in run_
    return self.run(edit)
  File "AppData\Roaming\Sublime Text 3\Packages\LaTeXTools\jumpToPDF.py", line 36, in run
    from_keybinding = args["from_keybinding"]
KeyError: 'from_keybinding'
```

This commit fixes that.