### PR TITLE
Update LaTeX.sublime-build

### DIFF
--- a/LaTeX.sublime-build
+++ b/LaTeX.sublime-build
@@ -119,7 +119,7 @@
 		// backward/forward search, forcing compilation (e.g. even if no bib file is found)
 		// and producing pdf rather than dvi output
 		"cmd": ["latexmk", "-cd",
-				"-e", "\\$pdflatex='%E -interaction=nonstopmode -synctex=1 %S %O'",
+				"-e", "\\$pdflatex = '%E -interaction=nonstopmode -synctex=1 %S %O'",
 				"-f", "-pdf"],
 
 		// Paths to TeX binaries; needed as GUI apps do not inherit


### PR DESCRIPTION
Spaces are required in makePDF.py for "linux" (in "windows" it's correct)