### PR TITLE
Add texmf path setting and search the corresponding path for bib files

### DIFF
--- a/latex_cite_completions.py
+++ b/latex_cite_completions.py
@@ -1,5 +1,5 @@
 # ST2/ST3 compat
-from __future__ import print_function 
+from __future__ import print_function
 import sublime
 if sublime.version() < '3000':
     # we are on ST2 and Python 2.X
@@ -38,7 +38,7 @@ def match(rex, str):
 # recursively search all linked tex files to find all
 # included bibliography tags in the document and extract
 # the absolute filepaths of the bib files
-def find_bib_files(rootdir, src, bibfiles):
+def find_bib_files(rootdir, src, bibfiles, texmfbibhome):
     if src[-4:].lower() != ".tex":
         src = src + ".tex"
 
@@ -80,13 +80,17 @@ def find_bib_files(rootdir, src, bibfiles):
             if bf[-4:].lower() != '.bib':
                 bf = bf + '.bib'
             # We join with rootdir - everything is off the dir of the master file
-            bf = os.path.normpath(os.path.join(rootdir,bf))
-            bibfiles.append(bf)
+            bff = os.path.normpath(os.path.join(rootdir,bf))
+            bibfiles.append(bff)
+            if texmfbibhome:
+                # Also look in texmf tree
+                bff = os.path.normpath(os.path.join(texmfbibhome,bf))
+                bibfiles.append(bff)
 
     # search through input tex files recursively
     for f in re.findall(r'\\(?:input|include)\{[^\}]+\}',src_content):
         input_f = re.search(r'\{([^\}]+)', f).group(1)
-        find_bib_files(rootdir, input_f, bibfiles)
+        find_bib_files(rootdir, input_f, bibfiles, texmfbibhome)
 
 
 def get_cite_completions(view, point, autocompleting=False):
@@ -158,7 +162,7 @@ def get_cite_completions(view, point, autocompleting=False):
         # Replace cite_blah with \cite{blah
         pre_snippet = "\cite" + fancy_cite + "{"
         # The "latex_tools_replace" command is defined in latex_ref_cite_completions.py
-        view.run_command("latex_tools_replace", {"a": point-len(expr), "b": point, "replacement": pre_snippet + prefix})        
+        view.run_command("latex_tools_replace", {"a": point-len(expr), "b": point, "replacement": pre_snippet + prefix})
         # save prefix begin and endpoints points
         new_point_a = point - len(expr) + len(pre_snippet)
         new_point_b = new_point_a + len(prefix)
@@ -180,9 +184,25 @@ def get_cite_completions(view, point, autocompleting=False):
         # FIXME: should probably search the buffer instead of giving up
         raise NoBibFilesError()
 
+    # better would be to use : kpsewhich -var-value TEXMFHOME or BIBINPUTS
+    texmfbibhome = None
+    s = sublime.load_settings("LaTeXTools Preferences.sublime-settings")
+    texmf = s.get('texmf')
+    if texmf:
+        print ("texmf tree path defined in LaTeXTools settings: " + texmf)
+        try:
+            texmfbibhome = os.path.abspath(texmf + "/bibtex/bib")
+            if not os.path.isdir(texmfbibhome):
+                texmfbibhome = None
+        except:
+            texmfbibhome = None
+            pass
+    if texmfbibhome:
+        print ("Bib path found in texmf : " + repr(texmfbibhome))
+
     print ("TEX root: " + repr(root))
     bib_files = []
-    find_bib_files(os.path.dirname(root), root, bib_files)
+    find_bib_files(os.path.dirname(root), root, bib_files, texmfbibhome)
     # remove duplicate bib files
     bib_files = list(set(bib_files))
     print ("Bib files found: ")
@@ -245,10 +265,10 @@ def get_cite_completions(view, point, autocompleting=False):
         years = []
         journals = []
         #
-        entry = {   "keyword": "", 
+        entry = {   "keyword": "",
                     "title": "",
-                    "author": "", 
-                    "year": "", 
+                    "author": "",
+                    "year": "",
                     "editor": "",
                     "journal": "",
                     "eprint": "" }
@@ -344,7 +364,7 @@ def get_cite_completions(view, point, autocompleting=False):
 # Based on html_completions.py
 # see also latex_ref_completions.py
 #
-# It expands citations; activated by 
+# It expands citations; activated by
 # cite<tab>
 # citep<tab> and friends
 #
@@ -352,7 +372,7 @@ def get_cite_completions(view, point, autocompleting=False):
 #
 # cite_sec
 #
-# to select all citation keywords starting with "sec". 
+# to select all citation keywords starting with "sec".
 #
 # There is only one problem: if you have a keyword "sec:intro", for instance,
 # doing "cite_intro:" will find it correctly, but when you insert it, this will be done

--- a/latex_cite_completions.py
+++ b/latex_cite_completions.py
@@ -186,7 +186,7 @@ def get_cite_completions(view, point, autocompleting=False):
 
     # better would be to use : kpsewhich -var-value TEXMFHOME or BIBINPUTS
     texmfbibhome = None
-    s = sublime.load_settings("LaTeXTools Preferences.sublime-settings")
+    s = sublime.load_settings("LaTeXTools.sublime-settings")
     texmf = s.get('texmf')
     if texmf:
         print ("texmf tree path defined in LaTeXTools settings: " + texmf)


### PR DESCRIPTION
Currently, LaTeXTools doesn't find the "obvious" place to put one's bib files - the bibtex/bib subdirectory of the texmf tree. As a workaround, this patch adds a "texmf" setting to the LaTeXTools preferences, which can be used to specify the texmf path. LaTeXTools will then also search the bibtex/bib subdirectory of that path for bib files for the /cite panel etc.

Of course, LaTeXTools should ideally search all the directories for bib files that LaTeX itself does when building. That would require querying kpsewhich for these paths (or something equivalent to that). This patch doesn't do that - I'm sharing it as a stopgap for people who need this functionality immediately ;)

