### PR TITLE
Fixed cite autocompletion with @preamble in bibtex file

### DIFF
--- a/latex_cite_completions.py
+++ b/latex_cite_completions.py
@@ -286,7 +286,7 @@ def get_cite_completions(view, point, autocompleting=False):
                     entry["keyword"] = kp_match.group(1) # No longer decode. Was: .decode('ascii','ignore')
                 else:
                     print ("Cannot process this @ line: " + line)
-                    print ("Previous record " + entry)
+                    print ("Previous record ", entry)
                 continue
             # Now test for title, author, etc.
             # Note: we capture only the first line, but that's OK for our purposes

--- a/latex_cite_completions.py
+++ b/latex_cite_completions.py
@@ -261,6 +261,8 @@ def get_cite_completions(view, point, autocompleting=False):
                 continue
             if line.lower()[0:7] == "@string":
                 continue
+            if line.lower()[0:9]  == "@preamble":
+                continue 
             if line[0] == "@":
                 # First, see if we can add a record; the keyword must be non-empty, other fields not
                 if entry["keyword"]:


### PR DESCRIPTION
'@preamble' is not necessary and can be ignored like lines with '@string' or ‘@comment‘.
Additionally fixed TypeError: cannot concatenate 'str' and 'dict' objects.

