### PR TITLE
Snippet tweak

### DIFF
--- a/figure.sublime-snippet
+++ b/figure.sublime-snippet
@@ -5,7 +5,7 @@
 		\includegraphics[$2]{$3}
 	\end{center}
 	\caption{${4:Caption here}}
-	\label{${5:fig:figure1}}
+	\label{fig:${5:figure1}}
 \end{figure}
 ]]></content>
 	<tabTrigger>bfigure</tabTrigger>

--- a/table.sublime-snippet
+++ b/table.sublime-snippet
@@ -2,7 +2,7 @@
 	<content><![CDATA[
 \begin{table}[${1:tb}]
 	\caption{${2:caption here}}
-	\label{${3:tab:tablename}}
+	\label{tab:${3:tablename}}
 	\begin{center}
 		\begin{tabular}{${4:l|cc}}
 		\hline


### PR DESCRIPTION
Exclude prefixes "tab:" and "fig:" from selections. This also conforms to the built-in "sec"-snippet, where "sec:" is omitted from the selection when tabbing to label.
