### PR TITLE
Handles varying types of bib file encodings

### DIFF
--- a/latex_cite_completions.py
+++ b/latex_cite_completions.py
@@ -230,7 +230,7 @@ def get_cite_completions(view, point, autocompleting=False):
         # print repr(bibfname)
 
         try:
-            # Handle varying types of encodings in addtion to the standard encoding: UTF-8
+            # Handle varying types of encodings in addition to the standard encoding: UTF-8
             raw = open(bibfname, 'rb').read(32)
 
             if raw.startswith(codecs.BOM_UTF8):

--- a/latex_cite_completions.py
+++ b/latex_cite_completions.py
@@ -228,8 +228,19 @@ def get_cite_completions(view, point, autocompleting=False):
         # # fix from Tobias Schmidt to allow for absolute paths
         # bibfname = os.path.normpath(os.path.join(texfiledir, bibfname))
         # print repr(bibfname)
+
         try:
-            bibf = codecs.open(bibfname,'r','UTF-8', 'ignore')  # 'ignore' to be safe
+            # Handle varying types of encodings in addtion to the standard encoding: UTF-8
+            raw = open(bibfname, 'rb').read(32)
+
+            if raw.startswith(codecs.BOM_UTF8):
+                encoding = 'utf_8_sig'
+            elif raw.startswith(codecs.BOM_UTF16_LE) or raw.startswith(codecs.BOM_UTF16_BE):
+                encoding = 'utf_16'
+            else:
+                encoding = 'utf_8'
+
+            bibf = codecs.open(bibfname,'r', encoding, 'ignore')  # 'ignore' to be safe
         except IOError:
             print ("Cannot open bibliography file %s !" % (bibfname,))
             sublime.status_message("Cannot open bibliography file %s !" % (bibfname,))

--- a/latex_cite_completions.py
+++ b/latex_cite_completions.py
@@ -231,7 +231,8 @@ def get_cite_completions(view, point, autocompleting=False):
 
         try:
             # Handle varying types of encodings in addition to the standard encoding: UTF-8
-            raw = open(bibfname, 'rb').read(32)
+            with open(bibfname, 'rb') as f:
+                raw = f.read(32)
 
             if raw.startswith(codecs.BOM_UTF8):
                 encoding = 'utf_8_sig'


### PR DESCRIPTION
This pull request addresses issue #335

The added code reads the first 32 bytes of a bib file and checks if it can determine the encoding of a file. If so it sets the encoding to the determined encoding. If it is not able to determine the encoding it uses UTF-8 as a default value.

It fixes issue #335 for the following encodings:

* UTF-8 with BOM
* UTF-16-LE with BOM
* UTF-16-BE with BOM