### PR TITLE
fix spaces in keyword for cite autocompletion

### DIFF
--- a/latex_cite_completions.py
+++ b/latex_cite_completions.py
@@ -198,7 +198,7 @@ def get_cite_completions(view, point, autocompleting=False):
     print (repr(bib_files))
 
     completions = []
-    kp = re.compile(r'@[^\{]+\{(.+),')
+    kp = re.compile(r'@[^\{]+\{\s*(.+)\s*,')
     # new and improved regex
     # we must have "title" then "=", possibly with spaces
     # then either {, maybe repeated twice, or "


### PR DESCRIPTION
This patch trims the cite-keyword. ( foo) looks ugly