### PR TITLE
Added setting show_panel to switch automatic open of output panel on build

### DIFF
--- a/LaTeXTools.default-settings
+++ b/LaTeXTools.default-settings
@@ -27,6 +27,8 @@
 	// Sync PDF to current editor position after building (true) or not 
 	"forward_sync": true,
 
+	// Show the output panel on build (defaults to true, if not specified).
+	"show_panel": true,
 
 // ------------------------------------------------------------------
 // Platform settings: adapt as needed for your machine

--- a/makePDF.py
+++ b/makePDF.py
@@ -218,7 +218,12 @@ class make_pdfCommand(sublime_plugin.WindowCommand):
 		# self.output_view.settings().set("result_line_regex", line_regex)
 		self.output_view.settings().set("result_base_dir", tex_dir)
 
-		self.window.run_command("show_panel", {"panel": "output.exec"})
+		# Get platform settings, builder, and builder settings
+		s = sublime.load_settings("LaTeXTools.sublime-settings")
+		
+		# Only show panel if activated (or by default if not specified otherwise)
+		if s.get("show_panel") in [None, True]:
+			self.window.run_command("show_panel", {"panel": "output.exec"})
 		
 		self.output_view.settings().set("result_file_regex", file_regex)
 
@@ -241,8 +246,7 @@ class make_pdfCommand(sublime_plugin.WindowCommand):
 			sublime.error_message("Platform as yet unsupported. Sorry!")
 			return	
 		
-		# Get platform settings, builder, and builder settings
-		s = sublime.load_settings("LaTeXTools.sublime-settings")
+		
 		platform_settings  = s.get(self.plat)
 		builder_name = s.get("builder")
 		# This *must* exist, so if it doesn't, the user didn't migrate


### PR DESCRIPTION
`LaTeXTools.sublime-settings` now takes an extra top-level options `show_panel` (which is set to `true` in default settings file). If set to `true` the output panel will be opened on build (as it is done if the option is omitted / which is the same behavior as previously). If set to `false` the output panel will stay hidden on build.