### PR TITLE
Better template for wrapping in environments

### DIFF
--- a/Wrap in environment.sublime-snippet
+++ b/Wrap in environment.sublime-snippet
@@ -2,8 +2,8 @@
 	<description>Turn selection into LaTeX environment</description>
 	<content><![CDATA[
 \\begin{${1:env}}
-$SELECTION
-\\end{$1}
+$SELECTION\\end{$1}
+
 ]]></content>
 	<!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
 	<!-- <tabTrigger>hello</tabTrigger> -->


### PR DESCRIPTION
Imho the most typical use case is a starting text like

```
We are going to make a list:

first item
second item
third item

and we are done!
```

Then we select the block “first item … third item”, including the EOLs (using double-click and drag on MacOS e.g.). With this commit, hitting the key combo to wrap the selection in an environment will produce

```
We are going to make a list:

\begin{env}
first item
second item
third item
\end{env}

and we are done!
```

whereas it used to produce before the change

```
We are going to make a list:

\begin{env}
first item
second item
third item

\end{env}
and we are done!
```

I argue that the former is better than the latter.