### PR TITLE
Fix bug in bibliography auto-completion that occurs when a line in the bib file can't be parsed

### DIFF
--- a/latex_cite_completions.py
+++ b/latex_cite_completions.py
@@ -284,7 +284,7 @@ def get_cite_completions(view, point, autocompleting=False):
                     entry["keyword"] = kp_match.group(1) # No longer decode. Was: .decode('ascii','ignore')
                 else:
                     print ("Cannot process this @ line: " + line)
-                    print ("Previous record " + entry)
+                    print ("Previous record " + str(entry))
                 continue
             # Now test for title, author, etc.
             # Note: we capture only the first line, but that's OK for our purposes


### PR DESCRIPTION
When there is an error in a `.bib` file the `latex_cite_completions.py` file prints a message to the user, and in the process attempts to print the previous entry, which is a dictionary object. For me that results in an error:
```
Cannot process this @ line: @INPROCEEDINGS{,
Traceback (most recent call last):
  File "/Applications/Sublime Text.app/Contents/MacOS/sublime_plugin.py", line 549, in run_
    return self.run(edit)
  File "/Users/bartvanmerrienboer/Library/Application Support/Sublime Text 3/Packages/LaTeXTools/latex_cite_completions.py", line 417, in run
    completions, prefix, post_brace, new_point_a, new_point_b = get_cite_completions(view, point)
  File "/Users/bartvanmerrienboer/Library/Application Support/Sublime Text 3/Packages/LaTeXTools/latex_cite_completions.py", line 287, in get_cite_completions
    print ("Previous record " + entry)
TypeError: Can't convert 'dict' object to str implicitly
```
As a result the `\cite` auto-completion doesn't work anymore. Using the `str` method seems to solve the problem for me.