### PR TITLE
Koma script sections

### DIFF
--- a/Symbol List - Sections.tmPreferences
+++ b/Symbol List - Sections.tmPreferences
@@ -12,7 +12,7 @@
 		<integer>1</integer>
 		<key>symbolTransformation</key>
 		<string>
-			s/\\(?:sub)*(.)(?:ection|hapter)(?:\*)?\{([^\}]+)\}/\u$1 $2/g;
+			s/\\(?:add)?(?:sub)*(.)(?:ection|hap|ec|hap)(?:\*)?\{([^\}]+)\}/\u$1 $2/g;
 		</string>
 	</dict>
 	<key>uuid</key>

--- a/Symbol List - Sections.tmPreferences
+++ b/Symbol List - Sections.tmPreferences
@@ -12,7 +12,7 @@
 		<integer>1</integer>
 		<key>symbolTransformation</key>
 		<string>
-			s/\\(?:add)?(?:sub)*(.)(?:ection|hap|ec|hap)(?:\*)?\{([^\}]+)\}/\u$1 $2/g;
+			s/\\(?:add)?(?:sub)*(.)(?:ection|hapter|ec|hap)(?:\*)?\{([^\}]+)\}/\u$1 $2/g;
 		</string>
 	</dict>
 	<key>uuid</key>


### PR DESCRIPTION
This is just a simple change to the Symbol List - Sections file to add support for \addchap, \addsec, \addsubsec commands from KOMA-Script to the section list. Doesn't change support for \chapter, \section, \subsection, etc.