### PR TITLE
Bibfiles in TEXMF Tree

### DIFF
--- a/kpsewhich.py
+++ b/kpsewhich.py
@@ -1,0 +1,15 @@
+from subprocess import Popen, PIPE
+
+def kpsewhich(filename, file_format=None):
+    try:
+        if file_format is None or type(file_format) != type(''):
+            p = Popen(['kpsewhich', filename], stdout=PIPE, stdin=PIPE)
+        else:
+            p = Popen(['kpsewhich', '-format=%s' % (file_format), filename], stdout=PIPE, stdin=PIPE)
+        path = p.communicate()[0].rstrip()
+        if p.returncode == 0:
+            return path
+    except OSError:
+        # i.e., kpsewhich cannot be found
+        pass
+    return None

--- a/latex_cite_completions.py
+++ b/latex_cite_completions.py
@@ -5,9 +5,12 @@ if sublime.version() < '3000':
     # we are on ST2 and Python 2.X
     _ST3 = False
     import getTeXRoot
+    import kpsewhich
+    from kpsewhich import kpsewhich
 else:
     _ST3 = True
     from . import getTeXRoot
+    from .kpsewhich import kpsewhich
 
 
 import sublime_plugin
@@ -79,9 +82,14 @@ def find_bib_files(rootdir, src, bibfiles):
         for bf in bfiles:
             if bf[-4:].lower() != '.bib':
                 bf = bf + '.bib'
-            # We join with rootdir - everything is off the dir of the master file
-            bf = os.path.normpath(os.path.join(rootdir,bf))
-            bibfiles.append(bf)
+            # We join with rootdir, the dir of the master file
+            candidate_file = os.path.normpath(os.path.join(rootdir,bf))
+            # if the file doesn't exist, search the default tex paths
+            if not os.path.exists(candidate_file):
+                candidate_file = kpsewhich(bf, 'mlbib')
+
+            if candidate_file is not None and os.path.exists(candidate_file):
+                bibfiles.append(candidate_file)
 
     # search through input tex files recursively
     for f in re.findall(r'\\(?:input|include)\{[^\}]+\}',src_content):


### PR DESCRIPTION
Finding bib files in the TEXMF tree seems to come up frequently---e.g. #314, #60 and #258. This seemed like a simple, clean way of implementing it: just execute `kpsewhich` with a file name and let it do the search. In the interest of performance and minimising damage to already existing projects, I've set it so that `kpsewhich` only gets run if LaTeXTools cannot otherwise find a specified bib file. If `kpsewhich` cannot be found on the path, it fails silently. I've tested this successfully on both ST2 and ST3.