### PR TITLE
Fix '$' auto-pairing and Vintage (closes #308)

### DIFF
--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -131,6 +131,7 @@ LaTeX Package keymap for Linux
 	{ "keys": ["$"], "command": "insert_snippet", "args": {"contents": "\\$$0\\$"}, 
 	"context":  
 		[
+			{ "key": "setting.command_mode", "operator": "equal", "operand": false },
 			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"},
 			{ "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
 			{ "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },

--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -143,6 +143,7 @@ LaTeX Package keymap for Linux
 	// wrap in $
 	{ "keys": ["$"], "command": "insert_snippet", "args": {"contents": "\\$${0:$SELECTION}\\$"}, "context":
 		[
+			{ "key": "setting.command_mode", "operator": "equal", "operand": false },
 			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"},
 			{ "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
 			{ "key": "selection_empty", "operator": "equal", "operand": false, "match_all": true }
@@ -151,6 +152,7 @@ LaTeX Package keymap for Linux
 	// move over closing $
 	{ "keys": ["$"], "command": "move", "args": {"by": "characters", "forward": true}, "context":
 		[	
+			{ "key": "setting.command_mode", "operator": "equal", "operand": false },
 			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"},
 			{ "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
 			{ "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -132,6 +132,7 @@ LaTeX Package keymap for OS X
 	{ "keys": ["$"], "command": "insert_snippet", "args": {"contents": "\\$$0\\$"}, 
 	"context":  
 		[
+			{ "key": "setting.command_mode", "operator": "equal", "operand": false },
 			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"},
 			{ "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
 			{ "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -144,6 +144,7 @@ LaTeX Package keymap for OS X
 	// wrap in $
 	{ "keys": ["$"], "command": "insert_snippet", "args": {"contents": "\\$${0:$SELECTION}\\$"}, "context":
 		[
+			{ "key": "setting.command_mode", "operator": "equal", "operand": false },
 			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"},
 			{ "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
 			{ "key": "selection_empty", "operator": "equal", "operand": false, "match_all": true }
@@ -152,6 +153,7 @@ LaTeX Package keymap for OS X
 	// move over closing $
 	{ "keys": ["$"], "command": "move", "args": {"by": "characters", "forward": true}, "context":
 		[	
+			{ "key": "setting.command_mode", "operator": "equal", "operand": false },
 			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"},
 			{ "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
 			{ "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -131,6 +131,7 @@ LaTeX Package keymap for Windows
 	{ "keys": ["$"], "command": "insert_snippet", "args": {"contents": "\\$$0\\$"}, 
 	"context":  
 		[
+			{ "key": "setting.command_mode", "operator": "equal", "operand": false },
 			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"},
 			{ "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
 			{ "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -143,6 +143,7 @@ LaTeX Package keymap for Windows
 	// wrap in $
 	{ "keys": ["$"], "command": "insert_snippet", "args": {"contents": "\\$${0:$SELECTION}\\$"}, "context":
 		[
+			{ "key": "setting.command_mode", "operator": "equal", "operand": false },
 			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"},
 			{ "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
 			{ "key": "selection_empty", "operator": "equal", "operand": false, "match_all": true }
@@ -151,6 +152,7 @@ LaTeX Package keymap for Windows
 	// move over closing $
 	{ "keys": ["$"], "command": "move", "args": {"by": "characters", "forward": true}, "context":
 		[	
+			{ "key": "setting.command_mode", "operator": "equal", "operand": false },
 			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"},
 			{ "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
 			{ "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },


### PR DESCRIPTION
It works with Vintage and without Vintage (didn't try Vintageous).