### PR TITLE
Support for multi-line/spaces in \bibliography command.

### DIFF
--- a/latex_cite_completions.py
+++ b/latex_cite_completions.py
@@ -77,6 +77,7 @@ def find_bib_files(rootdir, src, bibfiles):
     for tag in bibtags:
         bfiles = re.search(r'\{([^\}]+)', tag).group(1).split(',')
         for bf in bfiles:
+            bf = bf.strip()
             if bf[-4:].lower() != '.bib':
                 bf = bf + '.bib'
             # We join with rootdir - everything is off the dir of the master file


### PR DESCRIPTION
I usually write my texts using the same set of .bib files; I have several of these, separated by subject, in one directory. When using several .bib files in the ```\bibliography``` command, I find it much more readable to have each file in one line, as opposed to one big line. This is an example:
```
\bibliography{%
	IEEEfull,%
	../bib/support,%
	../bib/simulation,%
	../bib/sdfg_tools_and_methods,%
	(...)
	../bib/optimization%
}
```

LaTeX has no problem with this, but LaTeXTools will fail to open the .bib files, as it thinks the whitespaces (including ```\n```s) are a part of the filenames. This is a quick one-liner to ignore trailing whitespaces on the filenames. If perhaps this is not the best way to do this, I am open to suggestions.