### PR TITLE
Extend 'makePDF.py' to also accept the file extension '.tikz'. It is now...

### DIFF
--- a/builders/simpleBuilder.py
+++ b/builders/simpleBuilder.py
@@ -38,7 +38,7 @@ class SimpleBuilder(PdfBuilder):
 		# Print greeting
 		self.display("\n\nSimpleBuilder: ")
 
-		pdflatex = ["pdflatex", "-interaction=nonstopmode", "-synctex=1"]
+		pdflatex = ["pdflatex", "-shell-escape", "-interaction=nonstopmode", "-synctex=1"]
 		bibtex = ["bibtex"]
 
 		# Regex to look for missing citations

--- a/makePDF.py
+++ b/makePDF.py
@@ -243,7 +243,7 @@ class make_pdfCommand(sublime_plugin.WindowCommand):
 			print ("saving...")
 			view.run_command('save') # call this on view, not self.window
 		
-		if self.tex_ext.upper() != ".TEX":
+		if self.tex_ext.upper() in ".TEX;.TIKZ" == False:
 			sublime.error_message("%s is not a TeX source file: cannot compile." % (os.path.basename(view.file_name()),))
 			return
 		


### PR DESCRIPTION
... easy to extend the list of accepted file extensions by simply extending the string.

The motivation for this is that I also want to compile TikZ code that is generated from "matlab2tikz". Those files need to have the extension ".tikz" because I also include them in my main latex file using the CTAN package "tikzscale".

This is my first pull request. Suggestions how I should improve the process are highly welcome!