### PR TITLE
Delete temporary files recursively

### DIFF
--- a/delete_temp_files.py
+++ b/delete_temp_files.py
@@ -1,5 +1,5 @@
 # ST2/ST3 compat
-from __future__ import print_function 
+from __future__ import print_function
 import sublime
 if sublime.version() < '3000':
 	_ST3 = False
@@ -22,19 +22,18 @@ class Delete_temp_filesCommand(sublime_plugin.WindowCommand):
 			sublime.error_message(self.file_name + ": file not found.")
 			return
 
-		self.tex_base, self.tex_ext = os.path.splitext(self.file_name)
-
+		self.path = os.path.dirname(self.file_name)
 
 		# Delete the files.
-		temp_exts = ['.blg','.bbl','.aux','.log','.brf','.nlo','.out','.dvi','.ps',
-			'.lof','.toc','.fls','.fdb_latexmk','.pdfsync','.synctex.gz','.ind','.ilg','.idx']
+		temp_exts = set(['.blg','.bbl','.aux','.log','.brf','.nlo','.out','.dvi','.ps',
+			'.lof','.toc','.fls','.fdb_latexmk','.pdfsync','.synctex.gz','.ind','.ilg','.idx'])
 
-		for temp_ext in temp_exts:
-			file_name_to_del = self.tex_base + temp_ext
-			#print file_name_to_del
-			if os.path.exists(file_name_to_del):
-				#print ' deleted '
-				os.remove(file_name_to_del)
+		for dir_path, dir_names, file_names in os.walk(self.path):
+			for file_name in file_names:
+				file_base, file_ext = os.path.splitext(file_name)
+				if file_ext in temp_exts:
+					file_name_to_del = os.path.join(dir_path, file_name)
+					if os.path.exists(file_name_to_del):
+						os.remove(file_name_to_del)
 
 		sublime.status_message("Deleted the temp files")
-		


### PR DESCRIPTION
I don't know if it's very common, but in long manuscripts, like a thesis for example, I often split up the chapters in separated files and even in separated folders. It causes the compiler to scatter the temporary files through the created folders. So I modified `delete_temp_files.py` to delete the temporary files recursively.