### PR TITLE
Update latex_cite_completions.py

### DIFF
--- a/latex_cite_completions.py
+++ b/latex_cite_completions.py
@@ -284,7 +284,7 @@ def get_cite_completions(view, point, autocompleting=False):
                     entry["keyword"] = kp_match.group(1) # No longer decode. Was: .decode('ascii','ignore')
                 else:
                     print ("Cannot process this @ line: " + line)
-                    print ("Previous record " + entry)
+                    # print ("Previous record " + entry)
                 continue
             # Now test for title, author, etc.
             # Note: we capture only the first line, but that's OK for our purposes


### PR DESCRIPTION
Line 287 was failing when trying to do cite completions. The reason:
     TypeError: Can't convert 'dict' object to str implicitly