### PR TITLE
Replaced \begin{center}[...] with \centering in snippets table and figure

### DIFF
--- a/figure.sublime-snippet
+++ b/figure.sublime-snippet
@@ -1,9 +1,8 @@
 <snippet>
 	<content><![CDATA[
 \begin{figure}[${1:tb}]
-	\begin{center}
-		\includegraphics[$2]{$3}
-	\end{center}
+	\centering
+	\includegraphics[$2]{$3}
 	\caption{${4:Caption here}}
 	\label{${5:fig:figure1}}
 \end{figure}

--- a/table.sublime-snippet
+++ b/table.sublime-snippet
@@ -3,19 +3,19 @@
 \begin{table}[${1:tb}]
 	\caption{${2:caption here}}
 	\label{${3:tab:tablename}}
-	\begin{center}
-		\begin{tabular}{${4:l|cc}}
-		\hline
+	\centering
 
-		\hline
-		\textbf{${5:column 1}} & \textbf{${6:column 2}} & \textbf{${7:column 3}} \\\\
-		\hline
-			 & & \\\\
-		\hline
+	\begin{tabular}{${4:l|cc}}
+	\hline
 
-		\hline
-		\end{tabular}
-	\end{center}
+	\hline
+	\textbf{${5:column 1}} & \textbf{${6:column 2}} & \textbf{${7:column 3}} \\\\
+	\hline
+		 & & \\\\
+	\hline
+
+	\hline
+	\end{tabular}
 \end{table}
 ]]></content>
 	<tabTrigger>btable</tabTrigger>


### PR DESCRIPTION
\begin{center}...\end{center} includes additional vertical space and thus
should be avoided in float environments.

See section 3.1 in:
"An essential guide to LATEX 2ε usage - Obsolete commands and packages"
ftp://ftp.dante.de/tex-archive/info/l2tabu/english/l2tabuen.pdf