### PR TITLE
Make from_keybinding default to false; Find Skim if not located at default path

### DIFF
--- a/jumpToPDF.py
+++ b/jumpToPDF.py
@@ -62,8 +62,13 @@ class jump_to_pdfCommand(sublime_plugin.TextCommand):
 		if plat == 'darwin':
 			options = ["-r","-g"] if keep_focus else ["-r"]		
 			if forward_sync:
-				subprocess.Popen(["/Applications/Skim.app/Contents/SharedSupport/displayline"] + 
-								options + [str(line), pdffile, srcfile])
+				path_to_skim = '/Applications/Skim.app/'
+				if not os.path.exists(path_to_skim):
+					path_to_skim = subprocess.check_output(
+						['osascript', '-e', 'POSIX path of (path to app id "net.sourceforge.skim-app.skim")']
+					).decode("utf8")[:-1]
+				subprocess.Popen([os.path.join(path_to_skim, "Contents/SharedSupport/displayline")] + 
+								  options + [str(line), pdffile, srcfile])
 			else:
 				skim = os.path.join(sublime.packages_path(),
 								'LaTeXTools', 'skim', 'displayfile')

--- a/jumpToPDF.py
+++ b/jumpToPDF.py
@@ -32,7 +32,7 @@ class jump_to_pdfCommand(sublime_plugin.TextCommand):
 		# need to invoke the command. And if it is not visible, the natural way to just bring up the
 		# window without syncing is by using the system's window management shortcuts.
 		# As for focusing, we honor the toggles / prefs.
-		from_keybinding = args["from_keybinding"]
+		from_keybinding = args["from_keybinding"] if "from_keybinding" in args else False
 		if from_keybinding:
 			forward_sync = True
 		print (from_keybinding, keep_focus, forward_sync)


### PR DESCRIPTION
From [README.markdown](https://github.com/SublimeText/LaTeXTools/blob/master/README.markdown)

> If you have installed Skim in a non-standard location, there is not much you can do short of hacking the `jumpToPDF.py` file (**not supported!**). This will change in the near future. 

I couldn't wait for it, so I did it myself. Let me know if it looks good!