### PR TITLE
TEXroot relative to project settings

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -139,7 +139,12 @@ The default ST Build command takes care of the following:
 
 **Multi-file documents** are supported as follows. If the first line in the current file consists of the text `%!TEX root = <master file name>`, then tex & friends are invoked on the specified master file, instead of the current one. Note: the only file that gets saved automatically is the current one. Also, the master file name **must** have a `.tex` extension, or it won't be recognized.
 
-There is also support for project files; this is to be documented.
+There is also support for project files. A master file can be specified in the project's settings section by setting the `"TEXroot"` key. In the following example `"main.tex"` is the project's master file:
+
+	"settings":
+	{
+		"TEXroot": "main.tex"
+	}
 
 **TeX engine selection** is supported. If the first line of the current file consists of the text `%!TEX program = <program>`, where `program` is `pdflatex`, `lualatex` or `xelatex`, the corresponding engine is selected. If no such directive is specified, `pdflatex` is the default. Multi-file documents are supported: the directive must be in the *root* (i.e. master) file. Also, for compatibility with TeXshop, you can use `TS-program` instead of `program`. **Note**: for this to work, you must **not** customize the `"command"` option in `LaTeX.sublime-settings`. If you do, you will not get this functionality. 
 

--- a/getTeXRoot.py
+++ b/getTeXRoot.py
@@ -1,5 +1,5 @@
 # ST2/ST3 compat
-from __future__ import print_function 
+from __future__ import print_function
 import sublime
 if sublime.version() < '3000':
 	# we are on ST2 and Python 2.X
@@ -20,28 +20,33 @@ import codecs
 # Contributed by Sam Finn
 
 def get_tex_root(view):
-
-	# Get TEXroot from project.
 	try:
-		projFile = view.window().project_file_name()
-		projData = view.window().project_data()
+		# Retrive TEX root from the project settings file.
+		root = view.settings().get('TEXroot', None)
 
-		# TEXroot is relative project file.
-		(projPath, _) = os.path.split(projFile)
-		root = os.path.join(projPath, projData.get('settings').get('TEXroot'))
+		# The TEX root must have an absolute path.
+		if os.path.isabs(root):
+			if os.path.isfile(root):
+				return root
+		else:
+			try:
+				# Make root relative to the current project's .sublime-project
+				# file. This will thrown an exception on ST2 and when no
+				# project is loaded on ST3.
+				projFile = view.window().project_file_name()
+				projDir = os.path.dirname(projFile)
 
-		if os.path.isfile(root):
-			print("Main file defined in project settings : " + root)
-			return root
-	except:
-		pass
+				rootPath = os.path.join(projDir, root)
+				if os.path.isfile(rootPath):
+					return rootPath
+			except:
+				pass
 
-	# Get TEXroot from global settings.
-	try:
-		root = os.path.abspath(view.settings().get('TEXroot'))
-		if os.path.isfile(root):
-			print("Main file defined in global settings : " + root)
-			return root
+			# Make root relative to the current working directory. This fails if
+			# multiple instances of ST are running (issue #152).
+			rootPath = os.path.abspath(root)
+			if os.path.isfile(rootPath):
+				return rootPath
 	except:
 		pass
 
@@ -72,7 +77,7 @@ def get_tex_root(view):
 			# We have a comment match; check for a TEX root match
 			mroot = re.match(r"%\s*!TEX\s+root *= *(.*(tex|TEX))\s*$",line)
 			if mroot:
-				# we have a TEX root match 
+				# we have a TEX root match
 				# Break the match into path, file and extension
 				# Create TEX root file name
 				# If there is a TEX root path, use it

--- a/getTeXRoot.py
+++ b/getTeXRoot.py
@@ -20,14 +20,30 @@ import codecs
 # Contributed by Sam Finn
 
 def get_tex_root(view):
+
+	# Get TEXroot from project.
 	try:
-		root = os.path.abspath(view.settings().get('TEXroot'))
+		projFile = view.window().project_file_name()
+		projData = view.window().project_data()
+
+		# TEXroot is relative project file.
+		(projPath, _) = os.path.split(projFile)
+		root = os.path.join(projPath, projData.get('settings').get('TEXroot'))
+
 		if os.path.isfile(root):
 			print("Main file defined in project settings : " + root)
 			return root
 	except:
 		pass
 
+	# Get TEXroot from global settings.
+	try:
+		root = os.path.abspath(view.settings().get('TEXroot'))
+		if os.path.isfile(root):
+			print("Main file defined in global settings : " + root)
+			return root
+	except:
+		pass
 
 	texFile = view.file_name()
 	root = texFile


### PR DESCRIPTION
I've modified `get_tex_root()` to take the project-file's location into account when searching for the master file for projects that define a `"TEXroot"` setting. This solves two issues. Firstly, it is now possible to compile multi-file projects from included tex files that are located in subdirectories. Secondly, it is now possible to open multiple projects simultaneously (in different windows) and compile them. Issue #152 is related.