### PR TITLE
Ignore .git and .svn folders to prevent corrupting their contents

### DIFF
--- a/delete_temp_files.py
+++ b/delete_temp_files.py
@@ -27,8 +27,10 @@ class Delete_temp_filesCommand(sublime_plugin.WindowCommand):
 		# Delete the files.
 		temp_exts = set(['.blg','.bbl','.aux','.log','.brf','.nlo','.out','.dvi','.ps',
 			'.lof','.toc','.fls','.fdb_latexmk','.pdfsync','.synctex.gz','.ind','.ilg','.idx'])
+		ignored_folders = ['.git','.svn']
 
 		for dir_path, dir_names, file_names in os.walk(self.path):
+			dir_names[:] = [d for d in dir_names if d not in ignored_folders]
 			for file_name in file_names:
 				file_base, file_ext = os.path.splitext(file_name)
 				if file_ext in temp_exts:


### PR DESCRIPTION
`delete_temp_files.py` deletes files with matching extensions descending recursively into folders **including .git**. On my machine, cleaning the LaTeX temporary files results in corruption of the associated git repository because git includes `.idx` files.  I've modified `delete_temp_files.py` to ignore folders whose names match a list of folder names, currently including `.git` and `.svn` by default which prevents inadvertent damage to the repositories. 