### PR TITLE
Fix Beamer angle bracket snippet

### DIFF
--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -181,7 +181,7 @@ LaTeX Package keymap for Linux
 			{"key": "selector", "operator": "not_equal", "operand": "string.other.math.block.tex"},
 			{ "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
 			{ "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
-			{ "key": "preceding_text", "operator": "regex_contains", "operand": "\\item|only|textbf|color|onslide|only|uncover|visible|invisible|alt|temporal$", "match_all": true }
+			{ "key": "preceding_text", "operator": "regex_contains", "operand": "\\\\(?:item|only|textbf|color|onslide|only|uncover|visible|invisible|alt|temporal)$", "match_all": true }
 		]
 	},
 	// wrap in <>

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -182,7 +182,7 @@ LaTeX Package keymap for OS X
 			{"key": "selector", "operator": "not_equal", "operand": "string.other.math.block.tex"},
 			{ "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
 			{ "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
-			{ "key": "preceding_text", "operator": "regex_contains", "operand": "\\item|only|textbf|color|onslide|only|uncover|visible|invisible|alt|temporal$", "match_all": true }
+			{ "key": "preceding_text", "operator": "regex_contains", "operand": "\\\\(?:item|only|textbf|color|onslide|only|uncover|visible|invisible|alt|temporal)$", "match_all": true }
 		]
 	},
 	// wrap in <>

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -181,7 +181,7 @@ LaTeX Package keymap for Windows
 			{"key": "selector", "operator": "not_equal", "operand": "string.other.math.block.tex"},
 			{ "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
 			{ "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
-			{ "key": "preceding_text", "operator": "regex_contains", "operand": "\\item|only|textbf|color|onslide|only|uncover|visible|invisible|alt|temporal$", "match_all": true }
+			{ "key": "preceding_text", "operator": "regex_contains", "operand": "\\\\(?:item|only|textbf|color|onslide|only|uncover|visible|invisible|alt|temporal)$", "match_all": true }
 		]
 	},
 	// wrap in <>


### PR DESCRIPTION
While looking at support apacite's cite commands, which use angle brackets, I discovered that the keymap rule intended for Beamer overlays wasn't configured properly. For example, if you create a document that invokes `\textbf{}`, any time you enter an angle bracket after that you will get `<+->` regardless of the context, e.g.,

    \textbf{this is important}. But however <+->

This commit fixes this so it will work as intended, i.e., for a small list of commands, pressing `<` will insert the beamer overlay snippet.