### PR TITLE
Refactor completion code

### DIFF
--- a/latex_cite_completions.py
+++ b/latex_cite_completions.py
@@ -7,10 +7,12 @@ if sublime.version() < '3000':
     import getTeXRoot
     import kpsewhich
     from kpsewhich import kpsewhich
+    from latextools_utils.subfiles import walk_subfiles
 else:
     _ST3 = True
     from . import getTeXRoot
     from .kpsewhich import kpsewhich
+    from .latextools_utils.subfiles import walk_subfiles
 
 
 import sublime_plugin
@@ -41,61 +43,27 @@ def match(rex, str):
 # recursively search all linked tex files to find all
 # included bibliography tags in the document and extract
 # the absolute filepaths of the bib files
-def find_bib_files(rootdir, src, bibfiles):
-    if src[-4:].lower() != ".tex":
-        src = src + ".tex"
+def find_bib_files(rootdir, src):
+    bib_files = []
+    for content in walk_subfiles(rootdir, src):
+        bibtags =  re.findall(r'\\bibliography\{([^\}]+)\}', content)
+        bibtags += re.findall(r'\\addbibresource\{([^\}]+.bib)\}', content)
 
-    file_path = os.path.normpath(os.path.join(rootdir,src))
-    print("Searching file: " + repr(file_path))
-    # See latex_ref_completion.py for why the following is wrong:
-    #dir_name = os.path.dirname(file_path)
+        # extract absolute filepath for each bib file
+        for tag in bibtags:
+            bfiles = tag.split(',')
+            for bf in bfiles:
+                if bf[-4:].lower() != '.bib':
+                    bf = bf + '.bib'
+                # We join with rootdir, the dir of the master file
+                candidate_file = os.path.normpath(os.path.join(rootdir, bf))
+                # if the file doesn't exist, search the default tex paths
+                if not os.path.exists(candidate_file):
+                    candidate_file = kpsewhich(bf, 'mlbib')
 
-    # read src file and extract all bibliography tags
-    try:
-        src_file = codecs.open(file_path, "r", 'UTF-8')
-    except IOError:
-        sublime.status_message("LaTeXTools WARNING: cannot open included file " + file_path)
-        print ("WARNING! I can't find it! Check your \\include's and \\input's.")
-        return
-
-    src_content = re.sub("%.*","",src_file.read())
-    src_file.close()
-
-    m = re.search(r"\\usepackage\[(.*?)\]\{inputenc\}", src_content)
-    if m:
-        f = None
-        try:
-            f = codecs.open(file_path, "r", m.group(1))
-            src_content = re.sub("%.*", "", f.read())
-        except:
-            pass
-        finally:
-            if f and not f.closed:
-                f.close()
-
-    bibtags =  re.findall(r'\\bibliography\{[^\}]+\}', src_content)
-    bibtags += re.findall(r'\\addbibresource\{[^\}]+.bib\}', src_content)
-
-    # extract absolute filepath for each bib file
-    for tag in bibtags:
-        bfiles = re.search(r'\{([^\}]+)', tag).group(1).split(',')
-        for bf in bfiles:
-            if bf[-4:].lower() != '.bib':
-                bf = bf + '.bib'
-            # We join with rootdir, the dir of the master file
-            candidate_file = os.path.normpath(os.path.join(rootdir,bf))
-            # if the file doesn't exist, search the default tex paths
-            if not os.path.exists(candidate_file):
-                candidate_file = kpsewhich(bf, 'mlbib')
-
-            if candidate_file is not None and os.path.exists(candidate_file):
-                bibfiles.append(candidate_file)
-
-    # search through input tex files recursively
-    for f in re.findall(r'\\(?:input|include)\{[^\}]+\}',src_content):
-        input_f = re.search(r'\{([^\}]+)', f).group(1)
-        find_bib_files(rootdir, input_f, bibfiles)
-
+                if candidate_file is not None and os.path.exists(candidate_file):
+                    bib_files.append(candidate_file)
+    return bib_files
 
 def get_cite_completions(view, point, autocompleting=False):
     line = view.substr(sublime.Region(view.line(point).a, point))
@@ -189,10 +157,7 @@ def get_cite_completions(view, point, autocompleting=False):
         raise NoBibFilesError()
 
     print ("TEX root: " + repr(root))
-    bib_files = []
-    find_bib_files(os.path.dirname(root), root, bib_files)
-    # remove duplicate bib files
-    bib_files = list(set(bib_files))
+    bib_files = list(set(find_bib_files(os.path.dirname(root), root)))
     print ("Bib files found: ")
     print (repr(bib_files))
 

--- a/latex_cite_completions.py
+++ b/latex_cite_completions.py
@@ -7,11 +7,13 @@ if sublime.version() < '3000':
     import getTeXRoot
     import kpsewhich
     from kpsewhich import kpsewhich
+    from latextools_utils import is_tex_buffer
     from latextools_utils.subfiles import walk_subfiles
 else:
     _ST3 = True
     from . import getTeXRoot
     from .kpsewhich import kpsewhich
+    from .latextools_utils import is_tex_buffer
     from .latextools_utils.subfiles import walk_subfiles
 
 
@@ -341,8 +343,7 @@ class LatexCiteCompletions(sublime_plugin.EventListener):
 
     def on_query_completions(self, view, prefix, locations):
         # Only trigger within LaTeX
-        if not view.match_selector(locations[0],
-                "text.tex.latex"):
+        if not is_tex_buffer(view):
             return []
 
         point = locations[0]
@@ -381,11 +382,8 @@ class LatexCiteCommand(sublime_plugin.TextCommand):
         # get view and location of first selection, which we expect to be just the cursor position
         view = self.view
         point = view.sel()[0].b
-        print (point)
         # Only trigger within LaTeX
-        # Note using score_selector rather than match_selector
-        if not view.score_selector(point,
-                "text.tex.latex"):
+        if not is_tex_buffer(view):
             return
 
         try:

--- a/latex_ref_cite_completions.py
+++ b/latex_ref_cite_completions.py
@@ -8,12 +8,13 @@ if sublime.version() < '3000':
     import getTeXRoot
     from latex_cite_completions import OLD_STYLE_CITE_REGEX, NEW_STYLE_CITE_REGEX
     from latex_ref_completions import OLD_STYLE_REF_REGEX, NEW_STYLE_REF_REGEX
+    from latextools_utils import is_tex_buffer
 else:
     _ST3 = True
     from . import getTeXRoot
     from .latex_cite_completions import OLD_STYLE_CITE_REGEX, NEW_STYLE_CITE_REGEX
     from .latex_ref_completions import OLD_STYLE_REF_REGEX, NEW_STYLE_REF_REGEX
-
+    from .latextools_utils import is_tex_buffer
 
 ## Match both refs and cites, then dispatch as needed
 
@@ -31,11 +32,8 @@ class LatexRefCiteCommand(sublime_plugin.TextCommand):
         # get view and location of first selection, which we expect to be just the cursor position
         view = self.view
         point = view.sel()[0].b
-        print (point)
         # Only trigger within LaTeX
-        # Note using score_selector rather than match_selector
-        if not view.score_selector(point,
-                "text.tex.latex"):
+        if not is_tex_buffer(view, point):
             return
 
 

--- a/latex_ref_completions.py
+++ b/latex_ref_completions.py
@@ -5,9 +5,11 @@ if sublime.version() < '3000':
     # we are on ST2 and Python 2.X
     _ST3 = False
     import getTeXRoot
+    from latextools_utils.subfiles import walk_subfiles
 else:
     _ST3 = True
     from . import getTeXRoot
+    from .latextools_utils.subfiles import walk_subfiles
 
 import sublime_plugin
 import os, os.path
@@ -30,57 +32,15 @@ def match(rex, str):
     else:
         return None
 
-
 # recursively search all linked tex files to find all
 # included \label{} tags in the document and extract
-def find_labels_in_files(rootdir, src, labels):
-    if src[-4:].lower() != ".tex":
-        src = src + ".tex"
+def find_labels_in_files(rootdir, src):
+    completions = []
+    for content in walk_subfiles(rootdir, src):
+        for label in re.findall(r'\\label\{([^{}]+)\}', content):
+            completions.append(label)
 
-    file_path = os.path.normpath(os.path.join(rootdir, src))
-    print ("Searching file: " + repr(file_path))
-    # The following was a mistake:
-    #dir_name = os.path.dirname(file_path)
-    # THe reason is that \input and \include reference files **from the directory
-    # of the master file**. So we must keep passing that (in rootdir).
-
-    # read src file and extract all label tags
-
-    # We open with utf-8 by default. If you use a different encoding, too bad.
-    # If we really wanted to be safe, we would read until \begin{document},
-    # then stop. Hopefully we wouldn't encounter any non-ASCII chars there. 
-    # But for now do the dumb thing.
-    try:
-        src_file = codecs.open(file_path, "r", "UTF-8")
-    except IOError:
-        sublime.status_message("LaTeXTools WARNING: cannot find included file " + file_path)
-        print ("WARNING! I can't find it! Check your \\include's and \\input's." )
-        return
-
-    src_content = re.sub("%.*", "", src_file.read())
-    src_file.close()
-
-    # If the file uses inputenc with a DIFFERENT encoding, try re-opening
-    # This is still not ideal because we may still fail to decode properly, but still... 
-    m = re.search(r"\\usepackage\[(.*?)\]\{inputenc\}", src_content)
-    if m and (m.group(1) not in ["utf8", "UTF-8", "utf-8"]):
-        print("reopening with encoding " + m.group(1))
-        f = None
-        try:
-            f = codecs.open(file_path, "r", m.group(1))
-            src_content = re.sub("%.*", "", f.read())
-        except:
-            print("Uh-oh, could not read file " + file_path + " with encoding " + m.group(1))
-        finally:
-            if f and not f.closed:
-                f.close()
-
-    labels += re.findall(r'\\label\{([^{}]+)\}', src_content)
-
-    # search through input tex files recursively
-    for f in re.findall(r'\\(?:input|include)\{([^\{\}]+)\}', src_content):
-        find_labels_in_files(rootdir, f, labels)
-
+    return completions
 
 # get_ref_completions forms the guts of the parsing shared by both the
 # autocomplete plugin and the quick panel command
@@ -160,17 +120,18 @@ def get_ref_completions(view, point, autocompleting=False):
     #    1) in case there are unsaved changes
     #    2) if this file is unnamed and unsaved, get_tex_root will fail
     view.find_all(r'\\label\{([^\{\}]+)\}', 0, '\\1', completions)
+    print(completions)
 
     root = getTeXRoot.get_tex_root(view)
     if root:
         print ("TEX root: " + repr(root))
-        find_labels_in_files(os.path.dirname(root), root, completions)
+        completions.extend(find_labels_in_files(os.path.dirname(root), root))
 
     # remove duplicates
+    print(completions)
     completions = list(set(completions))
 
     return completions, prefix, post_snippet, new_point_a, new_point_b
-
 
 # Based on html_completions.py
 #

--- a/latex_ref_completions.py
+++ b/latex_ref_completions.py
@@ -5,10 +5,12 @@ if sublime.version() < '3000':
     # we are on ST2 and Python 2.X
     _ST3 = False
     import getTeXRoot
+    from latextools_utils import is_tex_buffer
     from latextools_utils.subfiles import walk_subfiles
 else:
     _ST3 = True
     from . import getTeXRoot
+    from .latextools_utils import is_tex_buffer
     from .latextools_utils.subfiles import walk_subfiles
 
 import sublime_plugin
@@ -155,8 +157,7 @@ class LatexRefCompletions(sublime_plugin.EventListener):
 
     def on_query_completions(self, view, prefix, locations):
         # Only trigger within LaTeX
-        if not view.match_selector(locations[0],
-                "text.tex.latex"):
+        if not is_tex_buffer(view):
             return []
 
         point = locations[0]
@@ -181,11 +182,8 @@ class LatexRefCommand(sublime_plugin.TextCommand):
         # get view and location of first selection, which we expect to be just the cursor position
         view = self.view
         point = view.sel()[0].b
-        print (point)
         # Only trigger within LaTeX
-        # Note using score_selector rather than match_selector
-        if not view.score_selector(point,
-                "text.tex.latex"):
+        if not is_tex_buffer(view, point):
             return
 
         try:

--- a/latextools_utils/__init__.py
+++ b/latextools_utils/__init__.py
@@ -1,0 +1,3 @@
+def is_tex_buffer(view, point=0):
+    # per unofficial docs, match_selector is equivalent to score_selector != 0
+    return view.match_selector(point, 'text.tex.latex')

--- a/latextools_utils/subfiles.py
+++ b/latextools_utils/subfiles.py
@@ -1,0 +1,61 @@
+from __future__ import print_function
+
+import codecs
+import os
+import re
+
+import sublime
+
+INPUT_FILE = re.compile(r'\\(?:input|include)\{([^\}]+)\}')
+DOCUMENT_START = re.compile(r'\\begin{document}')
+
+# recursively search all linked tex files to find all
+# included bibliography tags in the document and extract
+# the absolute filepaths of the bib files
+def walk_subfiles(rootdir, src, preamble_only=False):
+    # rootdir has to be passed along because \input and \include
+    # are relative to the root file
+    if src[-4:].lower() != ".tex":
+        src = src + ".tex"
+
+    file_path = os.path.normpath(os.path.join(rootdir, src))
+    print("Scanning file: " + repr(file_path))
+
+    # We open with utf-8 by default. If you use a different encoding, too bad.
+    # If we really wanted to be safe, we would read until \begin{document},
+    # then stop. Hopefully we wouldn't encounter any non-ASCII chars there.
+    # But for now do the dumb thing.
+    try:
+        src_file = codecs.open(file_path, "r", 'UTF-8')
+    except IOError:
+        print ("LaTeXTools WARNING: cannot open included file " + file_path)
+        return
+
+    src_content = re.sub('%.*', '', src_file.read())
+    src_file.close()
+
+    m = re.search(r"\\usepackage\[(.*?)\]\{inputenc\}", src_content)
+    if m:
+        f = None
+        try:
+            f = codecs.open(file_path, "r", m.group(1))
+            src_content = re.sub("%.*", "", f.read())
+        except:
+            pass
+        finally:
+            if f and not f.closed:
+                f.close()
+
+    yield src_content
+
+    document_start = None
+    # search through input tex files recursively
+    if preamble_only:
+        src_content, document_start = re.split(DOCUMENT_START, src_content, 1)[0]
+
+    for input_file in re.findall(INPUT_FILE, src_content):
+        for src_content in walk_subfiles(rootdir, input_file, preamble_only):
+            yield src_content
+
+    if document_start is not None:
+        raise StopIteration()

--- a/latextools_utils/subfiles.py
+++ b/latextools_utils/subfiles.py
@@ -51,7 +51,7 @@ def walk_subfiles(rootdir, src, preamble_only=False):
     document_start = None
     # search through input tex files recursively
     if preamble_only:
-        src_content, document_start = re.split(DOCUMENT_START, src_content, 1)[0]
+        src_content, document_start = re.split(DOCUMENT_START, src_content, 1)
 
     for input_file in re.findall(INPUT_FILE, src_content):
         for src_content in walk_subfiles(rootdir, input_file, preamble_only):


### PR DESCRIPTION
This is a simple refactoring to extract some of the common elements of the completion code into library functions, mostly to avoid code duplication.

I've defined two new functions:

 * `latextools_utils.is_tex_buffer(view, point=0)` which is intended to standardise the various ways that we were detecting whether or not a buffer was a TeX buffer (mostly by using `view.score_selector()`).

 * `latextools_utils.walk_subfiles(rootdir, src, preamble_only=False)` which is intended to cover the shared code between `find_bib_files()` and `find_labels_in_files()` and make those implementations more straight-forward. It is implemented as a generator, yielding the contents of each file found via either an `\input` or `\include` command. The contents returned have all comments stripped. If `preamble_only` is set to true, it through subfiles once `\begin{document}` is encountered. This should make it easier to support other packages that load external files, such as [`import`](http://www.ctan.org/pkg/import) and [`subfiles`](http://www.ctan.org/tex-archive/macros/latex/contrib/subfiles/).

Incidentally, I'm trying to keep my pull requests pretty atomic, but I do have separate branches to merge these changes with #521 and #504 and to merge #522 into `walk_subdirs()` to continue supporting non-`.tex` extensions.