### PR TITLE
Better Bibliography Editing

### DIFF
--- a/BibLaTeX.tmLanguage
+++ b/BibLaTeX.tmLanguage
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>name</key>
+    <string>BibLaTeX</string>
+    <key>fileTypes</key>
+    <array>
+        <string>bib</string>
+    </array>
+    <key>patterns</key>
+    <array>
+        <dict>
+            <key>include</key>
+            <string>text.bibtex</string>
+        </dict>
+    </array>
+    <key>scopeName</key>
+    <string>text.biblatex</string>
+    <key>uuid</key>
+    <string>7920bb3c-1423-11e5-85a9-e16ceb8a2689</string>
+</dict>
+</plist>

--- a/LaTeXTools.sublime-settings
+++ b/LaTeXTools.sublime-settings
@@ -69,6 +69,10 @@
 	// files that match one of the configured `tex_file_exts`
 	"latextools_set_syntax": true,
 
+	// set to true to use BibLaTeX instead of BibTex for bibliography completions
+	// can also be set on a per-project basis
+	"use_biblatex": false,
+
 	// the mapping from the locales to the dictionaries for the 
 	// `%!TEX spellcheck` directive, where the locales must be all lowercase
 	// and separated by a minus sign (-). The dictionaries must be valid path

--- a/README.markdown
+++ b/README.markdown
@@ -464,6 +464,13 @@ Spell-checking
 LaTeXTools parses the `%!TEX spellcheck` directive to set the language for the spell-checker integrated in Sublime Text. The [Dictionaries](https://github.com/titoBouzout/Dictionaries) package is recommended and supported. If you have additional dictionaries, you can add them using the `tex_spellcheck_paths` setting. This is a mapping from the locales to the dictionary paths. Each locale must be lowercase and minus (-) separated and the dictionary paths must be compatible with the Sublime Text spell-checker. For example `{"en-us": "Packages/Language - English/en_US.dic"}` would be a valid value.
 
 
+Support for Editing Bibliographies
+----------------------------------
+LaTeXTools has some enhanced support for editing either BibTeX or BibLaTeX `.bib` files. Snippet completions are provided for every entry type supported by either BibTeX or BibLaTeX, as are completions for field names. In addition, LaTeXTools provides smart completions for name fields (such as `author`, `editor`, etc.) and crossrefs. When auto-completions are triggered in a name field, a list of all entered names in the current file is presented. Similarly, when auto-completions are triggered in a crossref field, a list of all current entry keys will be provided.
+
+This behaviour is controlled by a single setting, `use_biblatex` (default: `false`), which indicates whether LaTeXTools should use the BibTeX versions of the auto-completions (this is the default behavior) or the BibLaTeX versions of the auto-completions (if `use_biblatex` is set to `true`).
+
+
 Miscellaneous
 -------------
 
@@ -504,6 +511,7 @@ The following options are currently available (defaults in parentheses):
 - `temp_files_ignored_folders`: subdirectories to skip when deleting temp files.
 * `tex_file_exts` (`['.tex']`): a list of extensions that should be considered TeX documents. Any extensions in this list will be treated exactly the same as `.tex` files. See the section on [Support for non-`.tex` files](#support-for-non-tex-files).
 * `latextools_set_syntax` (`true`): if `true` LaTeXTools will automatically set the syntax to `LaTeX` when opening or saving any file with an extension in the `tex_file_exts` list.
+* `use_biblatex`: (`false`): if `true` LaTeXTools will use BibLaTeX defaults for editing `.bib` files. If `false`, LaTeXTools will use BibTeX defaults. See the section on [Support for Editing Bibliographies](#support-for-editing-bibliographies) for details.
 * `tex_spellcheck_paths` (`{}`): A mapping from the locales to the paths of the dictionaries. See the section [Spell-checking](#spell-checking)
 * `hide_local_cache` (`true`): Whether the local cache should be hidden in the sublime cache path (`true`) or in the same directory as the root file (`false`). See the section [Caching](#caching).
 * `local_cache_life_span` (`30 m`): The lifespan of the local cache. See the section [Caching](#caching).

--- a/biblatex_crossref_completions.py
+++ b/biblatex_crossref_completions.py
@@ -1,0 +1,166 @@
+from __future__ import print_function
+
+import sublime
+import sublime_plugin
+
+import re
+import sys
+
+try:
+    from latextools_utils import is_bib_buffer, is_biblatex_buffer
+except ImportError:
+    from .latextools_utils import is_bib_buffer, is_biblatex_buffer
+
+if sys.version_info > (3, 0):
+    strbase = str
+else:
+    strbase = basestring
+
+# Regexes to detect the various types of crossref fields
+# Expected field in the format:
+#   <field> = {<value>,<value>}
+# Should support partials approaching this format
+#
+# I've tried to simply the comprehensibility of the backwards regexes used by
+# constructing them here
+#
+# VALUE_REGEX is a common suffix to hand the `= {<value>,<value>}` part
+VALUE_REGEX = r'(?!.*\})\s*(?P<ENTRIES>(?:,[^,]*)+\b)?\s*(?P<OPEN>\{)?(?P<EQUALS>\s*=\s*)?'
+CROSSREF_REGEX = re.compile(
+    VALUE_REGEX + r'crossref'[::-1] + r'\b',
+    re.IGNORECASE | re.UNICODE
+)
+
+BIBLATEX_REGEX = re.compile(
+    VALUE_REGEX + r'(?:' + r'|'.join((s[::-1] for s in ('xref', 'related'))) + r')' + r'\b',
+    re.IGNORECASE | re.UNICODE
+)
+
+ENTRY_SET_REGEX = re.compile(
+    VALUE_REGEX + r'entryset'[::-1] + r'\b',
+    re.IGNORECASE | re.UNICODE
+)
+
+XDATA_REGEX = re.compile(
+    VALUE_REGEX + r'xdata'[::-1] + r'\b',
+    re.IGNORECASE | re.UNICODE
+)
+
+# set indicating entries that have their own special handling...
+SPECIAL_ENTRIES = set(['@xdata', '@set'])
+
+def _get_keys_by_type(view, valid_types):
+    if not valid_types:
+        return []
+
+    if callable(valid_types):
+        validator = valid_types
+    elif type(valid_types) == strbase:
+        def validator(s):
+            return s == valid_types
+    else:
+        def validator(s):
+            return s in valid_types
+
+    keys = []
+
+    contents = view.substr(sublime.Region(0, view.size()))
+    for entry_type, key in re.findall(
+        r'(@(?!preamble|comment|string)[a-zA-Z]+)\s*\{\s*([^,]+)\b',
+        contents,
+        re.IGNORECASE | re.UNICODE
+    ):
+        if validator(entry_type):
+            keys.append(key)
+
+    return keys
+
+# BibLaTeX supports custom user-defined keys specified in the `id` field
+def _get_keys_from_id_field(view):
+    keys = []
+
+    contents = view.substr(sublime.Region(0, view.size()))
+    # TODO: Should probably figure out how to work out the entry-type
+    for ids in re.findall(
+        r'\bids\s*=\s*\{([^}]+)\}',
+        contents,
+        re.IGNORECASE | re.UNICODE | re.DOTALL
+    ):
+        for key in re.findall(
+            r'\b([^,]+)\b',
+            ids,
+            re.IGNORECASE | re.UNICODE
+        ):
+            keys.append(key)
+
+    return keys
+
+def _get_cite_keys_validator(s):
+    return s not in SPECIAL_ENTRIES
+
+def get_cite_keys(view):
+    return _get_keys_by_type(view, _get_cite_keys_validator) + \
+        _get_keys_from_id_field(view)
+
+def get_xdata_keys(view):
+    return _get_keys_by_type(view, '@xdata')
+
+def get_entryset_keys(view):
+    return _get_keys_by_type(view, '@set')
+
+def get_text_to_cursor(view):
+    cursor = view.sel()[0].b
+    current_region = sublime.Region(0, cursor)
+    return view.substr(current_region)
+
+# builds the replacement string depending on the current context of the line
+def _get_replacement(matcher, key):
+    if not matcher.group('ENTRIES'):
+        return u'{0}{1}{2}{3}'.format(
+            u'' if matcher.group('EQUALS') else u'= ',
+            u'' if matcher.group('OPEN') else u'{',
+            key,
+            u'' if matcher.group('OPEN') else u'}'
+        )
+
+    return '{0}{1}'.format(
+        u',' if matcher.group('ENTRIES')[0] != u',' else u'',
+        key
+    )
+
+def get_completions_if_matches(regex, line, get_key_list_func, view):
+    matcher = regex.match(line)
+    if matcher:
+        return ([(key, _get_replacement(matcher, key))
+                for key in sorted(set(get_key_list_func(view)))],
+                sublime.INHIBIT_WORD_COMPLETIONS |
+                sublime.INHIBIT_EXPLICIT_COMPLETIONS)
+    else:
+        return []
+
+class BiblatexCrossrefCompletions(sublime_plugin.EventListener):
+    def on_query_completions(self, view, prefix, locations):
+        if not is_bib_buffer(view):
+            return []
+
+        current_line = get_text_to_cursor(view)[::-1]
+
+        if current_line.startswith(prefix[::-1]):
+            current_line = current_line[len(prefix):]
+
+        result = get_completions_if_matches(
+            CROSSREF_REGEX, current_line, get_cite_keys, view)
+
+        if result:
+            return result
+
+        if not is_biblatex_buffer(view):
+            return []
+
+        return get_completions_if_matches(
+                    BIBLATEX_REGEX, current_line, get_cite_keys, view) or \
+            get_completions_if_matches(
+                    XDATA_REGEX, current_line, get_xdata_keys, view) or \
+            get_completions_if_matches(
+                    ENTRY_SET_REGEX, current_line, get_entryset_keys, view) or \
+            []

--- a/biblatex_field_name_completions.py
+++ b/biblatex_field_name_completions.py
@@ -1,0 +1,210 @@
+from __future__ import print_function
+
+import sublime
+import sublime_plugin
+
+try:
+    from latextools_utils import is_bib_buffer, is_biblatex_buffer
+except ImportError:
+    from .latextools_utils import is_bib_buffer, is_biblatex_buffer
+
+bibtex_fields = [
+    ['address', 'address = {${1:Address}},'],
+    ['annote', 'annote = {${1:Annote}},'],
+    ['author', 'author = {${1:Author}},'],
+    ['booktitle', 'booktitle = {${1:Booktitle}},'],
+    ['chapter', 'chapter = {${1:Chapter}},'],
+    ['crossref', 'crossref = {${1:Crossref}},'],
+    ['edition', 'edition = {${1:Edition}},'],
+    ['editor', 'editor = {${1:Editor}},'],
+    ['howpublished', 'howpublished = {${1:Howpublished}},'],
+    ['instituion', 'instituion = {${1:Instituion}},'],
+    ['journal', 'journal = {${1:Journal}},'],
+    ['key', 'key = {${1:Key}},'],
+    ['month', 'month = {${1:Month}},'],
+    ['note', 'note = {${1:Note}},'],
+    ['number', 'number = {${1:Number}},'],
+    ['organization', 'organization = {${1:Organization}},'],
+    ['pages', 'pages = {${1:Pages}},'],
+    ['publisher', 'publisher = {${1:Publisher}},'],
+    ['school', 'school = {${1:School}},'],
+    ['series', 'series = {${1:Series}},'],
+    ['title', 'title = {${1:Title}},'],
+    ['type', 'type = {${1:Type}},'],
+    ['volume', 'volume = {${1:Volume}},'],
+    ['year', 'year = {${1:Year}},']
+]
+
+biblatex_fields = [
+    ['abstract', 'abstract = {${1:Abstract}},'],
+    ['addendum', 'addendum = {${1:Addendum}},'],
+    ['address', 'address = {${1:Address}},'],
+    ['afterword', 'afterword = {${1:Afterword}},'],
+    ['annotation', 'annotation = {${1:Annotation}},'],
+    ['annotator', 'annotator = {${1:Annotator}},'],
+    ['annote', 'annote = {${1:Annote}},'],
+    ['archiveprefix', 'archiveprefix = {${1:Archiveprefix}},'],
+    ['author', 'author = {${1:Author}},'],
+    ['authortype', 'authortype = {${1:Authortype}},'],
+    ['bookauthor', 'bookauthor = {${1:Bookauthor}},'],
+    ['bookpagination', 'bookpagination = {${1:Bookpagination}},'],
+    ['booksubtitle', 'booksubtitle = {${1:Booksubtitle}},'],
+    ['booktitle', 'booktitle = {${1:Booktitle}},'],
+    ['booktitleaddon', 'booktitleaddon = {${1:Booktitleaddon}},'],
+    ['chapter', 'chapter = {${1:Chapter}},'],
+    ['commentator', 'commentator = {${1:Commentator}},'],
+    ['crossref', 'crossref = {${1:Crossref}},'],
+    ['date', 'date = {${1:Date}},'],
+    ['doi', 'doi = {${1:Doi}},'],
+    ['edition', 'edition = {${1:Edition}},'],
+    ['editor', 'editor = {${1:Editor}},'],
+    ['editora', 'editora = {${1:Editora}},'],
+    ['editoratype', 'editoratype = {${1:Editoratype}},'],
+    ['editorb', 'editorb = {${1:Editorb}},'],
+    ['editorbtype', 'editorbtype = {${1:Editorbtype}},'],
+    ['editorc', 'editorc = {${1:Editorc}},'],
+    ['editorctype', 'editorctype = {${1:Editorctype}},'],
+    ['editortype', 'editortype = {${1:Editortype}},'],
+    ['eid', 'eid = {${1:Eid}},'],
+    ['entryset', 'entryset = {${1:Entryset}},'],
+    ['entrysubtype', 'entrysubtype = {${1:Entrysubtype}},'],
+    ['eprint', 'eprint = {${1:Eprint}},'],
+    ['eprintclass', 'eprintclass = {${1:Eprintclass}},'],
+    ['eprinttype', 'eprinttype = {${1:Eprinttype}},'],
+    ['eventdate', 'eventdate = {${1:Eventdate}},'],
+    ['eventtitle', 'eventtitle = {${1:Eventtitle}},'],
+    ['eventtitleaddon', 'eventtitleaddon = {${1:Eventtitleaddon}},'],
+    ['execute', 'execute = {${1:Execute}},'],
+    ['file', 'file = {${1:File}},'],
+    ['foreward', 'foreward = {${1:Foreward}},'],
+    ['gender', 'gender = {${1:Gender}},'],
+    ['holder', 'holder = {${1:Holder}},'],
+    ['howpublished', 'howpublished = {${1:Howpublished}},'],
+    ['ids', 'ids = {${1:Ids}},'],
+    ['indexsorttitle', 'indexsorttitle = {${1:Indexsorttitle}},'],
+    ['indextitle', 'indextitle = {${1:Indextitle}},'],
+    ['instituion', 'instituion = {${1:Instituion}},'],
+    ['introduction', 'introduction = {${1:Introduction}},'],
+    ['isan', 'isan = {${1:Isan}},'],
+    ['isbn', 'isbn = {${1:Isbn}},'],
+    ['ismn', 'ismn = {${1:Ismn}},'],
+    ['isrn', 'isrn = {${1:Isrn}},'],
+    ['issn', 'issn = {${1:Issn}},'],
+    ['issue', 'issue = {${1:Issue}},'],
+    ['issuesubtitle', 'issuesubtitle = {${1:Issuesubtitle}},'],
+    ['issuetitle', 'issuetitle = {${1:Issuetitle}},'],
+    ['iswc', 'iswc = {${1:Iswc}},'],
+    ['journal', 'journal = {${1:Journal}},'],
+    ['journalsubtitle', 'journalsubtitle = {${1:Journalsubtitle}},'],
+    ['journaltitle', 'journaltitle = {${1:Journaltitle}},'],
+    ['key', 'key = {${1:Key}},'],
+    ['keywords', 'keywords = {${1:Keywords}},'],
+    ['label', 'label = {${1:Label}},'],
+    ['langid', 'langid = {${1:Langid}},'],
+    ['langidopts', 'langidopts = {${1:Langidopts}},'],
+    ['language', 'language = {${1:Language}},'],
+    ['library', 'library = {${1:Library}},'],
+    ['lista', 'lista = {${1:Lista}},'],
+    ['listb', 'listb = {${1:Listb}},'],
+    ['listc', 'listc = {${1:Listc}},'],
+    ['listd', 'listd = {${1:Listd}},'],
+    ['liste', 'liste = {${1:Liste}},'],
+    ['listf', 'listf = {${1:Listf}},'],
+    ['location', 'location = {${1:Location}},'],
+    ['mainsubtitle', 'mainsubtitle = {${1:Mainsubtitle}},'],
+    ['maintitle', 'maintitle = {${1:Maintitle}},'],
+    ['maintitleaddon', 'maintitleaddon = {${1:Maintitleaddon}},'],
+    ['month', 'month = {${1:Month}},'],
+    ['namea', 'namea = {${1:Namea}},'],
+    ['nameaddon', 'nameaddon = {${1:Nameaddon}},'],
+    ['nameatype', 'nameatype = {${1:Nameatype}},'],
+    ['nameb', 'nameb = {${1:Nameb}},'],
+    ['namebtype', 'namebtype = {${1:Namebtype}},'],
+    ['namec', 'namec = {${1:Namec}},'],
+    ['namectype', 'namectype = {${1:Namectype}},'],
+    ['note', 'note = {${1:Note}},'],
+    ['number', 'number = {${1:Number}},'],
+    ['options', 'options = {${1:Options}},'],
+    ['organization', 'organization = {${1:Organization}},'],
+    ['origdate', 'origdate = {${1:Origdate}},'],
+    ['origlanguage', 'origlanguage = {${1:Origlanguage}},'],
+    ['origlocation', 'origlocation = {${1:Origlocation}},'],
+    ['origpublisher', 'origpublisher = {${1:Origpublisher}},'],
+    ['origtitle', 'origtitle = {${1:Origtitle}},'],
+    ['pages', 'pages = {${1:Pages}},'],
+    ['pagetotal', 'pagetotal = {${1:Pagetotal}},'],
+    ['pagination', 'pagination = {${1:Pagination}},'],
+    ['part', 'part = {${1:Part}},'],
+    ['pdf', 'pdf = {${1:Pdf}},'],
+    ['presort', 'presort = {${1:Presort}},'],
+    ['primaryclass', 'primaryclass = {${1:Primaryclass}},'],
+    ['publisher', 'publisher = {${1:Publisher}},'],
+    ['pubstate', 'pubstate = {${1:Pubstate}},'],
+    ['related', 'related = {${1:Related}},'],
+    ['relatedoptions', 'relatedoptions = {${1:Relatedoptions}},'],
+    ['relatedstring', 'relatedstring = {${1:Relatedstring}},'],
+    ['relatedtype', 'relatedtype = {${1:Relatedtype}},'],
+    ['reprinttitle', 'reprinttitle = {${1:Reprinttitle}},'],
+    ['school', 'school = {${1:School}},'],
+    ['series', 'series = {${1:Series}},'],
+    ['shortauthor', 'shortauthor = {${1:Shortauthor}},'],
+    ['shorteditor', 'shorteditor = {${1:Shorteditor}},'],
+    ['shorthand', 'shorthand = {${1:Shorthand}},'],
+    ['shorthandintro', 'shorthandintro = {${1:Shorthandintro}},'],
+    ['shortjournal', 'shortjournal = {${1:Shortjournal}},'],
+    ['shortseries', 'shortseries = {${1:Shortseries}},'],
+    ['shorttitle', 'shorttitle = {${1:Shorttitle}},'],
+    ['sortkey', 'sortkey = {${1:Sortkey}},'],
+    ['sortname', 'sortname = {${1:Sortname}},'],
+    ['sortshorthand', 'sortshorthand = {${1:Sortshorthand}},'],
+    ['sorttitle', 'sorttitle = {${1:Sorttitle}},'],
+    ['sortyear', 'sortyear = {${1:Sortyear}},'],
+    ['subtitle', 'subtitle = {${1:Subtitle}},'],
+    ['title', 'title = {${1:Title}},'],
+    ['titleaddon', 'titleaddon = {${1:Titleaddon}},'],
+    ['translator', 'translator = {${1:Translator}},'],
+    ['type', 'type = {${1:Type}},'],
+    ['url', 'url = {${1:Url}},'],
+    ['urldate', 'urldate = {${1:Urldate}},'],
+    ['usera', 'usera = {${1:Usera}},'],
+    ['userb', 'userb = {${1:Userb}},'],
+    ['userc', 'userc = {${1:Userc}},'],
+    ['userd', 'userd = {${1:Userd}},'],
+    ['usere', 'usere = {${1:Usere}},'],
+    ['userf', 'userf = {${1:Userf}},'],
+    ['venue', 'venue = {${1:Venue}},'],
+    ['verba', 'verba = {${1:Verba}},'],
+    ['verbb', 'verbb = {${1:Verbb}},'],
+    ['verbc', 'verbc = {${1:Verbc}},'],
+    ['version', 'version = {${1:Version}},'],
+    ['volume', 'volume = {${1:Volume}},'],
+    ['volumes', 'volumes = {${1:Volumes}},'],
+    ['xdata', 'xdata = {${1:Xdata}},'],
+    ['xref', 'xref = {${1:Xref}},'],
+    ['year', 'year = {${1:Year}},']
+]
+
+class FieldNameCompletions(sublime_plugin.EventListener):
+    def on_query_completions(self, view, prefix, locations):
+        if not is_bib_buffer(view):
+            return []
+
+        cursor_point = view.sel()[0].b
+
+        # do not autocomplete if the cursor is outside an entry
+        if not view.match_selector(cursor_point, 'meta.entry.braces.bibtex'):
+            return []
+
+        # do not autocomplete when cursor is in the citekey field
+        if view.match_selector(cursor_point, 'entity.name.type.entry-key.bibtex'):
+            return []
+
+        # do not autocomplete if we are already inside a field
+        if view.match_selector(cursor_point, 'meta.key-assignment.bibtex'):
+            return []
+
+        if is_biblatex_buffer(view):
+            return (biblatex_fields, sublime.INHIBIT_WORD_COMPLETIONS)
+
+        else:
+            return (bibtex_fields, sublime.INHIBIT_WORD_COMPLETIONS)

--- a/biblatex_name_completions.py
+++ b/biblatex_name_completions.py
@@ -1,0 +1,896 @@
+# coding=utf-8
+
+from __future__ import print_function
+
+from collections import namedtuple
+
+import re
+import sys
+
+if sys.version_info > (3, 0):
+    strbase = str
+    unicode = str
+else:
+    strbase = basestring
+
+# list of known BibLaTeX fields of the type `list (name)`
+NAME_FIELDS = set((
+    'author',
+    'bookauthor',
+    'commentator',
+    'editor',
+    'editora',
+    'editorb',
+    'editorc',
+    'foreword',
+    'holder',
+    'introduction',
+    'shortauthor',
+    'shorteditor',
+    'translator',
+    'sortname',
+    'namea',
+    'nameb',
+    'namec'
+))
+
+# Regex to recognise if we are in a name field
+#
+# I've tried to simply the comprehensibility of the backwards regexes used by
+# constructing them here
+#
+# VALUE_REGEX is a common suffix to handle the `= {<value> and <value>}` part
+VALUE_REGEX = r'[\s~]*(?P<ENTRIES>(?:dna[\s~]+.+)+)?[\s~]*(?P<OPEN>\{)?(?P<EQUALS>\s*=\s*)?'
+
+ON_NAME_FIELD_REGEX = re.compile(
+    VALUE_REGEX + r'(?:' + r'|'.join((s[::-1] for s in NAME_FIELDS)) + r')' + r'\b',
+    re.IGNORECASE | re.UNICODE
+)
+
+def get_text_to_cursor(view):
+    cursor = view.sel()[0].b
+    current_region = sublime.Region(0, cursor)
+    return view.substr(current_region)
+
+def split_tex_string(string, maxsplit=-1, sep=None):
+    '''
+    A variation of string.split() to support tex strings
+
+    In particular, ignores text in brackets, no matter how deeply nested and
+    defaults to breaking on any space char or ~.
+    '''
+
+    if sep is None:
+        # tilde == non-breaking space
+        sep = r'(?u)[\s~]+'
+    sep_re = re.compile(sep)
+
+    result = []
+
+    # track ignore separators in braces
+    brace_level = 0
+    # calculate once
+    string_len = len(string)
+    word_start = 0
+    splits = 0
+
+    for pos, c in enumerate(string):
+        if c == '{':
+            brace_level += 1
+        elif c == '}':
+            brace_level -= 1
+        elif brace_level == 0 and pos > 0:
+            matcher = sep_re.match(string[pos:])
+            if matcher:
+                sep_len = len(matcher.group())
+                if pos + sep_len <= string_len:
+                    result.append(string[word_start:pos])
+                    word_start = pos + sep_len
+
+                    splits += 1
+                    if splits == maxsplit:
+                        break
+
+    if word_start < string_len:
+        result.append(string[word_start:])
+
+    return [part.strip() for part in result if part]
+
+def tokenize_list(list_str):
+    return split_tex_string(list_str, sep=r'(?iu)[\s~]+and(?:[\s~]+|$)')
+
+# namedtuple so results are a little more comprehensible
+NameResult = namedtuple('NameResult', ['first', 'middle', 'prefix', 'last', 'generation'])
+
+def tokenize_name(name_str):
+    u'''
+    Takes a string representing a name and returns a NameResult breaking that
+    string into its component parts, as defined in the LaTeX book and BibTeXing.
+
+    The supported formats are thus:
+
+    First von Last
+    von Last, First
+    von Last, Jr, First
+
+    We try to follow the rules in BibTeXing relatively strictly, meaning that the
+    first of these formats can result in unexpected results because it is more
+    ambiguous with complex names.
+    '''
+
+    def extract_middle_names(first):
+        return split_tex_string(first, 1)
+
+    def extract_name_prefix(last):
+        names = split_tex_string(last, 1)
+        if len(names) == 1:
+            return names
+
+        result = [names[0]]
+
+        new_names = split_tex_string(names[1], 1)
+        while len(new_names) > 1 and new_names[0].islower():
+            result[0] = u' '.join((result[0], new_names[0]))
+            names = new_names
+            new_names = split_tex_string(names[1], 1)
+
+        result.append(names[1])
+
+        return result
+
+    name_str = name_str.strip()
+
+    parts = split_tex_string(name_str, sep=r',[\s~]*')
+    if len(parts) == 1:
+        # first last
+        # reverse the string so split only selects the right-most instance of the token
+        try:
+            last, first = [part[::-1] for part in split_tex_string(parts[0][::-1], 1)]
+        except ValueError:
+            # we only have a single name
+            return NameResult(
+                parts[0],
+                '', '', '', ''
+            )
+
+        # because of our splitting method, van, von, della, etc. may end up at the end of the first name field
+        first_parts = split_tex_string(first)
+        first_parts_len = len(first_parts)
+        if first_parts_len > 1:
+            lower_name_index = None
+            for i, part in enumerate(first_parts[::-1], 1):
+                if part.islower():
+                    if lower_name_index is None or lower_name_index == i - 1:
+                        lower_name_index = i
+                    else:
+                        break
+            if lower_name_index is not None:
+                last = u' '.join((
+                    u' '.join(first_parts[-lower_name_index:]),
+                    last
+                ))
+                first = u' '.join(first_parts[:-lower_name_index])
+
+        forenames = extract_middle_names(first)
+        lastnames = extract_name_prefix(last)
+        return NameResult(
+            forenames[0],
+            forenames[1] if len(forenames) > 1 else '',
+            lastnames[0] if len(lastnames) > 1 else '',
+            lastnames[1] if len(lastnames) > 1 else lastnames[0],
+            ''
+        )
+    elif len(parts) == 2:
+        # last, first
+        last, first = parts
+
+        # for consistency with spaces being stripped in first last format
+        first = u' '.join((s for s in split_tex_string(first)))
+        last = u' '.join((s for s in split_tex_string(last)))
+
+        forenames = extract_middle_names(first)
+        lastnames = extract_name_prefix(last)
+
+        if len(lastnames) > 1:
+            name_index = 0
+            for part in lastnames:
+                if part.islower():
+                    name_index += 1
+                else:
+                    break
+
+        return NameResult(
+            forenames[0],
+            forenames[1] if len(forenames) > 1 else '',
+            u' '.join(lastnames[:name_index]) if len(lastnames) > 1 else '',
+            u' '.join(lastnames[name_index:]) if len(lastnames) > 1 else lastnames[0],
+            ''
+        )
+    elif len(parts) == 3:
+        # last, generation, first
+        last, generation, first = parts
+        forenames = extract_middle_names(first)
+        lastnames = extract_name_prefix(last)
+        return NameResult(
+            forenames[0],
+            forenames[1] if len(forenames) > 1 else '',
+            lastnames[0] if len(lastnames) > 1 else '',
+            lastnames[1] if len(lastnames) > 1 else lastnames[0],
+            generation
+        )
+    else:
+        raise ValueError(u'Unrecognised name format for "{0}"'.format(name_str))
+
+class Name(object):
+    u'''
+    Represents a BibLaTeX name entry. __str__ will return a name formatted in
+    the preferred format
+    '''
+    def __init__(self, name_str):
+        self.first = None
+        self.middle = None
+        self.prefix = None
+        self.last = None
+        self.generation = None
+
+        self.first, self.middle, self.prefix, self.last, self.generation = \
+            tokenize_name(name_str)
+
+    def __unicode__(self):
+        if not self.last:
+            return self.first
+
+        result = u' '.join((self.prefix, self.last)) if self.prefix else unicode(self.last)
+        if self.generation:
+            result = u', '.join((result, self.generation))
+        result = u', '.join((result, self.first))
+        if self.middle:
+            result = u' '.join((result, self.middle))
+        return result
+
+    __str__ = __unicode__
+    __repr__ = __unicode__
+
+# builds the replacement string depending on the current context of the line
+def _get_replacement(matcher, key):
+    if not matcher:
+        return key
+
+    match = matcher.group(0)
+    if not matcher.group('ENTRIES'):
+        equals = matcher.group('EQUALS')
+
+        return u'{0}{1}{2}'.format(
+            u'' if equals else u'= ' if match.startswith(u' ') else u' = ',
+            u'' if matcher.group('OPEN') else u'{' if not equals or match.startswith(u' ') else u' {',
+            key
+        )
+
+    if matcher.group('ENTRIES').startswith('dna'):
+        if match.startswith(' '):
+            return u'{0}'.format(key)
+        return u' {0}'.format(key)
+    else:
+        return u'{0}{1}'.format(
+            u' ' if matcher.group('ENTRIES').startswith(u' ') != u' ' else u'',
+            key
+        )
+
+NAME_FIELD_REGEX = re.compile(
+    r'(?:^|[\s~]+)(?:' + r'|'.join(NAME_FIELDS) + ')\s*=\s*\{',
+    re.IGNORECASE | re.UNICODE
+)
+
+def get_names_from_view(view):
+    contents = view.substr(sublime.Region(0, view.size()))
+    return get_names(contents)
+
+def get_names(contents):
+    u'''
+    Work-horse function to extract all the names defined in the current bib file.
+    '''
+    names = []
+
+    in_entry = False
+    pos = 0
+    contents_length = len(contents)
+
+    while True:
+        if not in_entry:
+            matcher = re.search(NAME_FIELD_REGEX, contents[pos:])
+            # no more `name =` fields
+            if not matcher:
+                break
+
+            pos += matcher.end()
+            in_entry = True
+        else:
+            chars = []
+
+            bracket_depth = 1
+            for c in contents[pos:]:
+                if c == '}':
+                    bracket_depth -= 1
+
+                if bracket_depth == 0:
+                    break
+
+                if c == '{':
+                    bracket_depth += 1
+
+                chars.append(c)
+
+            names.extend([unicode(Name(s)) for s in tokenize_list(u''.join(chars))])
+
+            pos += len(chars)
+            if pos >= contents_length:
+                break
+            in_entry = False
+
+    return sorted(set(names))
+
+# isolate sublime-dependent code to allow testing with unittest
+try:
+    import sublime
+    import sublime_plugin
+
+    try:
+        from latextools_utils import is_bib_buffer
+    except ImportError:
+        from .latextools_utils import is_bib_buffer
+
+    class BiblatexNameCompletions(sublime_plugin.EventListener):
+        def on_query_completions(self, view, prefix, locations):
+            if not is_bib_buffer(view):
+                return []
+
+            current_line = get_text_to_cursor(view)[::-1]
+
+            if current_line.startswith(prefix[::-1]):
+                current_line = current_line[len(prefix):]
+
+            matcher = ON_NAME_FIELD_REGEX.match(current_line)
+            if matcher:
+                return ([(name, _get_replacement(matcher, name))
+                        for name in get_names_from_view(view)],
+                        sublime.INHIBIT_WORD_COMPLETIONS |
+                        sublime.INHIBIT_EXPLICIT_COMPLETIONS)
+
+            return []
+except ImportError:
+    # Assume we are not in sublime
+    import unittest
+
+    class TestTokenizeList(unittest.TestCase):
+        def test_simple(self):
+            self.assertEqual(
+                tokenize_list(u'Chemicals and Entrails'),
+                [u'Chemicals', u'Entrails']
+            )
+
+        def test_nbsp(self):
+            self.assertEqual(
+                tokenize_list(u'Chemicals~and~Entrails'),
+                [u'Chemicals', u'Entrails']
+            )
+
+        def test_values_wrapped_in_brackets(self):
+            self.assertEqual(
+                tokenize_list(u'{Chemicals and Entrails}'),
+                [u'{Chemicals and Entrails}']
+            )
+
+        def test_and_wrapped_in_brackets(self):
+            self.assertEqual(
+                tokenize_list(u'Chemicals {and} Entrails'),
+                [u'Chemicals {and} Entrails']
+            )
+
+        def test_and_wrapped_in_brackets_with_whitespace(self):
+            self.assertEqual(
+                tokenize_list(u'Chemicals { and } Entrails'),
+                [u'Chemicals { and } Entrails']
+            )
+
+        def test_partial_list(self):
+            self.assertEqual(
+                tokenize_list(u'Chemicals and'),
+                [u'Chemicals']
+            )
+
+    class TestTokenizeName(unittest.TestCase):
+        def test_simple(self):
+            self.assertEqual(
+                tokenize_name(u'Coddlington, Simon'),
+                NameResult(first='Simon', middle='', prefix='', last='Coddlington', generation='')
+            )
+
+        def test_with_nbsp(self):
+            self.assertEqual(
+                tokenize_name(u'Coddlington,~Simon'),
+                NameResult(first='Simon', middle='', prefix='', last='Coddlington', generation='')
+            )
+
+        def test_without_comma(self):
+            self.assertEqual(
+                tokenize_name(u'Simon Coddlington'),
+                NameResult(first='Simon', middle='', prefix='', last='Coddlington', generation='')
+            )
+
+        def test_without_comma_with_nbsp(self):
+            self.assertEqual(
+                tokenize_name(u'Simon~Coddlington'),
+                NameResult(first='Simon', middle='', prefix='', last='Coddlington', generation='')
+            )
+
+        def test_middle_name(self):
+            self.assertEqual(
+                tokenize_name(u'Coddlington, Simon P.'),
+                NameResult(first='Simon', middle='P.', prefix='', last='Coddlington', generation='')
+            )
+
+        def test_middle_name_without_comma(self):
+            self.assertEqual(
+                tokenize_name(u'Simon P. Coddlington'),
+                NameResult(first='Simon', middle='P.', prefix='', last='Coddlington', generation='')
+            )
+
+        def test_middle_name_with_nbsp(self):
+            self.assertEqual(
+                tokenize_name(u'Coddlington, Simon~P.'),
+                NameResult(first='Simon', middle='P.', prefix='', last='Coddlington', generation='')
+            )
+
+        def test_multiple_middle_names(self):
+            self.assertEqual(
+                tokenize_name(u'Quine, Willard van Orman'),
+                NameResult(first='Willard', middle='van Orman', prefix='', last='Quine', generation='')
+            )
+
+        def test_multiple_middle_names_without_comma(self):
+            self.assertEqual(
+                tokenize_name(u'Willard van Orman Quine'),
+                NameResult(first='Willard', middle='', prefix='van', last='Orman Quine', generation='')
+            )
+
+        def test_single_name_only(self):
+            self.assertEqual(
+                tokenize_name(u'Augustine'),
+                NameResult(first='Augustine', middle='', prefix='', last='', generation='')
+            )
+
+        def test_generation(self):
+            # NB as with Bib(La)TeX, generations are only supported using commas
+            self.assertEqual(
+                tokenize_name(u'Jones, Jr, James Earl'),
+                NameResult(first='James', middle='Earl', prefix='', last='Jones', generation='Jr')
+            )
+
+        def test_hyphenated_first_name(self):
+            self.assertEqual(
+                tokenize_name(u'Sartre, Jean-Paul'),
+                NameResult(first='Jean-Paul', middle='', prefix='', last='Sartre', generation='')
+            )
+
+        def test_hyphenated_surname(self):
+            self.assertEqual(
+                tokenize_name(u'Jean Charles-Gabriel'),
+                NameResult(first='Jean', middle='', prefix='', last='Charles-Gabriel', generation='')
+            )
+
+        def test_prefixed_surname(self):
+            self.assertEqual(
+                tokenize_name(u'van Houten, James'),
+                NameResult(first='James', middle='', prefix='van', last='Houten', generation='')
+            )
+
+        def test_prefixed_surname_without_comma(self):
+            self.assertEqual(
+                tokenize_name(u'James van Houten'),
+                NameResult(first='James', middle='', prefix='van', last='Houten', generation='')
+            )
+
+        def test_long_prefixed_surname(self):
+            self.assertEqual(
+                tokenize_name(u'van auf der Rissen, Gloria'),
+                NameResult(first='Gloria', middle='', prefix='van auf der', last='Rissen', generation='')
+            )
+
+        def test_long_prefixed_surname_without_comma(self):
+            self.assertEqual(
+                tokenize_name(u'Gloria van auf der Rissen'),
+                NameResult(first='Gloria', middle='', prefix='van auf der', last='Rissen', generation='')
+            )
+
+        def test_compound_last_name(self):
+            self.assertEqual(
+                tokenize_name(u'Pedro {Almodóvar Caballero}'),
+                NameResult(first='Pedro', middle='', prefix='', last=u'{Almodóvar Caballero}', generation='')
+            )
+
+        def test_compound_last_name_with_comma(self):
+            self.assertEqual(
+                tokenize_name(u'{Almodóvar Caballero}, Pedro'),
+                NameResult(first='Pedro', middle='', prefix='', last=u'{Almodóvar Caballero}', generation='')
+            )
+
+        def test_compound_last_name_with_comma_without_brackets(self):
+            self.assertEqual(
+                tokenize_name(u'Almodóvar Caballero, Pedro'),
+                NameResult(first='Pedro', middle='', prefix='', last=u'Almodóvar Caballero', generation='')
+            )
+
+        def test_complex_name(self):
+            self.assertEqual(
+                tokenize_name(u'de la Vall{\\\'e}e~Poussin, Jean Charles~Gabriel'),
+                NameResult(first='Jean', middle='Charles Gabriel', prefix='de la', last="Vall{\\'e}e Poussin", generation='')
+            )
+
+        def test_complex_name_without_comma(self):
+            self.assertEqual(
+                tokenize_name(u'Jean Charles~Gabriel de la Vall{\\\'e}e~Poussin'),
+                NameResult(first='Jean', middle='Charles Gabriel', prefix='de la', last="Vall{\\'e}e Poussin", generation='')
+            )
+
+        def test_complex_name_with_unicode(self):
+            self.assertEqual(
+                tokenize_name(u'Jean Charles~Gabriel de la Vallée~Poussin'),
+                NameResult(first='Jean', middle='Charles Gabriel', prefix='de la', last=u'Vallée Poussin', generation='')
+            )
+
+        def test_another_complex_name(self):
+            self.assertEqual(
+                tokenize_name(u'von Berlichingen zu Hornberg, Johann Gottfried'),
+                NameResult(first='Johann', middle='Gottfried', prefix='von', last='Berlichingen zu Hornberg', generation='')
+            )
+
+        def test_name_with_brackets(self):
+            self.assertEqual(
+                tokenize_name(u'{Robert and Sons, Inc.}'),
+                NameResult(first='{Robert and Sons, Inc.}', middle='', prefix='', last='', generation='')
+            )
+
+    class TestNameClass(unittest.TestCase):
+        def test_simple(self):
+            self.assertEqual(
+                str(Name('Simon~Coddlington')),
+                'Coddlington, Simon'
+            )
+
+        def test_hyphenation(self):
+            self.assertEqual(
+                str(Name('Jean-Paul Sartre')),
+                'Sartre, Jean-Paul'
+            )
+
+        def test_prefixed_surname(self):
+            self.assertEqual(
+                str(Name('Gloria van auf der Rissen')),
+                'van auf der Rissen, Gloria'
+            )
+
+        def test_complex_name(self):
+            self.assertEqual(
+                str(Name('de la Vall{\\\'e}e~Poussin, Jean Charles~Gabriel')),
+                "de la Vall{\\'e}e Poussin, Jean Charles Gabriel"
+            )
+
+    class TestGetNames(unittest.TestCase):
+        def test_simple(self):
+            self.assertEqual(
+                get_names(u"""
+                    @article {
+                        title = {A Long Disquisition on Nothing},
+                        author = {Coddlington, Simon},
+                        date = {2014-08-01}
+                    }"""),
+                [u'Coddlington, Simon']
+            )
+
+        def test_editor(self):
+            self.assertEqual(
+                get_names(u"""
+                    @article {
+                        title = {A Long Disquisition on Nothing},
+                        editor = {Coddlington, Simon},
+                        date = {2014-08-01}
+                    }"""),
+                [u'Coddlington, Simon']
+            )
+
+        def test_translator(self):
+            self.assertEqual(
+                get_names(u"""
+                    @article {
+                        title = {A Long Disquisition on Nothing},
+                        translator = {Coddlington, Simon},
+                        date = {2014-08-01}
+                    }"""),
+                [u'Coddlington, Simon']
+            )
+
+        def test_newline_before_value(self):
+            self.assertEqual(
+                get_names(u"""
+                    @article {
+                        title = {A Long Disquisition on Nothing},
+                        author = {
+                            Coddlington, Simon},
+                        date = {2014-08-01}
+                    }"""),
+                [u'Coddlington, Simon']
+            )
+
+        def test_newline_after_value(self):
+            self.assertEqual(
+                get_names(u"""
+                    @article {
+                        title = {A Long Disquisition on Nothing},
+                        author = {Coddlington, Simon
+                            },
+                        date = {2014-08-01}
+                    }"""),
+                [u'Coddlington, Simon']
+            )
+
+        def test_newlines_in_value(self):
+            self.assertEqual(
+                get_names(u"""
+                    @article {
+                        title = {A Long Disquisition on Nothing},
+                        author = {
+                            Coddlington, Simon
+                        },
+                        date = {2014-08-01}
+                    }"""),
+                [u'Coddlington, Simon']
+            )
+
+        def test_two_authors(self):
+            self.assertEqual(
+                get_names(u"""
+                    @article {
+                        title = {A Long Disquisition on Nothing},
+                        author = {Coddlington, Simon and Gary Winchester},
+                        date = {2014-08-01}
+                    }"""),
+                [u'Coddlington, Simon', u'Winchester, Gary']
+            )
+
+        def test_two_authors_newline_before_and(self):
+            self.assertEqual(
+                get_names(u"""
+                    @article {
+                        title = {A Long Disquisition on Nothing},
+                        author = {Coddlington, Simon
+                            and Gary Winchester},
+                        date = {2014-08-01}
+                    }"""),
+                [u'Coddlington, Simon', u'Winchester, Gary']
+            )
+
+        def test_two_authors_newline_after_and(self):
+            self.assertEqual(
+                get_names(u"""
+                    @article {
+                        title = {A Long Disquisition on Nothing},
+                        author = {Coddlington, Simon and
+                            Gary Winchester},
+                        date = {2014-08-01}
+                    }"""),
+                [u'Coddlington, Simon', u'Winchester, Gary']
+            )
+
+        def test_three_authors(self):
+            self.assertEqual(
+                get_names(u"""
+                    @article {
+                        title = {A Long Disquisition on Nothing},
+                        author = {Coddlington, Simon and Gary Winchester and Calhoun, Buck},
+                        date = {2014-08-01}
+                    }"""),
+                [u'Calhoun, Buck', u'Coddlington, Simon', u'Winchester, Gary']
+            )
+
+        def test_two_name_fields(self):
+            self.assertEqual(
+                get_names(u"""
+                    @article {
+                        title = {A Long Disquisition on Nothing},
+                        author = {Coddlington, Simon},
+                        editor = {Winchester, Gary},
+                        date = {2014-08-01}
+                    }"""),
+                [u'Coddlington, Simon', u'Winchester, Gary']
+            )
+
+        def test_three_name_fields(self):
+            self.assertEqual(
+                get_names(u"""
+                    @article {
+                        title = {A Long Disquisition on Nothing},
+                        author = {Coddlington, Simon},
+                        editor = {Winchester, Gary},
+                        translator = {Calhoun, Buck},
+                        date = {2014-08-01}
+                    }"""),
+                [u'Calhoun, Buck', u'Coddlington, Simon', u'Winchester, Gary']
+            )
+
+        def test_two_name_fields_same_person(self):
+            self.assertEqual(
+                get_names(u"""
+                    @article {
+                        title = {A Long Disquisition on Nothing},
+                        author = {Coddlington, Simon},
+                        editor = {Coddlington, Simon},
+                        date = {2014-08-01}
+                    }"""),
+                [u'Coddlington, Simon']
+            )
+
+        def test_multiple_entries(self):
+            self.assertEqual(
+                get_names(u"""
+                    @article {
+                        title = {A Long Disquisition on Nothing},
+                        author = {Coddlington, Simon},
+                        date = {2014-08-01}
+                    }
+
+                    @book{
+                        title = {An Even Longer Disquisition on Nothingness and Other Thoughts},
+                        author = {Winchester, Gary},
+                        date = {2015-06-07}
+                    }"""),
+                [u'Coddlington, Simon', u'Winchester, Gary']
+            )
+
+        def test_paritially_complete_entry(self):
+            self.assertEqual(
+                get_names(u"""
+                    @article {
+                        title = {A Long Disquisition on Nothing},
+                        author = {Coddlington, Simon and"""),
+                [u'Coddlington, Simon']
+            )
+
+    class TestFieldMatchingRegex(unittest.TestCase):
+        def test_simple(self):
+            self.assertIsNotNone(
+                ON_NAME_FIELD_REGEX.match('author = {'[::-1])
+            )
+
+        def test_without_spaces(self):
+            self.assertIsNotNone(
+                ON_NAME_FIELD_REGEX.match('author={'[::-1])
+            )
+
+        def test_without_bracket(self):
+            self.assertIsNotNone(
+                ON_NAME_FIELD_REGEX.match('author = '[::-1])
+            )
+
+        def test_with_space_after_bracket(self):
+            self.assertIsNotNone(
+                ON_NAME_FIELD_REGEX.match('author = { '[::-1])
+            )
+
+        def test_alternative_field(self):
+            self.assertIsNotNone(
+                ON_NAME_FIELD_REGEX.match('editor = {'[::-1])
+            )
+
+        def test_doesnt_match_empty_field(self):
+            self.assertIsNone(
+                ON_NAME_FIELD_REGEX.match('author = {}'[::-1])
+            )
+
+        def test_doesnt_match_completed_field(self):
+            self.assertIsNone(
+                ON_NAME_FIELD_REGEX.match('author = {Coddlington, Simon}'[::-1])
+            )
+
+        def test_matches_partial_field(self):
+            self.assertIsNotNone(
+                ON_NAME_FIELD_REGEX.match('author = {Coddlington, Simon and'[::-1])
+            )
+
+        def test_matches_partial_field_two_names(self):
+            self.assertIsNotNone(
+                ON_NAME_FIELD_REGEX.match('author = {Coddlington, Simon and Gary Winchester and'[::-1])
+            )
+
+        def test_matches_partial_field_three_names(self):
+            self.assertIsNotNone(
+                ON_NAME_FIELD_REGEX.match('author = {Coddlington, Simon and Gary Winchester and Calhoun, Buck and'[::-1])
+            )
+
+    class TestGetReplacement(unittest.TestCase):
+        def test_simple(self):
+            self.assertEqual(
+                _get_replacement(
+                    ON_NAME_FIELD_REGEX.match('author = {'[::-1]),
+                    'Coddlington, Simon'
+                ),
+                'Coddlington, Simon'
+            )
+
+        def test_without_spaces(self):
+            self.assertEqual(
+                _get_replacement(
+                    ON_NAME_FIELD_REGEX.match('author={'[::-1]),
+                    'Coddlington, Simon'
+                ),
+                'Coddlington, Simon'
+            )
+
+        def test_without_bracket(self):
+            self.assertEqual(
+                _get_replacement(
+                    ON_NAME_FIELD_REGEX.match('author = '[::-1]),
+                    'Coddlington, Simon'
+                ),
+                '{Coddlington, Simon'
+            )
+
+        def test_without_bracket_or_preceding_space(self):
+            self.assertEqual(
+                _get_replacement(
+                    ON_NAME_FIELD_REGEX.match('author ='[::-1]),
+                    'Coddlington, Simon'
+                ),
+                ' {Coddlington, Simon'
+            )
+
+        def test_without_equals(self):
+            self.assertEqual(
+                _get_replacement(
+                    ON_NAME_FIELD_REGEX.match('author '[::-1]),
+                    'Coddlington, Simon'
+                ),
+                '= {Coddlington, Simon'
+            )
+
+        def test_without_equals_or_space(self):
+            self.assertEqual(
+                _get_replacement(
+                    ON_NAME_FIELD_REGEX.match('author'[::-1]),
+                    'Coddlington, Simon'
+                ),
+                ' = {Coddlington, Simon'
+            )
+
+        def test_with_existing_entry(self):
+            self.assertEqual(
+                _get_replacement(
+                    ON_NAME_FIELD_REGEX.match('author = {Coddlington, Simon and '[::-1]),
+                    'Coddlington, Simon'
+                ),
+                'Coddlington, Simon'
+            )
+
+        def test_with_existing_entry_without_space(self):
+            self.assertEqual(
+                _get_replacement(
+                    ON_NAME_FIELD_REGEX.match('author = {Coddlington, Simon and'[::-1]),
+                    'Coddlington, Simon'
+                ),
+                ' Coddlington, Simon'
+            )
+
+    # monkey patch unittest in Python 2.6
+    if sys.version_info < (2, 7) and sys.version_info >= (2, 6):
+        def assertIsNone(self, obj, msg=None):
+            if obj is not None:
+                raise self.failureException(msg or '%r is not None' % (obj,))
+
+        def assertIsNotNone(self, obj, msg=None):
+            if obj is None:
+                raise self.failureException(msg or '%r is None' % (obj,))
+
+        unittest.TestCase.assertIsNone = assertIsNone
+        unittest.TestCase.assertIsNotNone = assertIsNotNone
+
+if __name__ == '__main__':
+    unittest.main()

--- a/biblatex_snippet_completions.py
+++ b/biblatex_snippet_completions.py
@@ -1,0 +1,72 @@
+# coding=utf-8
+
+# This is here precisely so snippet completion doesn't interfere
+# with other autocompletions.
+
+from __future__ import print_function
+
+import sublime
+import sublime_plugin
+
+import os
+import traceback
+
+from xml.etree import ElementTree
+
+try:
+    from latextools_utils import is_bib_buffer, is_biblatex_buffer
+except ImportError:
+    from .latextools_utils import is_bib_buffer, is_biblatex_buffer
+
+__dir__ = os.path.dirname(__file__)
+if __dir__ == '.':
+    __dir__ = os.path.join(sublime.packages_path(), 'LaTeXTools')
+
+def _get_completions(ext):
+    completions = []
+
+    for root, dirs, files in os.walk(
+            os.path.join(__dir__, 'snippets')):
+        files = [f for f in files if f.endswith(ext)]
+
+        for f in files:
+            doc = ElementTree.parse(os.path.join(root, f))
+            try:
+                completions.append(
+                    [
+                        "{0}\t{1}".format(
+                            doc.find('tabTrigger').text.strip(),
+                            doc.find('description').text.strip()
+                        ),
+                        doc.find('content').text.strip()
+                    ]
+                )
+            except:
+                print('Error occurred when trying to load snippet from {0}'.format(
+                    os.path.join(root, f)
+                ))
+
+                traceback.print_exc()
+
+    return completions
+
+def get_biblatex_completions():
+    return _get_completions('.biblatex-snippet')
+
+def get_bibtex_completions():
+    return _get_completions('.bibtex-snippet')
+
+class SnippetCompletions(sublime_plugin.EventListener):
+    def on_query_completions(self, view, prefix, locations):
+        if not is_bib_buffer(view):
+            return []
+
+        # do not return completions if the cursor is inside an entry
+        if view.match_selector(view.sel()[0].b, 'meta.entry.braces.bibtex'):
+            return []
+
+        if is_biblatex_buffer(view):
+            return (get_biblatex_completions(), sublime.INHIBIT_WORD_COMPLETIONS)
+
+        else:
+            return (get_bibtex_completions(), sublime.INHIBIT_WORD_COMPLETIONS)

--- a/biblatex_syntax_listener.py
+++ b/biblatex_syntax_listener.py
@@ -1,0 +1,34 @@
+import sublime_plugin
+
+try:
+    from latextools_utils import get_setting
+except ImportError:
+    from .latextools_utils import get_setting
+
+BIBLATEX_SYNTAX = 'Packages/LaTeXTools/BibLaTeX.tmLanguage'
+
+
+# simple listener to default bib files to BibLaTeX syntax if the
+# `use_biblatex` configuration option has been set in either the user's
+# LaTeXTools.sublime-settings or the current project settings
+class BibLaTeXSyntaxListener(sublime_plugin.EventListener):
+    def on_load(self, view):
+        self.detect_and_apply_syntax(view)
+
+    def on_post_save(self, view):
+        self.detect_and_apply_syntax(view)
+
+    def detect_and_apply_syntax(self, view):
+        if view.is_scratch() or not view.file_name():
+            return
+
+        current_syntax = view.settings().get('syntax')
+        if current_syntax == BIBLATEX_SYNTAX:
+            return
+
+        if not get_setting('use_biblatex', False):
+            return
+
+        file_name = view.file_name()
+        if file_name.endswith('bib'):
+            view.set_syntax_file(BIBLATEX_SYNTAX)

--- a/latextools_utils/__init__.py
+++ b/latextools_utils/__init__.py
@@ -1,5 +1,13 @@
 from __future__ import print_function
 
+
+def is_bib_buffer(view, point=0):
+    return view.match_selector(point, 'text.bibtex') or is_biblatex_buffer(view, point)
+
+
+def is_biblatex_buffer(view, point=0):
+    return view.match_selector(point, 'text.biblatex')
+
 try:
     from latextools_utils.settings import get_setting
     from latextools_utils.tex_directives import parse_tex_directives

--- a/snippets/article.biblatex-snippet
+++ b/snippets/article.biblatex-snippet
@@ -1,0 +1,14 @@
+<snippet>
+    <content><![CDATA[
+% Optional fields: translator, annotator, commentator, subtitle, titleaddon, editor, editora, editorb, editorc, journalsubtitle, issuetitle, issuesubtitle, language, origlanguage, series, volume, number, eid, issue, month, pages, version, note, issn, addendum, pubstate, doi, eprint, eprintclass, eprinttype, url, urldate
+@article{${1:Key},
+    author = {${2:Author}},
+    title = {${3:Title}},
+    journaltitle = {${4:Journaltitle}},
+    year = {${5:Year}}
+}
+]]></content>
+    <tabTrigger>article</tabTrigger>
+    <description>BibLaTeX Article</description>
+    <scope>text.biblatex</scope>
+</snippet>

--- a/snippets/article.bibtex-snippet
+++ b/snippets/article.bibtex-snippet
@@ -1,0 +1,14 @@
+<snippet>
+	<content><![CDATA[
+% BibTeX Optional fields: volume, number, pages, month, note
+@ARTICLE{${1:Key},
+	author = {${2:Author}},
+	title = {${3:Title}},
+	journal = {${4:Journal}},
+	year = {${5:Year}}
+}
+]]></content>
+	<tabTrigger>article</tabTrigger>
+	<description>BibTeX Article</description>
+	<scope>text.bibtex</scope>
+</snippet>

--- a/snippets/artwork.biblatex-snippet
+++ b/snippets/artwork.biblatex-snippet
@@ -1,0 +1,11 @@
+<snippet>
+	<content><![CDATA[
+% Optional fields: author, title, subtitle, titleaddon, language, howpublished, type, version, note, organization, location, date, month, year, addendum, pubstate, doi, eprint, eprintclass, eprinttype, url, urldate
+@artwork{${1:Key},
+    ${2}
+}
+]]></content>
+	<tabTrigger>artwork</tabTrigger>
+	<description>BibLaTeX Artwork</description>
+	<scope>text.biblatex</scope>
+</snippet>

--- a/snippets/audio.biblatex-snippet
+++ b/snippets/audio.biblatex-snippet
@@ -1,0 +1,11 @@
+<snippet>
+	<content><![CDATA[
+% Optional fields: author, title, subtitle, titleaddon, language, howpublished, type, version, note, organization, location, date, month, year, addendum, pubstate, doi, eprint, eprintclass, eprinttype, url, urldate
+@audio{${1:Key},
+    ${2}
+}
+]]></content>
+	<tabTrigger>audio</tabTrigger>
+	<description>BibLaTeX Audio</description>
+	<scope>text.biblatex</scope>
+</snippet>

--- a/snippets/book.biblatex-snippet
+++ b/snippets/book.biblatex-snippet
@@ -1,0 +1,13 @@
+<snippet>
+	<content><![CDATA[
+% Optional fields: volumeditor, editora, editorb, editorc, translator, annotator, commentator, introduction, foreword, afterword, subtitle, titleaddon, maintitle, mainsubtitle, maintitleaddon, language, origlanguage, volume, part, edition, volumes, series, number, note, publisher, location, isbn, chapter, pages, pagetotal, addendum, pubstate, doi, eprint, eprintclass, eprinttype, url, urldate
+@book{${1:Key},
+	author = {${2:Author/Editor}},
+	title = {${3:Title}},
+	year = {${4:Year}}
+}
+]]></content>
+	<tabTrigger>book</tabTrigger>
+	<description>BibLaTeX Book</description>
+	<scope>text.biblatex</scope>
+</snippet>

--- a/snippets/book.bibtex-snippet
+++ b/snippets/book.bibtex-snippet
@@ -1,0 +1,14 @@
+<snippet>
+	<content><![CDATA[
+% Optional fields: volume/number, series, address, edition, month, note
+@BOOK{${1:Key},
+	author = {${2:Author/Editor}},
+	title = {${3:Title}},
+	publisher = {${4:Publisher}},
+	year = {${5:Year}}
+}
+]]></content>
+	<tabTrigger>book</tabTrigger>
+	<description>BibTeX Book</description>
+	<scope>text.bibtex</scope>
+</snippet>

--- a/snippets/bookinbook.biblatex-snippet
+++ b/snippets/bookinbook.biblatex-snippet
@@ -1,0 +1,14 @@
+<snippet>
+	<content><![CDATA[
+% Optional fields: bookauthor, editor, editora, editorb, editorc, translator, annotator, commentator, introduction, foreword, afterword, subtitle, titleaddon, maintitle, mainsubtitle, maintitleaddon, booksubtitle, booktitleaddon, language, origlanguage, volume, part, edition, volumes, series, number, note, publisher, location, isbn, chapter, pages, addendum, pubstate, doi, eprint, eprintclass, eprinttype, url, urldate
+@bookinbook{${1:Key},
+	author = {${2:Author/Editor}},
+	title = {${3:Title}},
+	booktitle = {${4:Booktitle}}
+	year = {${5:Year}}
+}
+]]></content>
+	<tabTrigger>bookinbook</tabTrigger>
+	<description>BibLaTeX Bookinbook</description>
+	<scope>text.biblatex</scope>
+</snippet>

--- a/snippets/booklet.biblatex-snippet
+++ b/snippets/booklet.biblatex-snippet
@@ -1,0 +1,13 @@
+<snippet>
+	<content><![CDATA[
+% Optional fields:subtitle, titleaddon, language, howpublished, type, note, location, chapter, pages, pagetotal, addendum, pubstate, doi, eprint, eprintclass, eprinttype, url, urldate
+@booklet{${1:Key},
+	author = {${2:Author/Editor}},
+    title = {${3:Title}},
+    year = {${4:Year}}
+}
+]]></content>
+	<tabTrigger>booklet</tabTrigger>
+	<description>BibLaTeX Booklet</description>
+	<scope>text.biblatex</scope>
+</snippet>

--- a/snippets/booklet.bibtex-snippet
+++ b/snippets/booklet.bibtex-snippet
@@ -1,0 +1,11 @@
+<snippet>
+	<content><![CDATA[
+% Optional fields: author, howpublished, address, month, year, note
+@BOOKLET{${1:Key},
+	title = {${2:Title}}
+}
+]]></content>
+	<tabTrigger>booklet</tabTrigger>
+	<description>BibTeX Booklet</description>
+	<scope>text.bibtex</scope>
+</snippet>

--- a/snippets/collection.biblatex-snippet
+++ b/snippets/collection.biblatex-snippet
@@ -1,0 +1,13 @@
+<snippet>
+	<content><![CDATA[
+% Optional fields: editora, editorb, editorc, translator, annotator, commentator, introduction, foreword, afterword, subtitle, titleaddon, maintitle, mainsubtitle, maintitleaddon, language, origlanguage, volume, part, edition, volumes, series, number, note, publisher, location, isbn, chapter, pages, pagetotal, addendum, pubstate, doi, eprint, eprintclass, eprinttype, url, urldate
+@collection{${1:Key},
+	editor = {${2:Editor}},
+	title = {${3:Title}},
+	year = {${4:Year}}
+}
+]]></content>
+	<tabTrigger>collection</tabTrigger>
+	<description>BibLaTeX Collection</description>
+	<scope>text.biblatex</scope>
+</snippet>

--- a/snippets/conference.biblatex-snippet
+++ b/snippets/conference.biblatex-snippet
@@ -1,0 +1,14 @@
+<snippet>
+	<content><![CDATA[
+% Optional fields: editor, subtitle, titleaddon, maintitle, mainsubtitle, maintitleaddon, booksubtitle, booktitleaddon, eventtitle, eventtitleaddon, eventdate, venue, language, volume, part, volumes, series, number, note, organization, publisher, location, month, isbn, chapter, pages, addendum, pubstate, doi, eprint, eprintclass, eprinttype, url, urldate
+@conference{${1:Key},
+	author = {${2:Author/Editor}},
+	title = {${3:Title}},
+	booktitle = {${4:Booktitle}},
+	year = {${5:Year}}
+}
+]]></content>
+	<tabTrigger>conference</tabTrigger>
+	<description>BibLaTeX Conference</description>
+	<scope>text.biblatex</scope>
+</snippet>

--- a/snippets/conference.bibtex-snippet
+++ b/snippets/conference.bibtex-snippet
@@ -1,0 +1,14 @@
+<snippet>
+	<content><![CDATA[
+% Optional fields: editor, volume/number, series, pages, address, month, organization, publisher, note
+@CONFERENCE{${1:Key},
+	author = {${2:Author/Editor}},
+	title = {${3:Title}},
+	booktitle = {${4:Booktitle}},
+	year = {${5:Year}}
+}
+]]></content>
+	<tabTrigger>conference</tabTrigger>
+	<description>BibTeX Conference</description>
+	<scope>text.bibtex</scope>
+</snippet>

--- a/snippets/electronic.biblatex-snippet
+++ b/snippets/electronic.biblatex-snippet
@@ -1,0 +1,14 @@
+<snippet>
+	<content><![CDATA[
+% Optional fields: subtitle, titleaddon, language, version, note,
+organization, date, month, year, addendum, pubstate, urldate
+@electronic{${1:Key},
+	author = {${2:Author/Editor}},
+    title = {${3:Title}},
+    year = {${4:Year}}
+}
+]]></content>
+	<tabTrigger>electronic</tabTrigger>
+	<description>BibLaTeX Electronic</description>
+	<scope>text.biblatex</scope>
+</snippet>

--- a/snippets/inbook.biblatex-snippet
+++ b/snippets/inbook.biblatex-snippet
@@ -1,0 +1,14 @@
+<snippet>
+	<content><![CDATA[
+% Optional fields: bookauthor, editor, editora, editorb, editorc, translator, annotator, commentator, introduction, foreword, afterword, subtitle, titleaddon, maintitle, mainsubtitle, maintitleaddon, booksubtitle, booktitleaddon, language, origlanguage, volume, part, edition, volumes, series, number, note, publisher, location, isbn, chapter, pages, addendum, pubstate, doi, eprint, eprintclass, eprinttype, url, urldate
+@inbook{${1:Key},
+	author = {${2:Author/Editor}},
+	title = {${3:Title}},
+	booktitle = {${4:Booktitle}},
+	year = {${5:Year}}
+}
+]]></content>
+	<tabTrigger>inbook</tabTrigger>
+	<description>BibLaTeX Inbook</description>
+	<scope>text.biblatex</scope>
+</snippet>

--- a/snippets/inbook.bibtex-snippet
+++ b/snippets/inbook.bibtex-snippet
@@ -1,0 +1,15 @@
+<snippet>
+	<content><![CDATA[
+% Optional fields: volume/number, series, type, address, edition, month, note
+@INBOOK{${1:Key},
+	author = {${2:Author/Editor}},
+	title = {${3:Title}},
+	chapter = {${4:Chapter/Pages}}
+	publisher = {${5:Publisher}},
+	year = {${6:Year}}
+}
+]]></content>
+	<tabTrigger>inbook</tabTrigger>
+	<description>BibTeX Inbook</description>
+	<scope>text.bibtex</scope>
+</snippet>

--- a/snippets/incollection.biblatex-snippet
+++ b/snippets/incollection.biblatex-snippet
@@ -1,0 +1,14 @@
+<snippet>
+	<content><![CDATA[
+% Optional fields: editor, editora, editorb, editorc, translator, annotator, commentator, introduction, foreword, afterword, subtitle, titleaddon, maintitle, mainsubtitle, maintitleaddon, booksubtitle, booktitleaddon, language, origlanguage, volume, part, edition, volumes, series, number, note, publisher, location, isbn, chapter, pages, addendum, pubstate, doi, eprint, eprintclass, eprinttype, url, urldate
+@incollection{${1:Key},
+	author = {${2:Author/Editor}},
+	title = {${3:Title}},
+	booktitle = {${4:Booktitle}}
+	year = {${5:Year}}
+}
+]]></content>
+	<tabTrigger>incollection</tabTrigger>
+	<description>BibLaTeX Incollection</description>
+	<scope>text.biblatex</scope>
+</snippet>

--- a/snippets/incollection.bibtex-snippet
+++ b/snippets/incollection.bibtex-snippet
@@ -1,0 +1,15 @@
+<snippet>
+	<content><![CDATA[
+% Optional fields: editor, volume/number, series, type, chapter, pages, address, edition, month, note
+@incollection{${1:Key},
+	author = {${2:Author/Editor}},
+	title = {${3:Title}},
+	booktitle = {${4:Booktitle}}
+	publisher = {${5:Publisher}},
+	year = {${6:Year}}
+}
+]]></content>
+	<tabTrigger>incollection</tabTrigger>
+	<description>BibTeX Incollection</description>
+	<scope>text.bibtex</scope>
+</snippet>

--- a/snippets/inproceedings.biblatex-snippet
+++ b/snippets/inproceedings.biblatex-snippet
@@ -1,0 +1,14 @@
+<snippet>
+	<content><![CDATA[
+% Optional fields: editor, subtitle, titleaddon, maintitle, mainsubtitle, maintitleaddon, booksubtitle, booktitleaddon, eventtitle, eventtitleaddon, eventdate, venue, language, volume, part, volumes, series, number, note, organization, publisher, location, month, isbn, chapter, pages, addendum, pubstate, doi, eprint, eprintclass, eprinttype, url, urldate
+@inproceedings{${1:Key},
+	author = {${2:Author/Editor}},
+	title = {${3:Title}},
+	booktitle = {${4:Booktitle}},
+	year = {${5:Year}}
+}
+]]></content>
+	<tabTrigger>inproceedings</tabTrigger>
+	<description>BibLaTeX Inproceedings</description>
+	<scope>text.biblatex</scope>
+</snippet>

--- a/snippets/inproceedings.bibtex-snippet
+++ b/snippets/inproceedings.bibtex-snippet
@@ -1,0 +1,14 @@
+<snippet>
+	<content><![CDATA[
+% Optional fields: editor, volume/number, series, pages, address, month, organization, publisher, note
+@INPROCEEDINGS{${1:Key},
+	author = {${2:Author/Editor}},
+	title = {${3:Title}},
+	booktitle = {${4:Booktitle}},
+	year = {${5:Year}}
+}
+]]></content>
+	<tabTrigger>inproceedings</tabTrigger>
+	<description>BibTeX Inproceedings</description>
+	<scope>text.bibtex</scope>
+</snippet>

--- a/snippets/inreference.biblatex-snippet
+++ b/snippets/inreference.biblatex-snippet
@@ -1,0 +1,14 @@
+<snippet>
+	<content><![CDATA[
+% Optional fields: editor, editora, editorb, editorc, translator, annotator, commentator, introduction, foreword, afterword, subtitle, titleaddon, maintitle, mainsubtitle, maintitleaddon, booksubtitle, booktitleaddon, language, origlanguage, volume, part, edition, volumes, series, number, note, publisher, location, isbn, chapter, pages, addendum, pubstate, doi, eprint, eprintclass, eprinttype, url, urldate
+@inreference{${1:Key},
+	author = {${2:Author/Editor}},
+	title = {${3:Title}},
+	booktitle = {${4:Booktitle}}
+	year = {${5:Year}}
+}
+]]></content>
+	<tabTrigger>inreference</tabTrigger>
+	<description>BibLaTeX Inreference</description>
+	<scope>text.biblatex</scope>
+</snippet>

--- a/snippets/manual.biblatex-snippet
+++ b/snippets/manual.biblatex-snippet
@@ -1,0 +1,13 @@
+<snippet>
+	<content><![CDATA[
+% Optional fields: subtitle, titleaddon, language, edition, type, series, number, version, note, organization, publisher, location, isbn, chapter, pages, pagetotal, addendum, pubstate, doi, eprint, eprintclass, eprinttype, url, urldate
+@manual{${1:Key},
+	author = {${2:Author/Editor}},
+    title = {${3:Title}},
+    year = {${4:Year}}
+}
+]]></content>
+	<tabTrigger>manual</tabTrigger>
+	<description>BibLaTeX Manual</description>
+	<scope>text.biblatex</scope>
+</snippet>

--- a/snippets/manual.bibtex-snippet
+++ b/snippets/manual.bibtex-snippet
@@ -1,0 +1,11 @@
+<snippet>
+	<content><![CDATA[
+% Optional fields: author, organization, address, edition, month, year, note
+@MANUAL{${1:Key},
+	title = {${2:Title}}
+}
+]]></content>
+	<tabTrigger>manual</tabTrigger>
+	<description>BibTeX Manual</description>
+	<scope>text.bibtex</scope>
+</snippet>

--- a/snippets/mastersthesis.biblatex-snippet
+++ b/snippets/mastersthesis.biblatex-snippet
@@ -1,0 +1,14 @@
+<snippet>
+	<content><![CDATA[
+% Optional fields: subtitle, titleaddon, language, note, location, month, isbn, chapter, pages, pagetotal, addendum, pubstate, doi, eprint, eprintclass, eprinttype, url, urldate, type
+@mastersthesis{${1:Key},
+	author = {${2:Author/Editor}},
+	title = {${3:Title}},
+	institution = {${4:Institution}},
+	year = {${5:Year}}
+}
+]]></content>
+	<tabTrigger>mastersthesis</tabTrigger>
+	<description>BibLaTeX Master's Thesis</description>
+	<scope>text.biblatex</scope>
+</snippet>

--- a/snippets/mastersthesis.bibtex-snippet
+++ b/snippets/mastersthesis.bibtex-snippet
@@ -1,0 +1,14 @@
+<snippet>
+	<content><![CDATA[
+% Optional fields: type, address, month, note
+@MASTERSTHESIS{${1:Key},
+	author = {${2:Author/Editor}},
+	title = {${3:Title}},
+	school = {${4:School}},
+	year = {${5:Year}}
+}
+]]></content>
+	<tabTrigger>mastersthesis</tabTrigger>
+	<description>BibTeX Master Thesis</description>
+	<scope>text.bibtex</scope>
+</snippet>

--- a/snippets/misc.biblatex-snippet
+++ b/snippets/misc.biblatex-snippet
@@ -1,0 +1,13 @@
+<snippet>
+	<content><![CDATA[
+% Optional fields: subtitle, titleaddon, language, howpublished, type, version, note, organization, location, date, month, year, addendum, pubstate, doi, eprint, eprintclass, eprinttype, url, urldate
+@misc{${1:Key},
+	author = {${2:Author/Editor}},
+    title = {${3:Title}},
+    year = {${4:Year}}
+}
+]]></content>
+	<tabTrigger>misc</tabTrigger>
+	<description>BibLaTeX Misc</description>
+	<scope>text.biblatex</scope>
+</snippet>

--- a/snippets/misc.bibtex-snippet
+++ b/snippets/misc.bibtex-snippet
@@ -1,0 +1,11 @@
+<snippet>
+	<content><![CDATA[
+% Optional fields: author, title, howpublished, month, year, note
+@MISC{${1:Key},
+	${2}
+}
+]]></content>
+	<tabTrigger>misc</tabTrigger>
+	<description>BibTeX Misc</description>
+	<scope>text.bibtex</scope>
+</snippet>

--- a/snippets/movie.biblatex-snippet
+++ b/snippets/movie.biblatex-snippet
@@ -1,0 +1,11 @@
+<snippet>
+	<content><![CDATA[
+% Optional fields: author, title, subtitle, titleaddon, language, howpublished, type, version, note, organization, location, date, month, year, addendum, pubstate, doi, eprint, eprintclass, eprinttype, url, urldate
+@movie{${1:Key},
+    ${2}
+}
+]]></content>
+	<tabTrigger>movie</tabTrigger>
+	<description>BibLaTeX Movie</description>
+	<scope>text.biblatex</scope>
+</snippet>

--- a/snippets/music.biblatex-snippet
+++ b/snippets/music.biblatex-snippet
@@ -1,0 +1,11 @@
+<snippet>
+	<content><![CDATA[
+% Optional fields: author, title, subtitle, titleaddon, language, howpublished, type, version, note, organization, location, date, month, year, addendum, pubstate, doi, eprint, eprintclass, eprinttype, url, urldate
+@music{${1:Key},
+    ${2}
+}
+]]></content>
+	<tabTrigger>music</tabTrigger>
+	<description>BibLaTeX Music</description>
+	<scope>text.biblatex</scope>
+</snippet>

--- a/snippets/mvbook.biblatex-snippet
+++ b/snippets/mvbook.biblatex-snippet
@@ -1,0 +1,13 @@
+<snippet>
+	<content><![CDATA[
+% Optional fields: volumeditor, editora, editorb, editorc, translator, annotator, commentator, introduction, foreword, afterword, subtitle, titleaddon, maintitle, mainsubtitle, maintitleaddon, language, origlanguage, volume, part, edition, volumes, series, number, note, publisher, location, isbn, chapter, pages, pagetotal, addendum, pubstate, doi, eprint, eprintclass, eprinttype, url, urldate
+@mvbook{${1:Key},
+	author = {${2:Author/Editor}},
+	title = {${3:Title}},
+	year = {${4:Year}}
+}
+]]></content>
+	<tabTrigger>mvbook</tabTrigger>
+	<description>BibLaTeX Multi-Volume Book</description>
+	<scope>text.biblatex</scope>
+</snippet>

--- a/snippets/mvcollection.biblatex-snippet
+++ b/snippets/mvcollection.biblatex-snippet
@@ -1,0 +1,13 @@
+<snippet>
+	<content><![CDATA[
+% Optional fields: editora, editorb, editorc, translator, annotator, commentator, introduction, foreword, afterword, subtitle, titleaddon, maintitle, mainsubtitle, maintitleaddon, language, origlanguage, volume, part, edition, volumes, series, number, note, publisher, location, isbn, chapter, pages, pagetotal, addendum, pubstate, doi, eprint, eprintclass, eprinttype, url, urldate
+@mvcollection{${1:Key},
+	editor = {${2:Editor}},
+	title = {${3:Title}},
+	year = {${4:Year}}
+}
+]]></content>
+	<tabTrigger>mvcollection</tabTrigger>
+	<description>BibLaTeX Multi-Volume Collection</description>
+	<scope>text.biblatex</scope>
+</snippet>

--- a/snippets/mvproceedings.biblatex-snippet
+++ b/snippets/mvproceedings.biblatex-snippet
@@ -1,0 +1,12 @@
+<snippet>
+	<content><![CDATA[
+% Optional fields: editor, subtitle, titleaddon, maintitle, mainsubtitle, maintitleaddon, eventtitle, eventtitleaddon, eventdate, venue, language, volume, part, volumes, series, number, note, organization, publisher, location, month, isbn, chapter, pages, pagetotal, addendum, pubstate, doi, eprint, eprintclass, eprinttype, url, urldate
+@mvproceedings{${1:Key},
+	title = {${2:Title}},
+	year = {${3:Year}}
+}
+]]></content>
+	<tabTrigger>mvproceedings</tabTrigger>
+	<description>BibLaTeX Multi-Volume Proceedings</description>
+	<scope>text.biblatex</scope>
+</snippet>

--- a/snippets/mvreference.biblatex-snippet
+++ b/snippets/mvreference.biblatex-snippet
@@ -1,0 +1,13 @@
+<snippet>
+	<content><![CDATA[
+% Optional fields: editora, editorb, editorc, translator, annotator, commentator, introduction, foreword, afterword, subtitle, titleaddon, maintitle, mainsubtitle, maintitleaddon, language, origlanguage, volume, part, edition, volumes, series, number, note, publisher, location, isbn, chapter, pages, pagetotal, addendum, pubstate, doi, eprint, eprintclass, eprinttype, url, urldate
+@mvreference{${1:Key},
+	editor = {${2:Editor}},
+	title = {${3:Title}},
+	year = {${4:Year}}
+}
+]]></content>
+	<tabTrigger>mvreference</tabTrigger>
+	<description>BibLaTeX Multi-Volume Reference</description>
+	<scope>text.biblatex</scope>
+</snippet>

--- a/snippets/online.biblatex-snippet
+++ b/snippets/online.biblatex-snippet
@@ -1,0 +1,14 @@
+<snippet>
+	<content><![CDATA[
+% Optional fields: subtitle, titleaddon, language, version, note,
+organization, date, month, year, addendum, pubstate, urldate
+@online{${1:Key},
+	author = {${2:Author/Editor}},
+    title = {${3:Title}},
+    year = {${4:Year}}
+}
+]]></content>
+	<tabTrigger>online</tabTrigger>
+	<description>BibLaTeX Online</description>
+	<scope>text.biblatex</scope>
+</snippet>

--- a/snippets/patent.biblatex-snippet
+++ b/snippets/patent.biblatex-snippet
@@ -1,0 +1,14 @@
+<snippet>
+	<content><![CDATA[
+% Optional fields: holder, subtitle, titleaddon, type, version, location, note, date, month, year, addendum, pubstate, doi, eprint, eprintclass, eprinttype, url, urldate
+@patent{${1:Key},
+	author = {${2:Author/Editor}},
+    title = {${3:Title}},
+    number = {${4:Number}}
+    year = {${5:Year}}
+}
+]]></content>
+	<tabTrigger>patent</tabTrigger>
+	<description>BibLaTeX Patent</description>
+	<scope>text.biblatex</scope>
+</snippet>

--- a/snippets/periodical.biblatex-snippet
+++ b/snippets/periodical.biblatex-snippet
@@ -1,0 +1,13 @@
+<snippet>
+    <content><![CDATA[
+% Optional fields: editora, editorb, editorc, subtitle, issuetitle, issuesubtitle, language, series, volume, number, issue, date, month, year, note, issn, addendum, pubstate, doi, eprint, eprintclass, eprinttype, url, urldate
+@periodical{${1:Key},
+    editor = {${2:Editor}},
+    title = {${3:Title}},
+    year = {${4:Year}}
+}
+]]></content>
+    <tabTrigger>periodical</tabTrigger>
+    <description>BibLaTeX Periodical</description>
+    <scope>text.biblatex</scope>
+</snippet>

--- a/snippets/phdthesis.biblatex-snippet
+++ b/snippets/phdthesis.biblatex-snippet
@@ -1,0 +1,14 @@
+<snippet>
+	<content><![CDATA[
+% Optional fields: subtitle, titleaddon, language, note, location, month, isbn, chapter, pages, pagetotal, addendum, pubstate, doi, eprint, eprintclass, eprinttype, url, urldate, type
+@phdthesis{${1:Key},
+	author = {${2:Author/Editor}},
+	title = {${3:Title}},
+	institution = {${4:Institution}},
+	year = {${5:Year}}
+}
+]]></content>
+	<tabTrigger>phdthesis</tabTrigger>
+	<description>BibLaTeX PhD Thesis</description>
+	<scope>text.biblatex</scope>
+</snippet>

--- a/snippets/phdthesis.bibtex-snippet
+++ b/snippets/phdthesis.bibtex-snippet
@@ -1,0 +1,14 @@
+<snippet>
+	<content><![CDATA[
+% Optional fields: type, address, month, note
+@PHDTHESIS{${1:Key},
+	author = {${2:Author/Editor}},
+	title = {${3:Title}},
+	school = {${4:School}},
+	year = {${5:Year}}
+}
+]]></content>
+	<tabTrigger>phdthesis</tabTrigger>
+	<description>BibTeX PhD Thesis</description>
+	<scope>text.bibtex</scope>
+</snippet>

--- a/snippets/proceedings.biblatex-snippet
+++ b/snippets/proceedings.biblatex-snippet
@@ -1,0 +1,12 @@
+<snippet>
+	<content><![CDATA[
+% Optional fields: editor, subtitle, titleaddon, maintitle, mainsubtitle, maintitleaddon, eventtitle, eventtitleaddon, eventdate, venue, language, volume, part, volumes, series, number, note, organization, publisher, location, month, isbn, chapter, pages, pagetotal, addendum, pubstate, doi, eprint, eprintclass, eprinttype, url, urldate
+@proceedings{${1:Key},
+	title = {${2:Title}},
+	year = {${3:Year}}
+}
+]]></content>
+	<tabTrigger>proceedings</tabTrigger>
+	<description>BibLaTeX Proceedings</description>
+	<scope>text.biblatex</scope>
+</snippet>

--- a/snippets/proceedings.bibtex-snippet
+++ b/snippets/proceedings.bibtex-snippet
@@ -1,0 +1,12 @@
+<snippet>
+	<content><![CDATA[
+% Optional fields: editor, volume/number, series, address, month, publisher, organization, note
+@PROCCEDINGS{${1:Key},
+	title = {${2:Title}},
+	year = {${3:Year}}
+}
+]]></content>
+	<tabTrigger>proceedings</tabTrigger>
+	<description>BibTeX Proceedings</description>
+	<scope>text.bibtex</scope>
+</snippet>

--- a/snippets/reference.biblatex-snippet
+++ b/snippets/reference.biblatex-snippet
@@ -1,0 +1,13 @@
+<snippet>
+	<content><![CDATA[
+% Optional fields: editora, editorb, editorc, translator, annotator, commentator, introduction, foreword, afterword, subtitle, titleaddon, maintitle, mainsubtitle, maintitleaddon, language, origlanguage, volume, part, edition, volumes, series, number, note, publisher, location, isbn, chapter, pages, pagetotal, addendum, pubstate, doi, eprint, eprintclass, eprinttype, url, urldate
+@reference{${1:Key},
+	editor = {${2:Editor}},
+	title = {${3:Title}},
+	year = {${4:Year}}
+}
+]]></content>
+	<tabTrigger>reference</tabTrigger>
+	<description>BibLaTeX Reference</description>
+	<scope>text.biblatex</scope>
+</snippet>

--- a/snippets/report.biblatex-snippet
+++ b/snippets/report.biblatex-snippet
@@ -1,0 +1,15 @@
+<snippet>
+    <content><![CDATA[
+% Optional fields: subtitle, titleaddon, language, number, version, note, location, month, isrn, chapter, pages, pagetotal, addendum, pubstate, doi, eprint, eprintclass, eprinttype, url, urldate
+@report{${1:Key},
+    author = {${2:Author}},
+    title = {${3:Title}},
+    type = {${4:Type}},
+    institution = {${5:Institution}},
+    year = {${6:Year}}
+}
+]]></content>
+    <tabTrigger>report</tabTrigger>
+    <description>BibLaTeX Report</description>
+    <scope>text.biblatex</scope>
+</snippet>

--- a/snippets/set.biblatex-snippet
+++ b/snippets/set.biblatex-snippet
@@ -1,0 +1,10 @@
+<snippet>
+	<content><![CDATA[
+@Set{${1:Key},
+    entryset = {${1:Entries}}
+}
+]]></content>
+	<tabTrigger>set</tabTrigger>
+	<description>BibLaTeX Set</description>
+	<scope>text.biblatex</scope>
+</snippet>

--- a/snippets/suppbook.biblatex-snippet
+++ b/snippets/suppbook.biblatex-snippet
@@ -1,0 +1,14 @@
+<snippet>
+	<content><![CDATA[
+% Optional fields: vbookauthor, editor, editora, editorb, editorc, translator, annotator, commentator, introduction, foreword, afterword, subtitle, titleaddon, maintitle, mainsubtitle, maintitleaddon, booksubtitle, booktitleaddon, language, origlanguage, volume, part, edition, volumes, series, number, note, publisher, location, isbn, chapter, pages, addendum, pubstate, doi, eprint, eprintclass, eprinttype, url, urldate
+@suppbook{${1:Key},
+	author = {${2:Author/Editor}},
+	title = {${3:Title}},
+	booktitle = {${4:Chapter/Pages}}
+	year = {${5:Year}}
+}
+]]></content>
+	<tabTrigger>suppbook</tabTrigger>
+	<description>BibLaTeX Suppbook</description>
+	<scope>text.biblatex</scope>
+</snippet>

--- a/snippets/suppcollection.biblatex-snippet
+++ b/snippets/suppcollection.biblatex-snippet
@@ -1,0 +1,14 @@
+<snippet>
+	<content><![CDATA[
+% Optional fields: editor, editora, editorb, editorc, translator, annotator, commentator, introduction, foreword, afterword, subtitle, titleaddon, maintitle, mainsubtitle, maintitleaddon, booksubtitle, booktitleaddon, language, origlanguage, volume, part, edition, volumes, series, number, note, publisher, location, isbn, chapter, pages, addendum, pubstate, doi, eprint, eprintclass, eprinttype, url, urldate
+@suppcollection{${1:Key},
+	author = {${2:Author/Editor}},
+	title = {${3:Title}},
+	booktitle = {${4:Booktitle}}
+	year = {${5:Year}}
+}
+]]></content>
+	<tabTrigger>suppcollection</tabTrigger>
+	<description>BibLaTeX Suppcollection</description>
+	<scope>text.biblatex</scope>
+</snippet>

--- a/snippets/suppperiodical.biblatex-snippet
+++ b/snippets/suppperiodical.biblatex-snippet
@@ -1,0 +1,14 @@
+<snippet>
+    <content><![CDATA[
+% Optional fields: translator, annotator, commentator, subtitle, titleaddon, editor, editora, editorb, editorc, journalsubtitle, issuetitle, issuesubtitle, language, origlanguage, series, volume, number, eid, issue, month, pages, version, note, issn, addendum, pubstate, doi, eprint, eprintclass, eprinttype, url, urldate
+@suppperiodical{${1:Key},
+    author = {${2:Author}},
+    title = {${3:Title}},
+    journal = {${4:Journal}},
+    year = {${5:Year}}
+}
+]]></content>
+    <tabTrigger>suppperiodical</tabTrigger>
+    <description>BibLaTeX Suppperiodical</description>
+    <scope>text.biblatex</scope>
+</snippet>

--- a/snippets/techreport.biblatex-snippet
+++ b/snippets/techreport.biblatex-snippet
@@ -1,0 +1,14 @@
+<snippet>
+    <content><![CDATA[
+% Optional fields: subtitle, titleaddon, language, number, version, note, location, month, isrn, chapter, pages, pagetotal, addendum, pubstate, doi, eprint, eprintclass, eprinttype, url, urldate, type
+@techreport{${1:Key},
+    author = {${2:Author}},
+    title = {${3:Title}},
+    institution = {${4:Institution}},
+    year = {${5:Year}}
+}
+]]></content>
+    <tabTrigger>techreport</tabTrigger>
+    <description>BibLaTeX Techreport</description>
+    <scope>text.biblatex</scope>
+</snippet>

--- a/snippets/techreport.bibtex-snippet
+++ b/snippets/techreport.bibtex-snippet
@@ -1,0 +1,14 @@
+<snippet>
+	<content><![CDATA[
+% Optional fields: type, number, address, month, note
+@TECHREPORT{${1:Key},
+	author = {${2:Author/Editor}},
+	title = {${3:Title}},
+	institution = {${4:Institution}},
+	year = {${5:Year}}
+}
+]]></content>
+	<tabTrigger>techreport</tabTrigger>
+	<description>BibTeX Techreport</description>
+	<scope>text.bibtex</scope>
+</snippet>

--- a/snippets/thesis.biblatex-snippet
+++ b/snippets/thesis.biblatex-snippet
@@ -1,0 +1,15 @@
+<snippet>
+	<content><![CDATA[
+% Optional fields: subtitle, titleaddon, language, note, location, month, isbn, chapter, pages, pagetotal, addendum, pubstate, doi, eprint, eprintclass, eprinttype, url, urldate
+@thesis{${1:Key},
+	author = {${2:Author/Editor}},
+	title = {${3:Title}},
+    type = {${4:Type}},
+	institution = {${5:Institution}},
+	year = {${6:Year}}
+}
+]]></content>
+	<tabTrigger>thesis</tabTrigger>
+	<description>BibLaTeX Thesis</description>
+	<scope>text.biblatex</scope>
+</snippet>

--- a/snippets/unpublished.biblatex-snippet
+++ b/snippets/unpublished.biblatex-snippet
@@ -1,0 +1,13 @@
+<snippet>
+	<content><![CDATA[
+% Optional fields: subtitle, titleaddon, language, howpublished, note, location, isbn, date, month, year, addendum, pubstate, url, urldate
+@unpublished{${1:Key},
+	author = {${2:Author/Editor}},
+	title = {${3:Title}},
+	year = {${4:Year}}
+}
+]]></content>
+	<tabTrigger>unpublished</tabTrigger>
+	<description>BibLaTeX Unpublished</description>
+	<scope>text.biblatex</scope>
+</snippet>

--- a/snippets/unpublished.bibtex-snippet
+++ b/snippets/unpublished.bibtex-snippet
@@ -1,0 +1,13 @@
+<snippet>
+	<content><![CDATA[
+% Optional fields: month, year
+@UNPUBLISHED{${1:Key},
+	author = {${2:Author/Editor}},
+	title = {${3:Title}},
+	note = {${4:Note}}
+}
+]]></content>
+	<tabTrigger>unpublished</tabTrigger>
+	<description>BibTeX Unpublished</description>
+	<scope>text.bibtex</scope>
+</snippet>

--- a/snippets/video.biblatex-snippet
+++ b/snippets/video.biblatex-snippet
@@ -1,0 +1,11 @@
+<snippet>
+	<content><![CDATA[
+% Optional fields: author, title, subtitle, titleaddon, language, howpublished, type, version, note, organization, location, date, month, year, addendum, pubstate, doi, eprint, eprintclass, eprinttype, url, urldate
+@video{${1:Key},
+    ${2}
+}
+]]></content>
+	<tabTrigger>video</tabTrigger>
+	<description>BibLaTeX Video</description>
+	<scope>text.biblatex</scope>
+</snippet>

--- a/snippets/www.biblatex-snippet
+++ b/snippets/www.biblatex-snippet
@@ -1,0 +1,14 @@
+<snippet>
+	<content><![CDATA[
+% Optional fields: subtitle, titleaddon, language, version, note,
+organization, date, month, year, addendum, pubstate, urldate
+@www{${1:Key},
+	author = {${2:Author/Editor}},
+    title = {${3:Title}},
+    year = {${4:Year}}
+}
+]]></content>
+	<tabTrigger>www</tabTrigger>
+	<description>BibLaTeX WWW</description>
+	<scope>text.biblatex</scope>
+</snippet>

--- a/snippets/xdata.biblatex-snippet
+++ b/snippets/xdata.biblatex-snippet
@@ -1,0 +1,10 @@
+<snippet>
+	<content><![CDATA[
+@xdata{${1:Key},
+    ${2}
+}
+]]></content>
+	<tabTrigger>xdata</tabTrigger>
+	<description>BibLaTeX Xdata</description>
+	<scope>text.biblatex</scope>
+</snippet>


### PR DESCRIPTION
This is a set of features intended to make it easier to edit BibTeX or BibLaTeX files in ST.

**Features:**
 * New `BibLaTeX` syntax. This is nothing special, it is just used by this code to differentiate determine whether it should treat a file as BibTeX or BibLaTeX. In addition, I've added a configuration option `use_biblatex` which can be set in either the user settings or at the project level that, if set to `true` (default is `false`) will automatically treat .bib files as BibLaTeX rather than BibTeX.
 * Smart completions for fields containing names. Basically, inside any BibTeX or vanilla BibLaTeX field that stores a name, we provide a list of auto-completions consisting of any name found in the current file.
 * Smart completions for crossref fields. For the `crossref` field or any of the vanilla BibLaTeX fields that can have one or more citekey values, we provide an auto-complete list of all the citekeys in the current file.
 * Snippet-completions for all BibTeX and BibLaTeX entry types.
 * Completions for all BibTeX and vanilla BibLaTeX fields when inside an entry.

Anyone who's familiar with the flexibility provided by Biber will realise that its very difficult to duplicate all of the possible ways in which BibLaTeX/Biber can be configured. But as long as you're sticking close to vanilla BibLaTeX, this should be helpful and (hopefully) stay out of your way if you're using heavy customisations.