### PR TITLE
Fix for parse log with duplicate identifier messages

### DIFF
--- a/parseTeXlog.py
+++ b/parseTeXlog.py
@@ -471,6 +471,11 @@ def parse_tex_log(data):
 			else:
 				debug("Found loaded) but top file name doesn't have xy")
 
+		# mostly these are caused by hyperref and re-using internal identifiers
+		if "pdfTeX warning (ext4): destination with the same identifier" in line:
+			# ignore this warning as usually they aren't important
+			debug("Skipping pdfTeX warning: " + line)
+			continue
 
 		line = line.strip() # get rid of initial spaces
 		# note: in the next line, and also when we check for "!", we use the fact that "and" short-circuits

--- a/parseTeXlog.py
+++ b/parseTeXlog.py
@@ -473,8 +473,8 @@ def parse_tex_log(data):
 
 		# mostly these are caused by hyperref and re-using internal identifiers
 		if "pdfTeX warning (ext4): destination with the same identifier" in line:
-			# ignore this warning as usually they aren't important
-			debug("Skipping pdfTeX warning: " + line)
+			# add warning
+			handle_warning(line[line.find("destination with the same identifier"):])
 			continue
 
 		line = line.strip() # get rid of initial spaces


### PR DESCRIPTION
The root cause of #477 is not properly handling pdfTeX warnings with the message `destination with the same identifier... has been already used, duplicate ignored` when they appear in the odd configuration of that log. These are primarily noise or can be addressed by [ensuring `hyperref` is loaded after most other packages](http://www.tex.ac.uk/FAQ-hyperdupdest.html).

This change will add these warnings to the list of warnings if they are not otherwise handled. It shouldn't break anything, but LaTeX log files are a mess...