### PR TITLE
Add support for OS X 10.11 El Capitan

### DIFF
--- a/LaTeXTools.default-settings
+++ b/LaTeXTools.default-settings
@@ -34,7 +34,7 @@
 
 	"osx": 	{
 		// Path used when invoking tex & friends; MUST include $PATH
-		"texpath" : "$PATH:/usr/texbin:/usr/local/bin:/opt/local/bin"
+		"texpath" : "$PATH:/Library/TeX/texbin:/usr/texbin:/usr/local/bin:/opt/local/bin"
 		// Path to PDF viewer, if needed
 		// TODO think about it. Also, maybe configure it here!
 	},


### PR DESCRIPTION
Adding the new install path for "texpath" in osx.

# Background
Under OS X 10.11, El Capitan, writing to `/usr` is no longer allowed, even with Administrator
privileges. The usual symbolic link to the active TEX Distribution, `/usr/texbin`, is therefore removed
(if it was there from a previous OS version) and cannot be installed. Many GUI applications
have the path to those binaries set to /usr/texbin by default and will no longer find the binaries
there.

# Fix
add  `/Library/TeX/texbin` to the path for texbin.