### PR TITLE
Input Completions Fixes

### DIFF
--- a/latex_input_completions.py
+++ b/latex_input_completions.py
@@ -107,6 +107,7 @@ def parse_completions(view, line):
         if addbib_filter is not None:
             prefix = addbib_filter[::-1]
         else:
+            prefix = ''
             bib_filter[::-1]
         input_file_types = ['bib']
     elif cls_filter is not None or pkg_filter is not None or bst_filter is not None:

--- a/latex_input_completions.py
+++ b/latex_input_completions.py
@@ -202,7 +202,9 @@ class LatexFillInputCommand(sublime_plugin.TextCommand):
             view,
             view.substr(sublime.Region(view.line(point).a, point)))
 
-        if len(completions) > 0 and not type(completions[0]) is tuple:
+        if len(completions) == 0:
+            result = []
+        elif not type(completions[0]) is tuple:
             result = completions
         else:
             tex_root = getTeXRoot.get_tex_root(self.view)

--- a/latex_input_completions.py
+++ b/latex_input_completions.py
@@ -212,7 +212,9 @@ class LatexFillInputCommand(sublime_plugin.TextCommand):
                 root_path = os.curdir
 
             result = [[
-                os.path.normpath(os.path.join(relpath, filename)),
+                # Replace backslash with forward slash to fix Windows paths
+                # LaTeX does not support forward slashes in paths
+                os.path.normpath(os.path.join(relpath, filename)).replace('\\', '/'),
                 os.path.normpath(os.path.join(root_path, relpath, filename))
             ] for relpath, filename in completions]
 


### PR DESCRIPTION
This addresses a fews issues with `LatexFillInputCommand` and adds its autocompletions to the usual pop-up.

Thanks to @r-stein for pointing most of this out.

Issues addressed:
 * On Windows we were inserting backslashes instead of slashes for folder names. This would cause the autocompletions not to work for items
 * Due to an oversight, completions for the `\bibliography{}` would not work

New feature:
 * Autocompletions added to the autocompletion pop up (i.e. ctrl + space or cmd +space)

In addition, the `.tex` extension is omitted for `\input` or `\include`