### PR TITLE
Bugfix: Jump to PDF doesn't use proper view

### DIFF
--- a/makePDF.py
+++ b/makePDF.py
@@ -213,7 +213,7 @@ class make_pdfCommand(sublime_plugin.WindowCommand):
 		else: # either it's the first time we run, or else we have no running processes
 			self.proc = None
 		
-		view = self.window.active_view()
+		view = self.view = self.window.active_view()
 
 		self.file_name = getTeXRoot.get_tex_root(view)
 		if not os.path.isfile(self.file_name):
@@ -392,7 +392,7 @@ class make_pdfCommand(sublime_plugin.WindowCommand):
 		# self.output_view.end_edit(edit)
 		self.output_view.run_command("do_finish_edit")
 		if can_switch_to_pdf:
-			self.window.active_view().run_command("jump_to_pdf", {"from_keybinding": False})
+			self.view.run_command("jump_to_pdf", {"from_keybinding": False})
 
 
 class DoOutputEditCommand(sublime_plugin.TextCommand):


### PR DESCRIPTION
In `makePDF.py`, the final call to `jump_to_pdf` uses the active view of the current window. Since LaTeX builds can take quite a while, this is not guaranteed to be the same view that was active when the build was initiated, meaning that `jump_to_pdf` might 1) not open any file at all or 2) might open the wrong PDF file (if the view was switched to another LaTeX document).

This change saves the view used at the launch of build and uses that to call `jump_to_pdf`.

This *may* fix some of #573, but I can't really promise anything.