### PR TITLE
Add support for bibentry's \nobibliography command

### DIFF
--- a/latex_cite_completions.py
+++ b/latex_cite_completions.py
@@ -74,6 +74,7 @@ def find_bib_files(rootdir, src, bibfiles):
                 f.close()
 
     bibtags =  re.findall(r'\\bibliography\{[^\}]+\}', src_content)
+    bibtags += re.findall(r'\\nobibliography\{[^\}]+\}', src_content)
     bibtags += re.findall(r'\\addbibresource\{[^\}]+.bib\}', src_content)
 
     # extract absolute filepath for each bib file


### PR DESCRIPTION
When searching a .tex document for .bib files to use for citation completion, look for \nobibliography command in addition to the \bibliography command. (The \nobibliography command allows one to use in-document citations without printing a references section at the end.)