### PR TITLE
Bugfix for 589 (inconsistent indentation )

### DIFF
--- a/builders/traditionalBuilder.py
+++ b/builders/traditionalBuilder.py
@@ -130,7 +130,7 @@ class TraditionalBuilder(PdfBuilder):
 				self.display("Engine: " + self.engine + " -> " + engine + ". ")
 
 			for i, c in enumerate(cmd):
-                cmd[i] = c.replace("%E", engine)
+				cmd[i] = c.replace("%E", engine)
 
 		# handle any options
 		if texify or latexmk:


### PR DESCRIPTION
Bugfix for https://github.com/SublimeText/LaTeXTools/issues/589. Only changes the indentation in one line from spaces to tabs to be consistent for the whole file.