### PR TITLE
Bugfix: LaTeXTools disables the `ctrl+l` globally

### DIFF
--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -106,6 +106,8 @@ LaTeX Package keymap for Linux
 
 	// Jump to a tex file (will create the file if it does not exists)
 	{ "keys": ["ctrl+l", "ctrl+o"],
+		"context": [
+			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"}],
 		"command": "jumpto_tex_file", "args": {"auto_create_missing_folders": true, "auto_insert_root": true}},
 
 	// Wrap selected text in command or environment

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -106,6 +106,8 @@ LaTeX Package keymap for OS X
 
 	// Jump to a tex file (will create the file if it does not exists)
 	{ "keys": ["super+l", "super+o"],
+		"context": [
+			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"}],
 		"command": "jumpto_tex_file", "args": {"auto_create_missing_folders": true, "auto_insert_root": true}},
 
 	// Wrap selected text in command or environment

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -106,6 +106,8 @@ LaTeX Package keymap for Windows
 
 	// Jump to a tex file (will create the file if it does not exists)
 	{ "keys": ["ctrl+l", "ctrl+o"],
+		"context": [
+			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"}],
 		"command": "jumpto_tex_file", "args": {"auto_create_missing_folders": true, "auto_insert_root": true}},
 
 	// Wrap selected text in command or environment


### PR DESCRIPTION
Added a context to the `jumpto_tex_file` command, such that is only for tex-files. Addressed in https://github.com/SublimeText/LaTeXTools/issues/595