### PR TITLE
Bugfix: Ensure that we kill child processes of the launched process

### DIFF
--- a/makePDF.py
+++ b/makePDF.py
@@ -244,7 +244,7 @@ class make_pdfCommand(sublime_plugin.WindowCommand):
 	def __init__(self, *args, **kwargs):
 		sublime_plugin.WindowCommand.__init__(self, *args, **kwargs)
 		self.proc = None
-		self.proc_lock = threading.Lock
+		self.proc_lock = threading.Lock()
 
 	def run(self, cmd="", file_regex="", path=""):
 		

--- a/makePDF.py
+++ b/makePDF.py
@@ -248,6 +248,7 @@ class make_pdfCommand(sublime_plugin.WindowCommand):
 			else:
 				os.killpg(self.proc.pid, signal.SIGTERM)
 			self.proc = None
+			return
 		else: # either it's the first time we run, or else we have no running processes
 			self.proc = None
 		

--- a/makePDF.py
+++ b/makePDF.py
@@ -241,7 +241,8 @@ class CmdThread ( threading.Thread ):
 
 class make_pdfCommand(sublime_plugin.WindowCommand):
 
-	def __init__(self):
+	def __init__(self, *args, **kwargs):
+		sublime_plugin.WindowCommand.__init__(self, *args, **kwargs)
 		self.proc = None
 		self.proc_lock = threading.Lock
 

--- a/makePDF.py
+++ b/makePDF.py
@@ -244,7 +244,13 @@ class make_pdfCommand(sublime_plugin.WindowCommand):
 		if hasattr(self, 'proc') and self.proc: # if we are running, try to kill running process
 			self.output("\n\n### Got request to terminate compilation ###")
 			if sublime.platform() == 'windows':
-				subprocess.call('taskkill /t /f /pid {pid}'.format(pid=self.proc.pid))
+				startupinfo = subprocess.STARTUPINFO()
+				startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
+				subprocess.call(
+					'taskkill /t /f /pid {pid}'.format(pid=self.proc.pid),
+					startupinfo=startupinfo,
+					shell=True
+				)
 			else:
 				os.killpg(self.proc.pid, signal.SIGTERM)
 			self.proc = None

--- a/makePDF.py
+++ b/makePDF.py
@@ -132,20 +132,23 @@ class CmdThread ( threading.Thread ):
 			
 			# Now actually invoke the command, making sure we allow for killing
 			# First, save process handle into caller; then communicate (which blocks)
-			self.caller.proc = proc
+			with self.caller.proc_lock:
+				self.caller.proc = proc
 			out, err = proc.communicate()
 			self.caller.builder.set_output(out.decode(self.caller.encoding,"ignore"))
 
 			# Here the process terminated, but it may have been killed. If so, stop and don't read log
 			# Since we set self.caller.proc above, if it is None, the process must have been killed.
 			# TODO: clean up?
-			if not self.caller.proc:
-				print (proc.returncode)
-				self.caller.output("\n\n[User terminated compilation process]\n")
-				self.caller.finish(False)	# We kill, so won't switch to PDF anyway
-				return
+			with self.caller.proc_lock:
+				if not self.caller.proc:
+					print (proc.returncode)
+					self.caller.output("\n\n[User terminated compilation process]\n")
+					self.caller.finish(False)	# We kill, so won't switch to PDF anyway
+					return
 			# Here we are done cleanly:
-			self.caller.proc = None
+			with self.caller.proc_lock:
+				self.caller.proc = None
 			print ("Finished normally")
 			print (proc.returncode)
 
@@ -238,25 +241,30 @@ class CmdThread ( threading.Thread ):
 
 class make_pdfCommand(sublime_plugin.WindowCommand):
 
+	def __init__(self):
+		self.proc = None
+		self.proc_lock = threading.Lock
+
 	def run(self, cmd="", file_regex="", path=""):
 		
 		# Try to handle killing
-		if hasattr(self, 'proc') and self.proc: # if we are running, try to kill running process
-			self.output("\n\n### Got request to terminate compilation ###")
-			if sublime.platform() == 'windows':
-				startupinfo = subprocess.STARTUPINFO()
-				startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
-				subprocess.call(
-					'taskkill /t /f /pid {pid}'.format(pid=self.proc.pid),
-					startupinfo=startupinfo,
-					shell=True
-				)
-			else:
-				os.killpg(self.proc.pid, signal.SIGTERM)
-			self.proc = None
-			return
-		else: # either it's the first time we run, or else we have no running processes
-			self.proc = None
+		with self.proc_lock:
+			if self.proc: # if we are running, try to kill running process
+				self.output("\n\n### Got request to terminate compilation ###")
+				if sublime.platform() == 'windows':
+					startupinfo = subprocess.STARTUPINFO()
+					startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
+					subprocess.call(
+						'taskkill /t /f /pid {pid}'.format(pid=self.proc.pid),
+						startupinfo=startupinfo,
+						shell=True
+					)
+				else:
+					os.killpg(self.proc.pid, signal.SIGTERM)
+				self.proc = None
+				return
+			else: # either it's the first time we run, or else we have no running processes
+				self.proc = None
 		
 		view = self.view = self.window.active_view()
 


### PR DESCRIPTION
This is to fix the issue reported in #603. 

In makePDF.py we kill the current running subprocess, which is fine as long as the subprocess itself doesn't spawn any executables. Both latexmk and texify spawn executables (pdflatex, bibtex, etc.) to complete there work and if these executables hang (as in the example given with #603), the processes will not be terminated by calling `subprocess.kill()`.

On OS X and Linux, I've switched it so we use a process group and `os.killpg()` to kill the builder and its children. On Windows with its different process architecture, I've used the `taskkill` executable to kill the process tree.

In addition, I added a lock to control access to the `proc` variable because on Windows, there appeared to be a race condition where taskkill would kill `texify` or `latexmk` but the CmdThread would think that execution had completed normally.

I don't currently have access to a Linux machine, so I'd appreciate it if someone else could test that.