### PR TITLE
Bugfix: over/underfull box parsing

### DIFF
--- a/parseTeXlog.py
+++ b/parseTeXlog.py
@@ -405,7 +405,7 @@ def parse_tex_log(data):
 				line_num += 1
 				debug("Over/underfull: skip " + line + " (%d) " % line_num)
 				# Sometimes it's " []" and sometimes it's "[]"...
-				if len(line)>0 and line in [" []", "[]"]:
+				if len(line)>0 and line[:3] == " []" or line[:2] == "[]":
 					ou_processing = False
 			if ou_processing:
 				warnings.append("Malformed LOG file: over/underfull")


### PR DESCRIPTION
The current version of parseTeXLog.py assumes that the `[]` terminating the underfull box warning is on a line by itself. However, this line sometimes contains the text which caused the box badness (as in the example given in #602). This fixes the issue by assuming that the remaining text on a line that starts with `[]` or ` []` after a underfull box can be safely ignored.