### PR TITLE
Keep focus for Windows and Linux

### DIFF
--- a/LaTeXTools.default-settings
+++ b/LaTeXTools.default-settings
@@ -79,7 +79,15 @@
 		// TeX distro: "miktex" or "texlive"
 		"distro" : "miktex",
 		// Command to invoke Sumatra. If blank, "SumatraPDF.exe" is used (it has to be on your PATH)
-		"sumatra": ""
+		"sumatra": "",
+		// Command to invoke Sublime Text. Used if the keep_focus toggle is true.
+		// If blank, "subl.exe" or "sublime_text.exe" will be used. Only 
+		// necessary if using ST2 and neither of those are on your path.
+		"sublime_executable": "",
+		// how long (in ms) to wait after the jump_to_pdf command completes before
+		// switching focus back to Sublime Text. This may need to be adjusted
+		// depending on your machine and configuration.
+		"keep_focus_delay": 500
 	},
 
 	"linux" : {
@@ -97,7 +105,15 @@
 		// Note: only tweak this if sync after launching the PDF viewer does not seem to work,
 		// or if the PDF viewer opens instantly and you don't want to wait.
 		// Default: 1.5 (works on my MBP4,1...)
-		"sync_wait": 1.5
+		"sync_wait": 1.5,
+		// Command to invoke Sublime Text. Used if the keep_focus toggle is true.
+		// If blank, "subl" or "sublime_text" will be used. Only 
+		// necessary if using ST2 and neither of those are on your path.
+		"sublime_executable": "",
+		// how long (in ms) to wait after the jump_to_pdf command completes before
+		// switching focus back to Sublime Text. This may need to be adjusted
+		// depending on your machine and configuration.
+		"keep_focus_delay": 500
 	},
 
 // ------------------------------------------------------------------

--- a/LaTeXTools.default-settings
+++ b/LaTeXTools.default-settings
@@ -83,8 +83,7 @@
 		// Command to invoke Sumatra. If blank, "SumatraPDF.exe" is used (it has to be on your PATH)
 		"sumatra": "",
 		// Command to invoke Sublime Text. Used if the keep_focus toggle is true.
-		// If blank, "subl.exe" or "sublime_text.exe" will be used. Only 
-		// necessary if using ST2 and neither of those are on your path.
+		// If blank, "subl.exe" or "sublime_text.exe" will be used.
 		"sublime_executable": "",
 		// how long (in seconds) to wait after the jump_to_pdf command completes
 		// before switching focus back to Sublime Text. This may need to be
@@ -109,8 +108,7 @@
 		// Default: 1.5 (works on my MBP4,1...)
 		"sync_wait": 1.5,
 		// Command to invoke Sublime Text. Used if the keep_focus toggle is true.
-		// If blank, "subl" or "sublime_text" will be used. Only 
-		// necessary if using ST2 and neither of those are on your path.
+		// If blank, "subl" or "sublime_text" will be used.
 		"sublime_executable": "",
 		// how long (in ms) to wait after the jump_to_pdf command completes
 		// before switching focus back to Sublime Text. This may need to be

--- a/LaTeXTools.default-settings
+++ b/LaTeXTools.default-settings
@@ -26,6 +26,8 @@
 	"fill_auto_trigger": true,
 
 	// Keep focus on Sublime Text after building (true) or switch to PDF viewer (false)
+	// If you are on Windows or Linux and using ST2, you may need to set the
+	// "sublime_executable" setting for this to work in your platform settings.
 	"keep_focus": true,
 	// Sync PDF to current editor position after building (true) or not 
 	"forward_sync": true,

--- a/LaTeXTools.default-settings
+++ b/LaTeXTools.default-settings
@@ -86,10 +86,10 @@
 		// If blank, "subl.exe" or "sublime_text.exe" will be used. Only 
 		// necessary if using ST2 and neither of those are on your path.
 		"sublime_executable": "",
-		// how long (in ms) to wait after the jump_to_pdf command completes before
-		// switching focus back to Sublime Text. This may need to be adjusted
-		// depending on your machine and configuration.
-		"keep_focus_delay": 500
+		// how long (in seconds) to wait after the jump_to_pdf command completes
+		// before switching focus back to Sublime Text. This may need to be
+		// adjusted depending on your machine and configuration.
+		"keep_focus_delay": 0.5
 	},
 
 	"linux" : {
@@ -112,10 +112,10 @@
 		// If blank, "subl" or "sublime_text" will be used. Only 
 		// necessary if using ST2 and neither of those are on your path.
 		"sublime_executable": "",
-		// how long (in ms) to wait after the jump_to_pdf command completes before
-		// switching focus back to Sublime Text. This may need to be adjusted
-		// depending on your machine and configuration.
-		"keep_focus_delay": 500
+		// how long (in ms) to wait after the jump_to_pdf command completes
+		// before switching focus back to Sublime Text. This may need to be
+		// adjusted depending on your machine and configuration.
+		"keep_focus_delay": 0.5
 	},
 
 // ------------------------------------------------------------------

--- a/README.markdown
+++ b/README.markdown
@@ -380,10 +380,14 @@ The following options are currently available (defaults in parentheses):
 - `windows`-specific settings:
   * `distro`: either `miktex` or `texlive`, depending on your TeX distribution
   * `sumatra`: leave blank or omit if the SumatraPDF executable is in your `PATH` and is called `SumatraPDF.exe`, as in a default installation; otherwise, specify the *full path and file name* of the SumatraPDF executable.
+  * `sublime_executable`: this is used if `keep_focus` is set to true, you are using Sublime Text 2, and neither subl.exe nor sublime_text.exe are on your `PATH`. It should point to the full path to your install of sublime_text.exe.
+  * `keep_focus_delay`: this is used if `keep_focus` is set to true. It controls how long (in ms) the delay is between the completion of the `jump_to_pdf` command and the attempt to refocus on Sublime Text. This may need to be adjusted depending on your machine or configuration.
 - `linux`-specific settings:
   * `python2` (`""`, i.e. empty string): name of the Python 2 executable. This is useful for systems that ship with both Python 2 and Python 3. The forward/backward search used with Evince require Python 2.
   * `sublime` (`sublime-text`): name of the ST executable. Ubuntu supports both `sublime-text` and `subl`; other distros may vary.
   * `sync_wait` (1.5): when you ask LaTeXTools to do a forward search, and the PDF file is not yet open (for example, right after compiling a tex file for the first time), LaTeXTools first launches evince, then waits a bit for it to come up, and then it performs the forward search. This parameter controls how long LaTeXTools should wait. If you notice that your machine opens the PDF, then sits there doing nothing, and finally performs the search, you can decrease this value to 1.0 or 0.5; if instead the PDF file comes up but the forward search does not seem to happen, increase it to 2.0.
+  * `sublime_executable`: this is used if `keep_focus` is set to true, you are using Sublime Text 2, and neither subl.exe nor sublime_text.exe are on your `PATH`. It should point to the full path to your install of sublime_text.exe.
+  * `keep_focus_delay`: this is used if `keep_focus` is set to true. It controls how long (in ms) the delay is between the completion of the `jump_to_pdf` command and the attempt to refocus on Sublime Text. This may need to be adjusted depending on your machine or configuration.
 
 **Build engine settings**:
 

--- a/README.markdown
+++ b/README.markdown
@@ -369,7 +369,7 @@ The following options are currently available (defaults in parentheses):
 - `fill_auto_trigger` (`true`): ditto, but for package and file inclusion commands (see Fill Helper feature above)
 - `cwl_completion` (`prefixed`): when to activate the cwl completion poput (see LaTeX-cwl feature above)
 - `cwl_list` (empty): list of paths to cwl files
-- `keep_focus` (`true`): if `true`, after compiling a tex file, ST retains the focus; if `false`, the PDF viewer gets the focus. Also note that you can *temporarily* toggle this behavior with `C-l,t,f`.
+- `keep_focus` (`true`): if `true`, after compiling a tex file, ST retains the focus; if `false`, the PDF viewer gets the focus. Also note that you can *temporarily* toggle this behavior with `C-l,t,f`. **Note**: If you are on ST2 on either Windows or Linux and you don't have the correct version of `subl` / `subl.exe` on your `PATH`, you will need to set the `sublime_executable` setting for this to work properly. See the **Platform settings** below.
 - `forward_sync` (`true`): if `true`, after compiling a tex file, the PDF viewer is asked to sync to the position corresponding to the current cursor location in ST. You can also *temporarily* toggle this behavior with `C-l,t,s`.
 - `temp_files_exts`: list of file extensions to be considered temporary, and hence deleted using the `C-l, backspace` command.
 - `temp_files_ignored_folders`: subdirectories to skip when deleting temp files.

--- a/README.markdown
+++ b/README.markdown
@@ -381,13 +381,13 @@ The following options are currently available (defaults in parentheses):
   * `distro`: either `miktex` or `texlive`, depending on your TeX distribution
   * `sumatra`: leave blank or omit if the SumatraPDF executable is in your `PATH` and is called `SumatraPDF.exe`, as in a default installation; otherwise, specify the *full path and file name* of the SumatraPDF executable.
   * `sublime_executable`: this is used if `keep_focus` is set to true, you are using Sublime Text 2, and neither subl.exe nor sublime_text.exe are on your `PATH`. It should point to the full path to your install of sublime_text.exe.
-  * `keep_focus_delay`: this is used if `keep_focus` is set to true. It controls how long (in ms) the delay is between the completion of the `jump_to_pdf` command and the attempt to refocus on Sublime Text. This may need to be adjusted depending on your machine or configuration.
+  * `keep_focus_delay`: this is used if `keep_focus` is set to true. It controls how long (in seconds) the delay is between the completion of the `jump_to_pdf` command and the attempt to refocus on Sublime Text. This may need to be adjusted depending on your machine or configuration.
 - `linux`-specific settings:
   * `python2` (`""`, i.e. empty string): name of the Python 2 executable. This is useful for systems that ship with both Python 2 and Python 3. The forward/backward search used with Evince require Python 2.
   * `sublime` (`sublime-text`): name of the ST executable. Ubuntu supports both `sublime-text` and `subl`; other distros may vary.
   * `sync_wait` (1.5): when you ask LaTeXTools to do a forward search, and the PDF file is not yet open (for example, right after compiling a tex file for the first time), LaTeXTools first launches evince, then waits a bit for it to come up, and then it performs the forward search. This parameter controls how long LaTeXTools should wait. If you notice that your machine opens the PDF, then sits there doing nothing, and finally performs the search, you can decrease this value to 1.0 or 0.5; if instead the PDF file comes up but the forward search does not seem to happen, increase it to 2.0.
   * `sublime_executable`: this is used if `keep_focus` is set to true, you are using Sublime Text 2, and neither subl.exe nor sublime_text.exe are on your `PATH`. It should point to the full path to your install of sublime_text.exe.
-  * `keep_focus_delay`: this is used if `keep_focus` is set to true. It controls how long (in ms) the delay is between the completion of the `jump_to_pdf` command and the attempt to refocus on Sublime Text. This may need to be adjusted depending on your machine or configuration.
+  * `keep_focus_delay`: this is used if `keep_focus` is set to true. It controls how long (in seconds) the delay is between the completion of the `jump_to_pdf` command and the attempt to refocus on Sublime Text. This may need to be adjusted depending on your machine or configuration.
 
 **Build engine settings**:
 

--- a/README.markdown
+++ b/README.markdown
@@ -369,7 +369,7 @@ The following options are currently available (defaults in parentheses):
 - `fill_auto_trigger` (`true`): ditto, but for package and file inclusion commands (see Fill Helper feature above)
 - `cwl_completion` (`prefixed`): when to activate the cwl completion poput (see LaTeX-cwl feature above)
 - `cwl_list` (empty): list of paths to cwl files
-- `keep_focus` (`true`): if `true`, after compiling a tex file, ST retains the focus; if `false`, the PDF viewer gets the focus. Also note that you can *temporarily* toggle this behavior with `C-l,t,f`. **Note**: If you are on ST2 on either Windows or Linux and you don't have the correct version of `subl` / `subl.exe` on your `PATH`, you will need to set the `sublime_executable` setting for this to work properly. See the **Platform settings** below.
+- `keep_focus` (`true`): if `true`, after compiling a tex file, ST retains the focus; if `false`, the PDF viewer gets the focus. Also note that you can *temporarily* toggle this behavior with `C-l,t,f`. **Note**: If you are on either Windows or Linux you may need to adjust the `sublime_executable` setting for this to work properly. See the **Platform settings** below.
 - `forward_sync` (`true`): if `true`, after compiling a tex file, the PDF viewer is asked to sync to the position corresponding to the current cursor location in ST. You can also *temporarily* toggle this behavior with `C-l,t,s`.
 - `temp_files_exts`: list of file extensions to be considered temporary, and hence deleted using the `C-l, backspace` command.
 - `temp_files_ignored_folders`: subdirectories to skip when deleting temp files.
@@ -380,13 +380,13 @@ The following options are currently available (defaults in parentheses):
 - `windows`-specific settings:
   * `distro`: either `miktex` or `texlive`, depending on your TeX distribution
   * `sumatra`: leave blank or omit if the SumatraPDF executable is in your `PATH` and is called `SumatraPDF.exe`, as in a default installation; otherwise, specify the *full path and file name* of the SumatraPDF executable.
-  * `sublime_executable`: this is used if `keep_focus` is set to true, you are using Sublime Text 2, and neither subl.exe nor sublime_text.exe are on your `PATH`. It should point to the full path to your install of sublime_text.exe.
+  * `sublime_executable`: this is used if `keep_focus` is set to true and the path to your sublime_text executable cannot be discovered automatically. It should point to the full path to your executable `sublime_text.exe`.
   * `keep_focus_delay`: this is used if `keep_focus` is set to true. It controls how long (in seconds) the delay is between the completion of the `jump_to_pdf` command and the attempt to refocus on Sublime Text. This may need to be adjusted depending on your machine or configuration.
 - `linux`-specific settings:
   * `python2` (`""`, i.e. empty string): name of the Python 2 executable. This is useful for systems that ship with both Python 2 and Python 3. The forward/backward search used with Evince require Python 2.
   * `sublime` (`sublime-text`): name of the ST executable. Ubuntu supports both `sublime-text` and `subl`; other distros may vary.
   * `sync_wait` (1.5): when you ask LaTeXTools to do a forward search, and the PDF file is not yet open (for example, right after compiling a tex file for the first time), LaTeXTools first launches evince, then waits a bit for it to come up, and then it performs the forward search. This parameter controls how long LaTeXTools should wait. If you notice that your machine opens the PDF, then sits there doing nothing, and finally performs the search, you can decrease this value to 1.0 or 0.5; if instead the PDF file comes up but the forward search does not seem to happen, increase it to 2.0.
-  * `sublime_executable`: this is used if `keep_focus` is set to true, you are using Sublime Text 2, and neither subl.exe nor sublime_text.exe are on your `PATH`. It should point to the full path to your install of sublime_text.exe.
+  * `sublime_executable`: this is used if `keep_focus` is set to true and the path to your sublime_text executable cannot be discovered automatically. It should point to the full path to your executable `sublime_text`.
   * `keep_focus_delay`: this is used if `keep_focus` is set to true. It controls how long (in seconds) the delay is between the completion of the `jump_to_pdf` command and the attempt to refocus on Sublime Text. This may need to be adjusted depending on your machine or configuration.
 
 **Build engine settings**:

--- a/jumpToPDF.py
+++ b/jumpToPDF.py
@@ -40,7 +40,7 @@ def get_sublime_executable():
 	if sublime.platform() == 'windows':
 		startupinfo = subprocess.STARTUPINFO()
 		startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
-		shell = True
+		shell = _ST3
 
 	version = sublime.version()
 
@@ -121,7 +121,7 @@ class jump_to_pdfCommand(sublime_plugin.TextCommand):
 				if platform == 'windows':
 					startupinfo = subprocess.STARTUPINFO()
 					startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
-					shell = True
+					shell = _ST3
 
 				subprocess.Popen(
 					sublime_command,

--- a/jumpToPDF.py
+++ b/jumpToPDF.py
@@ -80,7 +80,7 @@ class jump_to_pdfCommand(sublime_plugin.TextCommand):
 			s = sublime.load_settings('LaTeXTools.sublime-settings')
 			platform = sublime.platform()
 			plat_settings = s.get(platform, {})
-			wait_time =	plat_settings.get('keep_focus_delay', 500)
+			wait_time = plat_settings.get('keep_focus_delay', 500)
 
 			def keep_focus():
 				startupinfo = None

--- a/jumpToPDF.py
+++ b/jumpToPDF.py
@@ -113,7 +113,7 @@ class jump_to_pdfCommand(sublime_plugin.TextCommand):
 			s = sublime.load_settings('LaTeXTools.sublime-settings')
 			platform = sublime.platform()
 			plat_settings = s.get(platform, {})
-			wait_time = plat_settings.get('keep_focus_delay', 500)
+			wait_time = plat_settings.get('keep_focus_delay', 0.5)
 
 			def keep_focus():
 				startupinfo = None
@@ -131,9 +131,9 @@ class jump_to_pdfCommand(sublime_plugin.TextCommand):
 				)
 
 			if hasattr(sublime, 'set_async_timeout'):
-				sublime.set_async_timeout(keep_focus, wait_time)
+				sublime.set_async_timeout(keep_focus, int(wait_time * 1000))
 			else:
-				sublime.set_timeout(keep_focus, wait_time)
+				sublime.set_timeout(keep_focus, int(wait_time * 1000))
 
 	def run(self, edit, **args):
 		# Check prefs for PDF focus and sync

--- a/jumpToPDF.py
+++ b/jumpToPDF.py
@@ -1,7 +1,6 @@
 # ST2/ST3 compat
 from __future__ import print_function 
 import sublime
-from functools import partial
 if sublime.version() < '3000':
     # we are on ST2 and Python 2.X
 	_ST3 = False
@@ -79,18 +78,19 @@ class jump_to_pdfCommand(sublime_plugin.TextCommand):
 
 		if sublime_command is not None:
 			s = sublime.load_settings('LaTeXTools.sublime-settings')
-			plat_settings = s.get(sublime.platform(), {})
+			platform = sublime.platform()
+			plat_settings = s.get(platform, {})
 			wait_time =	plat_settings.get('keep_focus_delay', 500)
 
 			def keep_focus():
 				startupinfo = None
 				shell = False
-				if sublime.platform() == 'windows':
+				if platform == 'windows':
 					startupinfo = subprocess.STARTUPINFO()
 					startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
 					shell = True
 
-				subprocess.call(
+				subprocess.Popen(
 					sublime_command,
 					startupinfo=startupinfo,
 					shell=shell,

--- a/jumpToPDF.py
+++ b/jumpToPDF.py
@@ -1,6 +1,7 @@
 # ST2/ST3 compat
 from __future__ import print_function 
 import sublime
+import sys
 if sublime.version() < '3000':
     # we are on ST2 and Python 2.X
 	_ST3 = False
@@ -59,6 +60,10 @@ def get_sublime_executable():
 	# are we on ST3
 	if hasattr(sublime, 'executable_path'):
 		get_sublime_executable.result = sublime.executable_path()
+		return get_sublime_executable.result
+	# in ST2 the Python executable is actually "sublime_text"
+	elif sys.executable != 'python' and os.path.isabs(sys.executable):
+		get_sublime_executable.result = sys.executable
 		return get_sublime_executable.result
 
 	# guess-work for ST2

--- a/jumpToPDF.py
+++ b/jumpToPDF.py
@@ -39,23 +39,31 @@ def get_sublime_executable():
 		startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
 		shell = True
 
-	if subprocess.call(
-			['subl', '-v'],
-			startupinfo=startupinfo,
-			shell=shell,
-			env=os.environ
-		) == 0:
-		get_sublime_executable.result = 'subl'
-		return get_sublime_executable.result
+	processes = ['subl', 'sublime_text']
+	for process in processes:
+		if subprocess.call(
+				[process, '-v'],
+				startupinfo=startupinfo,
+				shell=shell,
+				env=os.environ
+			) == 0:
+				get_sublime_executable.result = process
+				return get_sublime_executable.result
 
-	if subprocess.call(
-			['sublime_text', '-v'],
-			startupinfo=startupinfo,
-			shell=shell,
-			env=os.environ
-		) == 0:
-		get_sublime_executable.result = 'sublime_text'
-		return get_sublime_executable.result
+	# guess the default install location for ST2 on Windows
+	if sublime.platform() == 'windows':
+		st2_dir = os.path.expandvars("%PROGRAMFILES%\\Sublime Text 2")
+		if os.path.exists(st2_dir):
+			for process in processes:
+				process = os.path.join(st2_dir, process)
+				if subprocess.call(
+					[process, '-v'],
+					startupinfo=startupinfo,
+					shell=shell,
+					env=os.environ
+				) == 0:
+					get_sublime_executable.result = process
+					return get_sublime_executable.result
 
 	get_sublime_executable.result = None
 

--- a/jumpToPDF.py
+++ b/jumpToPDF.py
@@ -17,11 +17,10 @@ import sublime_plugin, os.path, subprocess, time
 # is set.
 def get_sublime_executable():
 	s = sublime.load_settings('LaTeXTools.sublime-settings')
-	sublime_executable = sublime.active_window().active_view().\
-		settings().get('sublime_executable',
-			s.get('sublime_executable', None))
+	plat_settings = s.get(sublime.platform(), {})
+	sublime_executable = plat_settings.get('sublime_executable', None)
 
-	if sublime_executable is not None:
+	if sublime_executable:
 		return sublime_executable
 
 	# we cache the results of the other checks, if possible
@@ -80,8 +79,8 @@ class jump_to_pdfCommand(sublime_plugin.TextCommand):
 
 		if sublime_command is not None:
 			s = sublime.load_settings('LaTeXTools.sublime-settings')
-			wait_time = view.settings().get('keep_focus_delay',
-				s.get('keep_focus_delay', 500))
+			plat_settings = s.get(sublime.platform(), {})
+			wait_time =	plat_settings.get('keep_focus_delay', 500)
 
 			def keep_focus():
 				startupinfo = None

--- a/jumpToPDF.py
+++ b/jumpToPDF.py
@@ -165,9 +165,8 @@ class jump_to_pdfCommand(sublime_plugin.TextCommand):
 			print ("Windows, Calling Sumatra")
 
 			si = subprocess.STARTUPINFO()
-			if setfocus == 0:
-				si.dwFlags |= subprocess.STARTF_USESHOWWINDOW
-				si.wShowWindow = 4 #constant for SHOWNOACTIVATE
+			si.dwFlags |= subprocess.STARTF_USESHOWWINDOW
+			si.wShowWindow = 4 #constant for SHOWNOACTIVATE
 
 			su_binary = prefs_win.get("sumatra", "SumatraPDF.exe") or 'SumatraPDF.exe'
 			startCommands = [su_binary, "-reuse-instance"]


### PR DESCRIPTION
This is an adaptation and generalisation of @r-stein's suggestion from #495. Basically if `keep_focus` is set on Windows or Linux, it runs either `sublime_text` or `subl` to regain focus after a (configurable) short delay.

I've added some code to work out where the appropriate executable is, though it should be auto-detected on *most* configurations. The only worrying setup is ST2 where `subl` is not available on the `PATH`, in which, case the platform-specific `sublime_executable` setting must be set appropriately. Alternatively, the `sublime_executable` setting can be set and the auto-detect code will not be run.