### PR TITLE
Script Builder

### DIFF
--- a/builders/scriptBuilder.py
+++ b/builders/scriptBuilder.py
@@ -63,6 +63,8 @@ class ScriptBuilder(PdfBuilder):
 				"You MUST set a command in your LaTeXTools.sublime-settings " +
 				"file before launching the script builder."
 			)
+			# I'm not sure this is the best way to handle things...
+			raise StopIteration()
 
 		if isinstance(self.cmd, strbase):
 			self.cmd = [self.cmd]


### PR DESCRIPTION
This pull request adds an actual functioning script builder, at least as far as I understand the intention of it. It is able to run simple lists of commands, configurable in the `LaTeXTools.sublime-settings` file or even launching external build tools. There's some fairly extensive docs added to the README on how to configure it, etc., and some warnings on the assumptions that LaTeXTools makes.

The builder works by constructing and yielding `Popen()` objects to the `make_pdf` command, which has been modified to accept `Popen` objects *in addition to* strings or lists.