### PR TITLE
CWL completion for environment names

### DIFF
--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -68,6 +68,15 @@ LaTeX Package keymap for Linux
 				"operand": "(?:\\\\include)|(?:\\\\input)|(?:\\\\includegraphics(?:\\[[^{}\\[\\]]\\])?)|(?:\\\\addbibresource(?:\\[[^{}\\[\\]]\\])?)|(?:\\\\bibliography)|(?:\\\\documentclass(?:\\[[^{}\\[\\]]\\])?)|(?:\\\\usepackage(?:\\[[^{}\\[\\]]\\])?)|(?:\\\\bibliographystyle)", "match_all": true}],
 		"command": "latex_fill_input", "args": {"insert_char": "{"}},
 
+	{	"keys": ["{"],
+		"context":  [
+			{"key": "setting.disable_latex_ref_cite_auto_trigger", "operator": "not_equal", "operand": true},
+			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"},
+			{"key": "selection_empty", "operator": "equal", "operand": true, "match_all": true},
+			{"key": "preceding_text", "operator": "regex_contains",
+				"operand": "(?:\\\\begin(?:\\[[^{}\\[\\]]\\])?)|(?:\\\\end)", "match_all": true}],
+		"command": "latex_fill_env", "args": {"insert_char": "{"}},
+
 	// Toggle autocomplete
 	{ 	"keys": ["ctrl+l","t","a", "r"],
 		"context":  [
@@ -81,6 +90,10 @@ LaTeX Package keymap for Linux
 		"context":  [
 			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"}],
 		"command": "toggle_auto", "args": {"which": "fill"}},
+	{ 	"keys": ["ctrl+l","t","a", "e"],
+		"context":  [
+			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"}],
+		"command": "toggle_auto", "args": {"which": "env"}},
 
 	// View PDF, jump to point, toggle editor/viewer focus and syncing behavior
 	{ 	"keys": ["ctrl+l","v"],

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -68,6 +68,15 @@ LaTeX Package keymap for OS X
 				"operand": "(?:\\\\include)|(?:\\\\input)|(?:\\\\includegraphics(?:\\[[^{}\\[\\]]\\])?)|(?:\\\\addbibresource(?:\\[[^{}\\[\\]]\\])?)|(?:\\\\bibliography)|(?:\\\\documentclass(?:\\[[^{}\\[\\]]\\])?)|(?:\\\\usepackage(?:\\[[^{}\\[\\]]\\])?)|(?:\\\\bibliographystyle)", "match_all": true}],
 		"command": "latex_fill_input", "args": {"insert_char": "{"}},
 
+	{	"keys": ["{"],
+		"context":  [
+			{"key": "setting.disable_latex_ref_cite_auto_trigger", "operator": "not_equal", "operand": true},
+			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"},
+			{"key": "selection_empty", "operator": "equal", "operand": true, "match_all": true},
+			{"key": "preceding_text", "operator": "regex_contains",
+				"operand": "(?:\\\\begin(?:\\[[^{}\\[\\]]\\])?)|(?:\\\\end)", "match_all": true}],
+		"command": "latex_fill_env", "args": {"insert_char": "{"}},
+
 	// Toggle autocomplete
 	{ 	"keys": ["super+l","t","a", "r"],
 		"context":  [
@@ -81,6 +90,10 @@ LaTeX Package keymap for OS X
 		"context":  [
 			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"}],
 		"command": "toggle_auto", "args": {"which": "fill"}},
+	{ 	"keys": ["super+l","t","a", "e"],
+		"context":  [
+			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"}],
+		"command": "toggle_auto", "args": {"which": "env"}},
 
 	// View PDF, jump to point, toggle editor/viewer focus
 	{ 	"keys": ["super+l","v"],

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -68,6 +68,15 @@ LaTeX Package keymap for Windows
 				"operand": "(?:\\\\include)|(?:\\\\input)|(?:\\\\includegraphics(?:\\[[^{}\\[\\]]\\])?)|(?:\\\\addbibresource(?:\\[[^{}\\[\\]]\\])?)|(?:\\\\bibliography)|(?:\\\\documentclass(?:\\[[^{}\\[\\]]\\])?)|(?:\\\\usepackage(?:\\[[^{}\\[\\]]\\])?)|(?:\\\\bibliographystyle)", "match_all": true}],
 		"command": "latex_fill_input", "args": {"insert_char": "{"}},
 
+	{	"keys": ["{"],
+		"context":  [
+			{"key": "setting.disable_latex_ref_cite_auto_trigger", "operator": "not_equal", "operand": true},
+			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"},
+			{"key": "selection_empty", "operator": "equal", "operand": true, "match_all": true},
+			{"key": "preceding_text", "operator": "regex_contains",
+				"operand": "(?:\\\\begin(?:\\[[^{}\\[\\]]\\])?)|(?:\\\\end)", "match_all": true}],
+		"command": "latex_fill_env", "args": {"insert_char": "{"}},
+
 	// Toggle autocomplete
 	{ 	"keys": ["ctrl+l","t","a", "r"],
 		"context":  [
@@ -81,6 +90,10 @@ LaTeX Package keymap for Windows
 		"context":  [
 			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"}],
 		"command": "toggle_auto", "args": {"which": "fill"}},
+	{ 	"keys": ["ctrl+l","t","a", "e"],
+		"context":  [
+			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"}],
+		"command": "toggle_auto", "args": {"which": "env"}},
 
 	// View PDF, jump to point, toggle editor/viewer focus
 	{ 	"keys": ["ctrl+l","v"],

--- a/LaTeXTools.default-settings
+++ b/LaTeXTools.default-settings
@@ -25,6 +25,11 @@
 	// files. You can also use toggle: C-l,t,a,f
 	"fill_auto_trigger": true,
 
+	// Fill-helper autocompletion trigger for environment names after \begin{ and \end{
+	// this requires the LaTeX-cwl package and might not have a complete list of all environments.
+	// You can also use toggle: C-l,t,a,e
+	"env_auto_trigger": false,
+
 	// Keep focus on Sublime Text after building (true) or switch to PDF viewer (false)
 	// If you are on Windows or Linux and using ST2, you may need to set the
 	// "sublime_executable" setting for this to work in your platform settings.

--- a/latexFillAll.py
+++ b/latexFillAll.py
@@ -10,11 +10,13 @@ if sublime.version() < '3000':
     from latex_cite_completions import OLD_STYLE_CITE_REGEX, NEW_STYLE_CITE_REGEX, match
     from latex_ref_completions import OLD_STYLE_REF_REGEX, NEW_STYLE_REF_REGEX
     from latex_input_completions import TEX_INPUT_FILE_REGEX
+    from latex_cwl_completions import BEGIN_END_BEFORE_REGEX
 else:
     _ST3 = True
     from .latex_cite_completions import OLD_STYLE_CITE_REGEX, NEW_STYLE_CITE_REGEX, match
     from .latex_ref_completions import OLD_STYLE_REF_REGEX, NEW_STYLE_REF_REGEX
     from .latex_input_completions import TEX_INPUT_FILE_REGEX
+    from .latex_cwl_completions import BEGIN_END_BEFORE_REGEX
 
 # used to flag whether command is triggered for cite
 TRIGGER_CITE = False
@@ -67,9 +69,12 @@ class LatexFillAllCommand(sublime_plugin.TextCommand):
             else:
                 view.run_command("latex_fill_input")
 
+        if BEGIN_END_BEFORE_REGEX.match(line):
+            view.run_command("latex_fill_env")
+
 class OnLatexFillAllReplacement(sublime_plugin.EventListener):
     # This trigger is used to delete the last "}"
-    # character inserted by latex_cite command 
+    # character inserted by latex_cite command
     # when modifing the keyword between two commas.
     def on_selection_modified(self, view):
         global TRIGGER_CITE

--- a/latex_cwl_completions.py
+++ b/latex_cwl_completions.py
@@ -30,6 +30,19 @@ ENV_DONOT_AUTO_COM = [
 
 CWL_COMPLETION = False
 
+# regex to detect that the cursor is predecended by a \begin{
+BEGIN_END_BEFORE_REGEX = re.compile(
+    r"\\(?:begin|end)"
+    r"(?:\[[^\]]*\])?"
+    r"\{$"
+)
+# regex to parse a environment line from the cwl file
+# only search for \end to create a list without duplicates
+ENVIRONMENT_REGEX = re.compile(
+    r"\\end"
+    r"\{(?P<name>[^\}]+)\}"
+)
+
 
 def _is_snippet(completion_entry):
     """
@@ -56,17 +69,26 @@ class LatexCwlCompletion(sublime_plugin.EventListener):
             char_before = char_before.encode("utf-8")
         is_prefixed = char_before == "\\"
 
+        line = view.substr(get_Region(view.line(point).begin(), point_before))
+        is_env = bool(BEGIN_END_BEFORE_REGEX.match(line))
+
         completion_level = "prefixed"  # default completion level is "prefixed"
-        completion_level = get_setting("command_completion",
-                                       completion_level)
+        completion_level = get_setting("command_completion", completion_level)
 
         do_complete = {
             "never": False,
-            "prefixed": is_prefixed,
+            "prefixed": is_prefixed or is_env,
             "always": True
-        }.get(completion_level, is_prefixed)
+        }.get(completion_level, is_prefixed or is_env)
+
         if not do_complete:
             return []
+
+        # if it is inside the begin oder end of an env,
+        # create and return the available environments
+        if is_env:
+            completions = parse_cwl_file(parse_line_as_environment)
+            return completions
 
         line = view.substr(get_Region(view.line(point).a, point))
         line = line[::-1]
@@ -76,7 +98,7 @@ class LatexCwlCompletion(sublime_plugin.EventListener):
             if match(rex, line) != None:
                 return []
 
-        completions = parse_cwl_file()
+        completions = parse_cwl_file(parse_line_as_command)
         # autocompleting with slash already on line
         # this is necessary to work around a short-coming in ST where having a keyed entry
         # appears to interfere with it recognising that there is a \ already on the line
@@ -117,7 +139,20 @@ class LatexCwlCompletion(sublime_plugin.EventListener):
                 })
                 g_settings.set("auto_complete_triggers", acts)
 
-def parse_cwl_file():
+
+def parse_line_as_environment(line):
+    m = ENVIRONMENT_REGEX.match(line)
+    if not m:
+        return
+    env_name = m.group("name")
+    return env_name, env_name
+
+
+def parse_line_as_command(line):
+    return line, parse_keyword(line)
+
+
+def parse_cwl_file(parse_line):
     # Get cwl file list
     # cwl_path = sublime.packages_path() + "/LaTeX-cwl"
     cwl_file_list = get_setting('cwl_list',
@@ -156,6 +191,7 @@ def parse_cwl_file():
                 finally:
                     f.close()
 
+        method = os.path.splitext(os.path.basename(cwl))[0]
         for line in s.split('\n'):
             line = line.strip()
             if line == '':
@@ -163,9 +199,12 @@ def parse_cwl_file():
             if line[0] == '#':
                 continue
 
-            keyword = line.strip()
-            method = os.path.splitext(os.path.basename(cwl))[0]
-            item = (u'%s\t%s' % (keyword, method), parse_keyword(keyword))
+            result = parse_line(line)
+            if result is None:
+                continue
+            (keyword, insertion) = result
+            item = (u'%s\t%s' % (keyword, method), insertion)
+
             completions.append(item)
 
     return completions

--- a/latex_cwl_completions.py
+++ b/latex_cwl_completions.py
@@ -32,9 +32,12 @@ CWL_COMPLETION = False
 
 # regex to detect that the cursor is predecended by a \begin{
 BEGIN_END_BEFORE_REGEX = re.compile(
-    r"\\(?:begin|end)"
+    r"^"
+    r"[^\}\{\\]*"
+    r"\{"
     r"(?:\[[^\]]*\])?"
-    r"\{$"
+    r"(?:dne|nigeb)"
+    r"\\"
 )
 # regex to parse a environment line from the cwl file
 # only search for \end to create a list without duplicates
@@ -69,7 +72,8 @@ class LatexCwlCompletion(sublime_plugin.EventListener):
             char_before = char_before.encode("utf-8")
         is_prefixed = char_before == "\\"
 
-        line = view.substr(get_Region(view.line(point).begin(), point_before))
+        line = view.substr(get_Region(view.line(point).begin(), point))
+        line = line[::-1]
         is_env = bool(BEGIN_END_BEFORE_REGEX.match(line))
 
         completion_level = "prefixed"  # default completion level is "prefixed"
@@ -89,9 +93,6 @@ class LatexCwlCompletion(sublime_plugin.EventListener):
         if is_env:
             completions = parse_cwl_file(parse_line_as_environment)
             return completions
-
-        line = view.substr(get_Region(view.line(point).a, point))
-        line = line[::-1]
 
         # Do not do completions in actions
         for rex in ENV_DONOT_AUTO_COM:

--- a/latex_cwl_completions.py
+++ b/latex_cwl_completions.py
@@ -30,6 +30,10 @@ ENV_DONOT_AUTO_COM = [
 
 CWL_COMPLETION = False
 
+
+def is_cwl_available():
+    return CWL_COMPLETION
+
 # regex to detect that the cursor is predecended by a \begin{
 BEGIN_END_BEFORE_REGEX = re.compile(
     r"^"

--- a/latex_env_completions.py
+++ b/latex_env_completions.py
@@ -42,7 +42,16 @@ class LatexFillEnvCommand(sublime_plugin.TextCommand):
                 add_closing_bracket(view, edit)
                 return
 
-        prefix = get_current_word(view, point)[0] if not insert_char else ""
+        if not insert_char:
+            # only use the prefix if all cursors have the same
+            prefix = get_current_word(view, point)[0]
+            for sel in view.sel():
+                other_prefix = get_current_word(view, sel.b)[0]
+                if other_prefix != prefix:
+                    prefix = ""
+                    break
+        else:
+            prefix = ""
 
         completions = parse_cwl_file(parse_line_as_environment)
         if prefix:
@@ -59,9 +68,11 @@ class LatexFillEnvCommand(sublime_plugin.TextCommand):
                 key += "}"
 
             if prefix:
-                startpoint = point - len(prefix)
-                endpoint = point
-                view.run_command('latex_tools_replace', {'a': startpoint, 'b': endpoint, 'replacement': key})
+                for sel in view.sel():
+                    point = sel.b
+                    startpoint = point - len(prefix)
+                    endpoint = point
+                    view.run_command('latex_tools_replace', {'a': startpoint, 'b': endpoint, 'replacement': key})
             else:
                 view.run_command("insert", {"characters": key})
 

--- a/latex_env_completions.py
+++ b/latex_env_completions.py
@@ -1,0 +1,72 @@
+import sublime
+import sublime_plugin
+
+
+try:
+    _ST3 = True
+    from .latextools_utils import get_setting
+    from .latex_input_completions import add_closing_bracket
+    from .latex_cwl_completions import parse_cwl_file, parse_line_as_environment, is_cwl_available
+    from .latexFillAll import get_current_word
+except:
+    _ST3 = False
+    from latextools_utils import get_setting
+    from latex_input_completions import add_closing_bracket
+    from latex_cwl_completions import parse_cwl_file, parse_line_as_environment, is_cwl_available
+    from latexFillAll import get_current_word
+
+
+class LatexFillEnvCommand(sublime_plugin.TextCommand):
+    def run(self, edit, insert_char=""):
+        view = self.view
+        point = view.sel()[0].b
+        # Only trigger within LaTeX
+        # Note using score_selector rather than match_selector
+        if not view.score_selector(point, "text.tex.latex"):
+            return
+
+        if not is_cwl_available():
+            if insert_char:
+                view.insert(edit, point, insert_char)
+                add_closing_bracket(view, edit)
+            return
+
+        if insert_char:
+            # append the insert_char to the end of the current line if it
+            # is given so this works when being triggered by pressing "{"
+            point += view.insert(edit, point, insert_char)
+
+            do_completion = get_setting("env_auto_trigger", False)
+
+            if not do_completion:
+                add_closing_bracket(view, edit)
+                return
+
+        prefix = get_current_word(view, point)[0] if not insert_char else ""
+
+        completions = parse_cwl_file(parse_line_as_environment)
+        if prefix:
+            completions = [c for c in completions if c[1].startswith(prefix)]
+
+        show_entries = [c[0].split("\t") for c in completions]
+
+        def on_done(index):
+            if index < 0:
+                return
+            key = completions[index][1]
+            # close bracket
+            if insert_char:
+                key += "}"
+
+            if prefix:
+                startpoint = point - len(prefix)
+                endpoint = point
+                view.run_command('latex_tools_replace', {'a': startpoint, 'b': endpoint, 'replacement': key})
+            else:
+                view.run_command("insert", {"characters": key})
+
+        # autocomplete bracket if we aren't doing anything
+        if not show_entries and insert_char:
+            add_closing_bracket(view, edit)
+        else:
+            view.window().show_quick_panel(show_entries, on_done)

--- a/latex_input_completions.py
+++ b/latex_input_completions.py
@@ -191,6 +191,9 @@ def parse_completions(view, line):
     return prefix, completions
 
 def add_closing_bracket(view, edit):
+    # only add the closing bracked if auto match is enabled
+    if not view.settings().get("auto_match_enabled", True):
+        return
     caret = view.sel()[0].b
     view.insert(edit, caret, "}")
     view.sel().subtract(view.sel()[0])
@@ -255,7 +258,7 @@ class LatexFillInputCommand(sublime_plugin.TextCommand):
             point += view.insert(edit, point, insert_char)
 
             do_completion = get_setting("fill_auto_trigger", True)
-            
+
             if not do_completion:
                 add_closing_bracket(view, edit)
                 return


### PR DESCRIPTION
Changes the cwl completion inside the `\begin` and `\end` command to provide the environment names.
![cwl_env_completion](https://cloud.githubusercontent.com/assets/12573621/11747330/eef13dce-a022-11e5-8542-9a36a6ba33c3.gif)

Integrates into fill-all helper:
![cwl_env_fillall_completion](https://cloud.githubusercontent.com/assets/12573621/11762535/57481330-a0ea-11e5-98dd-db096588a18f.gif)


Technical detail:
The environment names are extracted from the `\end{env}` lines in the cwl file, because this directly generates a list without duplicates. This should be adequate, because every environment needs the `\end`-command.

*Edit:*
Added Fill-All Helper