### PR TITLE
Bugfix: Remove subprocess.Popen shell-argument in the "jump to image file" command

### DIFF
--- a/jumpto_tex_file.py
+++ b/jumpto_tex_file.py
@@ -177,7 +177,7 @@ def _jumpto_image_file(view, window, tex_root, file_name):
             else:
                 command.append(file_path)
             print("RUN: {0}".format(command))
-            subprocess.Popen(command, shell=True)
+            subprocess.Popen(command)
 
     psystem = sublime.platform()
     commands = settings.get("open_image_command", {})\


### PR DESCRIPTION
This fixes https://github.com/SublimeText/LaTeXTools/issues/624. It just removes the shell argument in the `subprocess.Popen`-command for opening image files, because it seems not to be necessary and produces errors on linux.
*(I added this argument before splitting the argument string into an argument array.)*