### PR TITLE
Support TEXroot relative to project file

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -144,16 +144,21 @@ The default ST Build command takes care of the following:
 
 **Project files** are fully supported! Some of the options related to building `tex` files are described here. However, you should consult the [subsection on project-specific settings](#project-specific-settings) for further details. 
 
-**Multi-file documents** are supported as follows. If the first line in the current file consists of the text `%!TEX root = <master file name>`, then tex & friends are invoked on the specified master file, instead of the current one. Note: the only file that gets saved automatically is the current one. Also, the master file name **must** have a `.tex` extension, or it won't be recognized. As an alternative, if you use a project file, you can set the `TEXroot` option (under `settings`):
+**Multi-file documents** are supported as follows. If the first line in the current file consists of the text `%!TEX root = <master file name>`, then tex & friends are invoked on the specified master file, instead of the current one. Note: the only file that gets saved automatically is the current one. Also, the master file name **must** have a valid tex extension (i.e., one configured in the `tex_file_exts` settings), or it won't be recognized. 
+
+As an alternative, to using the `%!TEX root = <master file name>` syntax, if you use a Sublime project, you can set the `TEXroot` option (under `settings`):
 	
-	{
-		... <folder-related settings> ...
+```json
+{
+	... <folder-related settings> ...
 
-		"settings": {
-			"TEXroot": "yourfilename.tex"
-		}
+	"settings": {
+		"TEXroot": "yourfilename.tex"
 	}
+}
+```
 
+Note that if you specify a relative path as the `TEXroot` in the project file, the path is determined *relative to the location of the project file itself*. It may be less ambiguous to specify an absolute path to the `TEXroot` if possible.
 
 **TeX engine selection** is supported. If the first line of the current file consists of the text `%!TEX program = <program>`, where `program` is `pdflatex`, `lualatex` or `xelatex`, the corresponding engine is selected. If no such directive is specified, `pdflatex` is the default. Multi-file documents are supported: the directive must be in the *root* (i.e. master) file. Also, for compatibility with TeXshop, you can use `TS-program` instead of `program`. **Note**: for this to work, you must **not** customize the `command` option in `LaTeXTools.sublime-settings`. If you do, you will not get this functionality. Finally, if you use project files, the `program` builder setting can also be customized there, under `settings`.
 

--- a/getTeXRoot.py
+++ b/getTeXRoot.py
@@ -1,5 +1,6 @@
 # ST2/ST3 compat
-from __future__ import print_function 
+from __future__ import print_function
+
 import sublime
 if sublime.version() < '3000':
 	# we are on ST2 and Python 2.X
@@ -10,8 +11,113 @@ else:
 	from .latextools_utils.is_tex_file import get_tex_extensions
 
 
-import os.path, re
-import codecs
+import os.path
+import re
+import json
+
+
+# normalizes the paths stored in sublime session files on Windows
+# from:
+#     /c/path/to/file.ext
+# to:
+#     c:\path\to\file.ext
+def normalize_sublime_path(path):
+	if sublime.platform() == 'windows':
+		return os.path.normpath(
+			path.lstrip('/').replace('/', ':/', 1)
+		)
+	else:
+		return path
+
+
+# long, complex hack for ST2 to load the project file from the current session
+def get_project_file_name(view):
+	window_id = view.window().id()
+	if window_id is None:
+		return None
+
+	session = os.path.normpath(
+		os.path.join(
+			sublime.packages_path(),
+			'..',
+			'Settings',
+			'Session.sublime_session'
+		)
+	)
+
+	auto_save_session = os.path.normpath(
+		os.path.join(
+			sublime.packages_path(),
+			'..',
+			'Settings',
+			'Auto Save Session.sublime_session'
+		)
+	)
+
+	session = auto_save_session if os.path.exists(auto_save_session) else session
+
+	if not os.path.exists(session):
+		return None
+
+	project_file = None
+
+	# we tell that we have found the current project's project file by
+	# looking at the folders registered for that project and comparing it
+	# to the open directorys in the current window
+	found_all_folders = False
+	try:
+		with open(session, 'r') as f:
+			session_data = f.read().replace('\t', ' ')
+		j = json.loads(session_data, strict=False)
+		projects = j.get('workspaces', {}).get('recent_workspaces', [])
+
+		for project_file in projects:
+			found_all_folders = True
+
+			project_file = normalize_sublime_path(project_file)
+			try:
+				with open(project_file, 'r') as fd:
+					project_json = json.loads(fd.read(), strict=False)
+
+				if 'folders' in project_json:
+					project_folders = project_json['folders']
+					for directory in view.window().folders():
+						found = False
+						for folder in project_folders:
+							folder_path = normalize_sublime_path(folder['path'])
+							# handle relative folder paths
+							if not os.path.isabs(folder_path):
+								folder_path = os.path.normpath(
+									os.path.join(os.path.dirname(project_file), folder_path)
+								)
+
+							if folder_path == directory:
+								found = True
+								break
+
+						if not found:
+							found_all_folders = False
+							break
+
+					if found_all_folders:
+						break
+			except:
+				found_all_folders = False
+	except:
+		pass
+
+	if not found_all_folders:
+		project_file = None
+
+	if (
+		project_file is None or
+		not project_file.endswith('.sublime-project') or
+		not os.path.exists(project_file)
+	):
+		return None
+
+	print('Using project file: %s' % project_file)
+	return project_file
 
 
 # Parse magic comments to retrieve TEX root
@@ -20,46 +126,29 @@ import codecs
 # and the current buffer is an unnamed unsaved file)
 
 # Contributed by Sam Finn
-
 def get_tex_root(view):
-	try:
-		root = os.path.abspath(view.settings().get('TEXroot'))
-		if os.path.isfile(root):
-			print("Main file defined in project settings : " + root)
-			return root
-	except:
-		pass
-
-
 	texFile = view.file_name()
 	root = texFile
-	if texFile is None:
-		# We are in an unnamed, unsaved file.
-		# Read from the buffer instead.
-		if view.substr(0) != '%':
-			return None
-		reg = view.find(r"^%[^\n]*(\n%[^\n]*)*", 0)
-		if not reg:
-			return None
-		line_regs = view.lines(reg)
-		lines = map(view.substr, line_regs)
-		is_file = False
 
-	else:
-		# This works on ST2 and ST3, but does not automatically convert line endings.
-		# We should be OK though.
-		lines = codecs.open(texFile, "r", "UTF-8")
-		is_file = True
+	lines = view.substr(
+		sublime.Region(0, view.size())
+	).split('\n')
 
 	for line in lines:
+		# remove any leading spaces
+		line = line.lstrip()
 		if not line.startswith('%'):
 			break
 		else:
 			# We have a comment match; check for a TEX root match
 			tex_exts = '|'.join([re.escape(ext) for ext in get_tex_extensions()])
-			mroot = re.match(r"(?i)%\s*!TEX\s+root *= *(.*({0}))\s*$".format(tex_exts), line)
+			mroot = re.match(
+				r"(?iu)%+\s*!TEX\s+root *= *(.*({0}))\s*$".format(tex_exts),
+				line
+			)
+
 			if mroot:
-				# we have a TEX root match 
+				# we have a TEX root match
 				# Break the match into path, file and extension
 				# Create TEX root file name
 				# If there is a TEX root path, use it
@@ -67,11 +156,36 @@ def get_tex_root(view):
 				root = mroot.group(1)
 				if not os.path.isabs(root) and texFile is not None:
 					(texPath, texName) = os.path.split(texFile)
-					root = os.path.join(texPath,root)
+					root = os.path.join(texPath, root)
 				root = os.path.normpath(root)
 				break
 
-	if is_file: # Not very Pythonic, but works...
-		lines.close()
+	if root == texFile:
+		root = get_tex_root_from_settings(view)
+		if root is not None:
+			return root
+		return texFile
+
+	return root
+
+
+def get_tex_root_from_settings(view):
+	root = view.settings().get('TEXroot', None)
+
+	if root is not None:
+		if os.path.isabs(root):
+			if os.path.isfile(root):
+				return root
+		else:
+			try:
+				proj_file = view.window().project_file_name()
+			except AttributeError:
+				proj_file = get_project_file_name(view)
+
+			if proj_file:
+				project_dir = os.path.dirname(proj_file)
+				root_path = os.path.normpath(os.path.join(project_dir, root))
+				if os.path.isfile(root_path):
+					return root_path
 
 	return root

--- a/getTeXRoot.py
+++ b/getTeXRoot.py
@@ -6,119 +6,14 @@ if sublime.version() < '3000':
 	# we are on ST2 and Python 2.X
 	_ST3 = False
 	from latextools_utils.is_tex_file import get_tex_extensions
+	from latextools_utils.sublime import get_project_file_name
 else:
 	_ST3 = True
 	from .latextools_utils.is_tex_file import get_tex_extensions
-
+	from .latextools_utils.sublime import get_project_file_name
 
 import os.path
 import re
-import json
-
-
-# normalizes the paths stored in sublime session files on Windows
-# from:
-#     /c/path/to/file.ext
-# to:
-#     c:\path\to\file.ext
-def normalize_sublime_path(path):
-	if sublime.platform() == 'windows':
-		return os.path.normpath(
-			path.lstrip('/').replace('/', ':/', 1)
-		)
-	else:
-		return path
-
-
-# long, complex hack for ST2 to load the project file from the current session
-def get_project_file_name(view):
-	window_id = view.window().id()
-	if window_id is None:
-		return None
-
-	session = os.path.normpath(
-		os.path.join(
-			sublime.packages_path(),
-			'..',
-			'Settings',
-			'Session.sublime_session'
-		)
-	)
-
-	auto_save_session = os.path.normpath(
-		os.path.join(
-			sublime.packages_path(),
-			'..',
-			'Settings',
-			'Auto Save Session.sublime_session'
-		)
-	)
-
-	session = auto_save_session if os.path.exists(auto_save_session) else session
-
-	if not os.path.exists(session):
-		return None
-
-	project_file = None
-
-	# we tell that we have found the current project's project file by
-	# looking at the folders registered for that project and comparing it
-	# to the open directorys in the current window
-	found_all_folders = False
-	try:
-		with open(session, 'r') as f:
-			session_data = f.read().replace('\t', ' ')
-		j = json.loads(session_data, strict=False)
-		projects = j.get('workspaces', {}).get('recent_workspaces', [])
-
-		for project_file in projects:
-			found_all_folders = True
-
-			project_file = normalize_sublime_path(project_file)
-			try:
-				with open(project_file, 'r') as fd:
-					project_json = json.loads(fd.read(), strict=False)
-
-				if 'folders' in project_json:
-					project_folders = project_json['folders']
-					for directory in view.window().folders():
-						found = False
-						for folder in project_folders:
-							folder_path = normalize_sublime_path(folder['path'])
-							# handle relative folder paths
-							if not os.path.isabs(folder_path):
-								folder_path = os.path.normpath(
-									os.path.join(os.path.dirname(project_file), folder_path)
-								)
-
-							if folder_path == directory:
-								found = True
-								break
-
-						if not found:
-							found_all_folders = False
-							break
-
-					if found_all_folders:
-						break
-			except:
-				found_all_folders = False
-	except:
-		pass
-
-	if not found_all_folders:
-		project_file = None
-
-	if (
-		project_file is None or
-		not project_file.endswith('.sublime-project') or
-		not os.path.exists(project_file)
-	):
-		return None
-
-	print('Using project file: %s' % project_file)
-	return project_file
-
 
 # Parse magic comments to retrieve TEX root
 # Stops searching for magic comments at first non-comment line of file
@@ -177,10 +72,7 @@ def get_tex_root_from_settings(view):
 			if os.path.isfile(root):
 				return root
 		else:
-			try:
-				proj_file = view.window().project_file_name()
-			except AttributeError:
-				proj_file = get_project_file_name(view)
+			proj_file = get_project_file_name(view)
 
 			if proj_file:
 				project_dir = os.path.dirname(proj_file)

--- a/latextools_utils/__init__.py
+++ b/latextools_utils/__init__.py
@@ -2,5 +2,7 @@ from __future__ import print_function
 
 try:
 	from latextools_utils.settings import get_setting
+	from latextools_utils import sublime
 except ImportError:
 	from .settings import get_setting
+	from . import sublime

--- a/latextools_utils/sublime.py
+++ b/latextools_utils/sublime.py
@@ -1,0 +1,117 @@
+import json
+import os.path
+import sublime
+
+
+__all__ = ['normalize_path', 'get_project_file_name']
+
+
+# normalizes the paths stored in sublime session files on Windows
+# from:
+#     /c/path/to/file.ext
+# to:
+#     c:\path\to\file.ext
+def normalize_path(path):
+	if sublime.platform() == 'windows':
+		return os.path.normpath(
+			path.lstrip('/').replace('/', ':/', 1)
+		)
+	else:
+		return path
+
+
+def get_project_file_name(view):
+	try:
+		return view.window().project_file_name()
+	except AttributeError:
+		return _get_project_file_name(view)
+
+
+# long, complex hack for ST2 to load the project file from the current session
+def _get_project_file_name(view):
+	window_id = view.window().id()
+	if window_id is None:
+		return None
+
+	session = os.path.normpath(
+		os.path.join(
+			sublime.packages_path(),
+			'..',
+			'Settings',
+			'Session.sublime_session'
+		)
+	)
+
+	auto_save_session = os.path.normpath(
+		os.path.join(
+			sublime.packages_path(),
+			'..',
+			'Settings',
+			'Auto Save Session.sublime_session'
+		)
+	)
+
+	session = auto_save_session if os.path.exists(auto_save_session) else session
+
+	if not os.path.exists(session):
+		return None
+
+	project_file = None
+
+	# we tell that we have found the current project's project file by
+	# looking at the folders registered for that project and comparing it
+	# to the open directorys in the current window
+	found_all_folders = False
+	try:
+		with open(session, 'r') as f:
+			session_data = f.read().replace('\t', ' ')
+		j = json.loads(session_data, strict=False)
+		projects = j.get('workspaces', {}).get('recent_workspaces', [])
+
+		for project_file in projects:
+			found_all_folders = True
+
+			project_file = normalize_path(project_file)
+			try:
+				with open(project_file, 'r') as fd:
+					project_json = json.loads(fd.read(), strict=False)
+
+				if 'folders' in project_json:
+					project_folders = project_json['folders']
+					for directory in view.window().folders():
+						found = False
+						for folder in project_folders:
+							folder_path = normalize_path(folder['path'])
+							# handle relative folder paths
+							if not os.path.isabs(folder_path):
+								folder_path = os.path.normpath(
+									os.path.join(os.path.dirname(project_file), folder_path)
+								)
+
+							if folder_path == directory:
+								found = True
+								break
+
+						if not found:
+							found_all_folders = False
+							break
+
+					if found_all_folders:
+						break
+			except:
+				found_all_folders = False
+	except:
+		pass
+
+	if not found_all_folders:
+		project_file = None
+
+	if (
+		project_file is None or
+		not project_file.endswith('.sublime-project') or
+		not os.path.exists(project_file)
+	):
+		return None
+
+	print('Using project file: %s' % project_file)
+	return project_file


### PR DESCRIPTION
This is identical in intention to #485, though the implementation is quite different. As such it should resolve #152.

The upshot of the change is that when the `TEXroot` setting is a relative path, it will be resolved relative to the location of the project file (which I think is the expected behaviour). This is necessary to support relative TEXroot paths with included documents in subfolders.

There are three other noteworthy changes, to how `getTeXRoot` works after this PR, though this shouldn't affect any documented behaviour:

1. I've changed the order of precedence of the preference setting versus the text in the file itself. Previously, a `TEXroot` setting would override the `%!TEX root` magic comment. With this PR, the magic comment will override the `TEXroot` setting.

1. Instead of opening the file and reading the contents, this PR just reads the content from the ST view directly.

1. It should support multiple `%` before the `!TEX` magic, if that's of interest to anyone.