### PR TITLE
Enable overriding settings with platform-specific settings

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -479,6 +479,26 @@ This sets `main.tex` as the master tex file (assuming a multi-file project), and
 **Note:** tweaking settings on a project-specific level can lead to even more subtle issues. If you notice a bug, in addition to resetting your `LaTeXTools.sublime-settings` file, you should remove at LaTeXTools settings from your project file.
 
 
+### Platform-Specific Overrides ###
+
+All of the generally available settings can be overridden for a specific platform in either a project file or the main `LaTeXTools.sublime-settings` file. This allows you to, for example, keep many of the same settings across platforms, but customize any settings on a platform-specific basis. This is particularly useful with builder settings. Previously, some settings could be overridden on a platform-specific basis, but this required extra code to provide this option.
+
+For example, if you are using the traditional builder, you might change the program used so that it is `xelatex` on Windows or Linux but `lualatex` on OS X by doing something like this in your `LaTeXTools.sublime-settings` file:
+
+```
+{
+	...
+	"builder_settings":
+	{
+		"program": "xelatex",  // xelatex by default
+		"osx":
+		{
+			"program": "lualatex"  // osx override
+		}
+	}
+}
+```
+
 Customizing the Build System
 ----------------------------
 

--- a/builders/pdfBuilder.py
+++ b/builders/pdfBuilder.py
@@ -35,14 +35,13 @@ class PdfBuilder(object):
 	# tex_root is properly split into the root tex file's directory,
 	# its base name, and extension, etc.
 
-	def __init__(self, tex_root, output, builder_settings, platform_settings):
+	def __init__(self, tex_root, output, builder_settings):
 		self.tex_root = tex_root
 		self.tex_dir, self.tex_name = os.path.split(tex_root)
 		self.base_name, self.tex_ext = os.path.splitext(self.tex_name)
 		self.output_callable = output
 		self.out = ""
 		self.builder_settings = builder_settings
-		self.platform_settings = platform_settings
 
 	# Send to callable object
 	# Usually no need to override

--- a/builders/scriptBuilder.py
+++ b/builders/scriptBuilder.py
@@ -23,16 +23,15 @@ DEBUG = False
 #
 class ScriptBuilder(PdfBuilder):
 
-	def __init__(self, tex_root, output, builder_settings, platform_settings):
+	def __init__(self, tex_root, output, builder_settings):
 		# Sets the file name parts, plus internal stuff
-		super(TraditionalBuilder, self).__init__(tex_root, output, builder_settings, platform_settings) 
+		super(TraditionalBuilder, self).__init__(tex_root, output, builder_settings) 
 		# Now do our own initialization: set our name
 		self.name = "Script Builder"
 		# Display output?
 		self.display_log = builder_settings.get("display_log", False)
-		plat = sublime.platform()
-		self.cmd = builder_settings[plat]["command"]
-		self.env = builder_settings[plat]["env"]
+		self.cmd = builder_settings.get('cmd')
+		self.env = builder_settings.get('env')
 
 
 	#
@@ -51,9 +50,9 @@ class ScriptBuilder(PdfBuilder):
 		yield (cmd + [self.base_name], " ".join(cmd) + "... ")
 
 		self.display("done.\n")
-		
+
 		# This is for debugging purposes 
 		if self.display_log:
 			self.display("\nCommand results:\n")
 			self.display(self.out)
-			self.display("\n\n")	
+			self.display("\n\n")

--- a/builders/simpleBuilder.py
+++ b/builders/simpleBuilder.py
@@ -27,9 +27,9 @@ DEBUG = False
 
 class SimpleBuilder(PdfBuilder):
 
-	def __init__(self, tex_root, output, builder_settings, platform_settings):
+	def __init__(self, tex_root, output, builder_settings):
 		# Sets the file name parts, plus internal stuff
-		super(SimpleBuilder, self).__init__(tex_root, output, builder_settings, platform_settings) 
+		super(SimpleBuilder, self).__init__(tex_root, output, builder_settings) 
 		# Now do our own initialization: set our name, see if we want to display output
 		self.name = "Simple Builder"
 		self.display_log = builder_settings.get("display_log", False)

--- a/builders/traditionalBuilder.py
+++ b/builders/traditionalBuilder.py
@@ -34,33 +34,35 @@ DOCUMENTCLASS_RE = re.compile(r'\\documentclass(?:\[[^\]]+\])?\{[^\}]+\}')
 #
 class TraditionalBuilder(PdfBuilder):
 
-	def __init__(self, tex_root, output, builder_settings, platform_settings):
+	def __init__(self, tex_root, output, builder_settings):
 		# Sets the file name parts, plus internal stuff
-		super(TraditionalBuilder, self).__init__(tex_root, output, builder_settings, platform_settings) 
+		super(TraditionalBuilder, self).__init__(tex_root, output, builder_settings) 
 		# Now do our own initialization: set our name
 		self.name = "Traditional Builder"
 		# Display output?
 		self.display_log = builder_settings.get("display_log", False)
+		
 		# Build command, with reasonable defaults
 		plat = sublime.platform()
 		# Figure out which distro we are using
-		try:
-			distro = platform_settings["distro"]
-		except KeyError: # default to miktex on windows and texlive elsewhere
-			if plat == 'windows':
-				distro = "miktex"
-			else:
-				distro = "texlive"
-		if distro in ["miktex", ""]:
+		distro = builder_settings.get(
+			'distro',
+			'miktex' if plat == 'windows' else 'texlive'
+		)
+
+		if plat == 'windows' and distro in ['miktex', '']:
 			default_command = DEFAULT_COMMAND_WINDOWS_MIKTEX
-		else: # osx, linux, windows/texlive, everything else really!
+		else:  # osx, linux, windows/texlive, everything else really!
 			default_command = DEFAULT_COMMAND_LATEXMK
+
 		self.cmd = builder_settings.get("command", default_command)
+
 		# Default tex engine (pdflatex if none specified)
 		self.engine = builder_settings.get("program", "pdflatex")
 		# Sanity check: if "strange" engine, default to pdflatex (silently...)
 		if not(self.engine in ['pdflatex', "pdftex", 'xelatex', 'xetex', 'lualatex', 'luatex']):
 			self.engine = 'pdflatex'
+
 		self.options = builder_settings.get("options", [])
 		if isinstance(self.options, strbase):
 			self.options = [self.options]

--- a/jumpToPDF.py
+++ b/jumpToPDF.py
@@ -50,8 +50,7 @@ def get_sublime_executable():
 							return process
 		return None
 
-	plat_settings = get_setting(sublime.platform(), {})
-	sublime_executable = plat_settings.get('sublime_executable', None)
+	sublime_executable = get_setting('sublime_executable', None)
 
 	if sublime_executable:
 		return sublime_executable
@@ -130,9 +129,7 @@ class jump_to_pdfCommand(sublime_plugin.TextCommand):
 		sublime_command = get_sublime_executable()
 
 		if sublime_command is not None:
-			platform = sublime.platform()
-			plat_settings = get_setting(platform, {})
-			wait_time = plat_settings.get('keep_focus_delay', 0.5)
+			wait_time = get_setting('keep_focus_delay', 0.5)
 
 			def keep_focus():
 				startupinfo = None
@@ -158,9 +155,6 @@ class jump_to_pdfCommand(sublime_plugin.TextCommand):
 		# Check prefs for PDF focus and sync
 		keep_focus = get_setting('keep_focus', True)
 		forward_sync = get_setting('forward_sync', True)
-
-		prefs_lin = get_setting("linux", {})
-		prefs_win = get_setting("windows", {})
 
 		# If invoked from keybinding, we sync
 		# Rationale: if the user invokes the jump command, s/he wants to see the result of the compilation.
@@ -200,8 +194,8 @@ class jump_to_pdfCommand(sublime_plugin.TextCommand):
 		
 
 		# platform-specific code:
-		plat = sublime_plugin.sys.platform
-		if plat == 'darwin':
+		plat = sublime.platform()
+		if plat == 'osx':
 			options = ["-r","-g"] if keep_focus else ["-r"]		
 			if forward_sync:
 				path_to_skim = '/Applications/Skim.app/'
@@ -215,7 +209,7 @@ class jump_to_pdfCommand(sublime_plugin.TextCommand):
 				skim = os.path.join(sublime.packages_path(),
 								'LaTeXTools', 'skim', 'displayfile')
 				subprocess.Popen(['sh', skim] + options + [pdffile])
-		elif plat == 'win32':
+		elif plat == 'windows':
 			# determine if Sumatra is running, launch it if not
 			print ("Windows, Calling Sumatra")
 
@@ -223,8 +217,7 @@ class jump_to_pdfCommand(sublime_plugin.TextCommand):
 			si.dwFlags |= subprocess.STARTF_USESHOWWINDOW
 			si.wShowWindow = 4 #constant for SHOWNOACTIVATE
 
-			su_binary = prefs_win.get("sumatra", "SumatraPDF.exe") or 'SumatraPDF.exe'
-			startCommands = [su_binary, "-reuse-instance"]
+			su_binary = get_setting('sumatra', 'SumatraPDF.exe')
 			if forward_sync:
 				startCommands.append("-forward-search")
 				startCommands.append(srcfile)
@@ -236,7 +229,7 @@ class jump_to_pdfCommand(sublime_plugin.TextCommand):
 
 			if keep_focus:
 				self.focus_st()
-		elif 'linux' in plat: # for some reason, I get 'linux2' from sys.platform
+		elif plat == 'linux': # for some reason, I get 'linux2' from sys.platform
 			print ("Linux!")
 			
 			# the required scripts are in the 'evince' subdir
@@ -255,10 +248,10 @@ class jump_to_pdfCommand(sublime_plugin.TextCommand):
 			# Run scripts through sh because the script files will lose their exec bit on github
 
 			# Get python binary if set:
-			py_binary = prefs_lin["python2"] or 'python'
-			sb_binary = prefs_lin["sublime"] or 'sublime-text'
+			py_binary = get_setting('python2', 'python')
+			sb_binary = get_setting('sublime', 'sublime_text')
 			# How long we should wait after launching sh before syncing
-			sync_wait = prefs_lin["sync_wait"] or 1.0
+			sync_wait = get_setting('sync_wait', 1.0)
 
 			evince_running = ("evince " + pdffile in running_apps)
 			if (not keep_focus) or (not evince_running):

--- a/jumpToPDF.py
+++ b/jumpToPDF.py
@@ -134,7 +134,7 @@ class jump_to_pdfCommand(sublime_plugin.TextCommand):
 			def keep_focus():
 				startupinfo = None
 				shell = False
-				if platform == 'windows':
+				if sublime.platform() == 'windows':
 					startupinfo = subprocess.STARTUPINFO()
 					startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
 					shell = _ST3
@@ -248,8 +248,8 @@ class jump_to_pdfCommand(sublime_plugin.TextCommand):
 			# Run scripts through sh because the script files will lose their exec bit on github
 
 			# Get python binary if set:
-			py_binary = get_setting('python2', 'python')
-			sb_binary = get_setting('sublime', 'sublime_text')
+			py_binary = get_setting('python2') or 'python'
+			sb_binary = get_setting('sublime') or 'sublime_text'
 			# How long we should wait after launching sh before syncing
 			sync_wait = get_setting('sync_wait', 1.0)
 

--- a/jumpto_tex_file.py
+++ b/jumpto_tex_file.py
@@ -178,8 +178,7 @@ def _jumpto_image_file(view, window, tex_root, file_name):
             print("RUN: {0}".format(command))
             subprocess.Popen(command)
 
-    psystem = sublime.platform()
-    commands = get_setting("open_image_command", {}).get(psystem, None)
+    commands = get_setting("open_image_command", {}).get(sublime.platform())
     print("Commands: '{0}'".format(commands))
     print("Open File: '{0}'".format(file_path))
 

--- a/kpsewhich.py
+++ b/kpsewhich.py
@@ -15,8 +15,7 @@ else:
 __all__ = ['kpsewhich']
 
 def get_texpath():
-    platform_settings = get_setting(sublime.platform(), {})
-    texpath = platform_settings.get('texpath', '')
+    texpath = get_setting('texpath', '')
 
     if not _ST3:
         return os.path.expandvars(texpath).encode(sys.getfilesystemencoding())

--- a/latexDocumentationViewer.py
+++ b/latexDocumentationViewer.py
@@ -21,8 +21,7 @@ else:
     strbase = str
 
 def get_texpath():
-    platform_settings = get_setting(sublime.platform(), {})
-    texpath = platform_settings.get('texpath', '')
+    texpath = get_setting('texpath', '')
 
     if not _ST3:
         return os.path.expandvars(texpath).encode(sys.getfilesystemencoding())
@@ -33,10 +32,8 @@ def using_miktex():
     if sublime.platform() != 'windows':
         return False
 
-    platform_settings = get_setting(sublime.platform(), {})
-
     try:
-        distro = platform_settings.get('distro', 'miktex')
+        distro = get_setting('distro', 'miktex')
         return distro in ['miktex', '']
     except KeyError:
         return True  # assumed

--- a/latex_installed_packages.py
+++ b/latex_installed_packages.py
@@ -27,8 +27,7 @@ else:
 __all__ = ['LatexGenPkgCacheCommand']
 
 def get_texpath():
-    platform_settings = get_setting(sublime.platform(), {})
-    texpath = platform_settings.get('texpath', '')
+    texpath = get_setting('texpath', '')
 
     if not _ST3:
         return os.path.expandvars(texpath).encode(sys.getfilesystemencoding())

--- a/latextools_utils/settings.py
+++ b/latextools_utils/settings.py
@@ -4,6 +4,7 @@ from collections import Mapping
 
 import sublime
 
+
 class SettingsWrapper(Mapping):
     '''
     Wrapper object for nested settings, to allow us to refer to keys
@@ -62,7 +63,7 @@ class SettingsWrapper(Mapping):
         return len(self.values)
 
 
-def get_setting(setting, default=None):
+def get_raw_setting(setting, default=None):
     global_settings = sublime.load_settings('LaTeXTools.sublime-settings')
 
     try:
@@ -76,8 +77,112 @@ def get_setting(setting, default=None):
 
     if result is None:
         result = default
-    
+
     if isinstance(result, sublime.Settings) or isinstance(result, dict):
         result = SettingsWrapper(setting, result)
 
     return result
+
+
+class PlatformSettingsWrapper(Mapping):
+    '''
+    Wrapper object for nested settings, to allow us to refer to keys
+    defined in the global settings but not overridden by, e.g.,
+    project or buffer-specific settings.
+
+    This is done so that, e.g., platform-specific settings can be
+    overridden per-project or per-buffer without needing to override
+    all settings that might be globally set (e.g., changing the texpath
+    setting for a project without changing viewer-specific settings)
+    '''
+    def __init__(self, key, values, view_settings, parent=None):
+        self.key = key
+        self.view_settings = view_settings
+        global_settings = sublime.load_settings('LaTeXTools.sublime-settings')
+
+        if parent is not None:
+            self.values = parent.values
+            self.values.update(values)
+        else:
+            values = {}
+            for s in (
+                global_settings.get(self.key, {}),
+                global_settings.get(sublime.platform(), {}).get(self.key, {}),
+                global_settings.get(self.key, {}).get(sublime.platform(), {}),
+                view_settings.get(self.key, {}),
+                view_settings.get(sublime.platform(), {}).get(self.key, {}),
+                view_settings.get(self.key, {}).get(sublime.platform(), {}),
+                values
+            ):
+                if isinstance(s, dict) or isinstance(s, sublime.Settings):
+                    for key in s:
+                        if key not in ('windows', 'linux', 'osx') or \
+                                not isinstance(s[key], dict):
+                            values[key] = s[key]
+            self.values = values
+
+    def get(self, key, default=None):
+        try:
+            result = self.values.get(key)
+        except KeyError:
+            result = None
+
+        if result is None:
+            result = default
+
+        if isinstance(result, dict) or isinstance(result, sublime.Settings):
+            result = PlatformSettingsWrapper(key, result, self.view_settings, self)
+
+        return result
+
+    def __getitem__(self, key):
+        result = self.get(key)
+        if result is None:
+            raise KeyError(key)
+        return result
+
+    def __iter__(self):
+        return iter(self.values)
+
+    def __len__(self):
+        return len(self.values)
+
+    def __repr__(self):
+        return repr(self.values)
+
+
+def get_platform_setting(setting, default=None):
+    global_settings = sublime.load_settings('LaTeXTools.sublime-settings')
+    try:
+        view_settings = sublime.active_window().active_view().settings()
+    except AttributeError:
+        # no view defined
+        view_settings = {}
+
+    platform = sublime.platform()
+
+    result = None
+
+    platform_settings = view_settings.get(platform, {})
+    result = platform_settings.get(setting)
+
+    if result is None:
+        result = view_settings.get(setting)
+
+    if result is None:
+        platform_settings = global_settings.get(platform, {})
+        result = platform_settings.get(setting)
+
+        if result is None:
+            result = global_settings.get(setting)
+
+    if result is None:
+        result = default
+
+    if isinstance(result, sublime.Settings) or isinstance(result, dict):
+        result = PlatformSettingsWrapper(setting, result, view_settings)
+
+    return result
+
+# define get_setting
+get_setting = get_platform_setting

--- a/makePDF.py
+++ b/makePDF.py
@@ -333,7 +333,6 @@ class make_pdfCommand(sublime_plugin.WindowCommand):
 			return
 
 		# Get platform settings, builder, and builder settings
-		platform_settings  = get_setting(self.plat, {})
 		builder_name = get_setting("builder", "traditional")
 		self.hide_panel_level = get_setting("hide_build_panel", "never")
 		# This *must* exist, so if it doesn't, the user didn't migrate
@@ -350,11 +349,7 @@ class make_pdfCommand(sublime_plugin.WindowCommand):
 		builder_settings = get_setting("builder_settings", {})
 
 		# Read the env option (platform specific)
-		builder_platform_settings = builder_settings.get(self.plat)
-		if builder_platform_settings:
-			self.env = builder_platform_settings.get("env", None)
-		else:
-			self.env = None
+		self.env = builder_settings.get("env", None)
 
 		# Safety check: if we are using a built-in builder, disregard
 		# builder_path, even if it was specified in the pref file
@@ -391,14 +386,14 @@ class make_pdfCommand(sublime_plugin.WindowCommand):
 		builder_class = getattr(builder_module, builder_class_name)
 		print(repr(builder_class))
 		# We should now be able to construct the builder object
-		self.builder = builder_class(self.file_name, self.output, builder_settings, platform_settings)
+		self.builder = builder_class(self.file_name, self.output, builder_settings)
 		
 		# Restore Python system path
 		sys.path[:] = syspath_save
 		
 		# Now get the tex binary path from prefs, change directory to
 		# that of the tex root file, and run!
-		self.path = platform_settings['texpath']
+		self.path = get_setting('texpath')
 		os.chdir(tex_dir)
 		CmdThread(self).start()
 		print (threading.active_count())

--- a/viewPDF.py
+++ b/viewPDF.py
@@ -13,7 +13,7 @@ else:
 	from .latextools_utils.is_tex_file import is_tex_file
 	from .latextools_utils import get_setting
 
-import sublime_plugin, os, os.path, platform
+import sublime_plugin, os, os.path
 from subprocess import Popen
 
 
@@ -24,8 +24,6 @@ from subprocess import Popen
 
 class View_pdfCommand(sublime_plugin.WindowCommand):
 	def run(self):
-		prefs_lin = get_setting('linux', {})
-
 		view = self.window.active_view()
 		if not is_tex_file(view.file_name()):
 			sublime.error_message("%s is not a TeX source file: cannot view." % (os.path.basename(view.file_name()),))
@@ -35,29 +33,28 @@ class View_pdfCommand(sublime_plugin.WindowCommand):
 
 		rootFile, rootExt = os.path.splitext(root)
 		pdfFile = quotes + rootFile + '.pdf' + quotes
-		s = platform.system()
 		script_path = None
-		if s == "Darwin":
+		p = sublime.platform()
+		if p == "osx":
 			# for inverse search, set up a "Custom" sync profile, using
 			# "subl" as command and "%file:%line" as argument
 			# you also have to put a symlink to subl somewhere on your path
 			# Also check the box "check for file changes"
 			viewercmd = ["open", "-a", "Skim"]
-		elif s == "Windows":
+		elif p == "windows":
 			# with new version of SumatraPDF, can set up Inverse 
 			# Search in the GUI: under Settings|Options...
 			# Under "Set inverse search command-line", set:
 			# sublime_text "%f":%l
-			prefs_win = get_setting("windows", {})
-			su_binary = prefs_win.get("sumatra", "SumatraPDF.exe")
+			su_binary = get_setting("sumatra", "SumatraPDF.exe")
 			viewercmd = [su_binary, "-reuse-instance"]		
-		elif s == "Linux":
+		elif p == "linux":
 			# the required scripts are in the 'evince' subdir
 			script_path = os.path.join(sublime.packages_path(), 'LaTeXTools', 'evince')
 			ev_sync_exec = os.path.join(script_path, 'evince_sync') # so we get inverse search
 			# Get python binary if set in preferences:
-			py_binary = prefs_lin["python2"] or 'python'
-			sb_binary = prefs_lin["sublime"] or 'sublime-text'
+			py_binary = get_setting('python2', 'python')
+			sb_binary = get_setting('sublime', 'sublime_text')
 			viewercmd = ['sh', ev_sync_exec, py_binary, sb_binary]
 		else:
 			sublime.error_message("Platform as yet unsupported. Sorry!")


### PR DESCRIPTION
This is similar in spirit to #609 and completely compatible with those changes, but introduces some new changes into how settings are loaded. For the motivation for doing this, see #412.

Basically, the idea is to generalise the OS-specific settings stanza and the OS-specific `builder_settings` stanza to all or most of the other settings, with the intention that the user can specify *platform-specific* versions of any setting and have those honoured.

From an API perspective, this means that its usually only necessary to call `get_setting()` and it will load the appropriate platform-overridden setting if it exists or otherwise continue to work as it does in the current release.

Among other things, this is meant to clear up the ambiguity discussed in #412, so that it's possible to specify either the `command` or `program` setting for the traditional builder in an OS-specific manner while still honouring any existing settings that are configured.

To do so, it constructs a hierarchy of settings. I'll use an abbreviated versions of settings files to demonstrate with numbers indicating the priority in which a setting is use (1 being the highest priority and 6 being the lowest and the platform assumed to be osx):

**`LaTeXTools.sublime-settings`**
```javascript
{
    ...
    "osx":
    {
        "builder_settings":
        {
            "program": "pdflatex" // #5
        }
    },
    ...
    "builder_settings":
    {
        ...
        "program": "pdflatex" // #6
        "osx":
        {
            "program": "pdflatex" // #4
        }
    }
}
```

**Project File**
```javascript
{
    ...
    "settings":
    {
        "osx":
        {
            "builder_settings":
            {
                "program": "pdflatex" // #2
            }
        },

        "builder_settings":
        {
            "program": "pdflatex" // #3
            "osx":
            {
                "program": "pdflatex" // #1
            }
        }
    }
}
```

These changes work with every current feature in LaTeXTools, including the `open_image_command` settings (which uses platform-specific settings, albeit in a different way), but there is some potential that this change could cause settings to behave in unexpected ways for future code, so I've left the current implementation of `get_setting()` in under the name `get_raw_setting()`.

Right now, I'm not sure there are a whole lot of use-cases for this feature, but with the script builder and some similar changes to allow viewer plugins to be created that I'm working on, something like this is becoming more necessary, I think.