### PR TITLE
Common `%!TEX` directive parsing

### DIFF
--- a/builders/pdfBuilder.py
+++ b/builders/pdfBuilder.py
@@ -4,10 +4,8 @@ import sublime
 if sublime.version() < '3000':
     # we are on ST2 and Python 2.X
 	_ST3 = False
-	strbase = basestring
 else:
 	_ST3 = True
-	strbase = str
 
 import os.path
 
@@ -37,35 +35,18 @@ class PdfBuilder(object):
 	# tex_root is properly split into the root tex file's directory,
 	# its base name, and extension, etc.
 
-	def __init__(self, tex_root, output, tex_directives, builder_settings, platform_settings):
+	def __init__(self, tex_root, output, engine, options,
+				 tex_directives, builder_settings, platform_settings):
 		self.tex_root = tex_root
 		self.tex_dir, self.tex_name = os.path.split(tex_root)
 		self.base_name, self.tex_ext = os.path.splitext(self.tex_name)
 		self.output_callable = output
 		self.out = ""
+		self.engine = engine
+		self.options = options
+		self.tex_directives = tex_directives
 		self.builder_settings = builder_settings
 		self.platform_settings = platform_settings
-
-		self.tex_directives = tex_directives
-
-		# Default tex engine (pdflatex if none specified)
-		self.engine = self.tex_directives.get('program',
-			builder_settings.get("program", "pdflatex"))
-
-		self.engine = self.engine.lower()
-
-		# Sanity check: if "strange" engine, default to pdflatex (silently...)
-		if not(self.engine in [
-			'pdflatex', "pdftex", 'xelatex', 'xetex', 'lualatex', 'luatex'
-		]):
-			self.engine = 'pdflatex'
-
-		self.options = builder_settings.get("options", [])
-		if isinstance(self.options, strbase):
-			self.options = [self.options]
-
-		if 'options' in self.tex_directives:
-			self.options.extend(self.tex_directives['options'])
 
 	# Send to callable object
 	# Usually no need to override

--- a/builders/scriptBuilder.py
+++ b/builders/scriptBuilder.py
@@ -23,9 +23,11 @@ DEBUG = False
 #
 class ScriptBuilder(PdfBuilder):
 
-	def __init__(self, tex_root, output, tex_directives, builder_settings, platform_settings):
+	def __init__(self, tex_root, output, engine, options,
+				 tex_directives, builder_settings, platform_settings):
 		# Sets the file name parts, plus internal stuff
-		super(TraditionalBuilder, self).__init__(tex_root, output, tex_directives, builder_settings, platform_settings) 
+		super(ScriptBuilder, self).__init__(tex_root, output, engine, options,
+			tex_directives, builder_settings, platform_settings)
 		# Now do our own initialization: set our name
 		self.name = "Script Builder"
 		# Display output?

--- a/builders/scriptBuilder.py
+++ b/builders/scriptBuilder.py
@@ -23,9 +23,9 @@ DEBUG = False
 #
 class ScriptBuilder(PdfBuilder):
 
-	def __init__(self, tex_root, output, builder_settings, platform_settings):
+	def __init__(self, tex_root, output, tex_directives, builder_settings, platform_settings):
 		# Sets the file name parts, plus internal stuff
-		super(TraditionalBuilder, self).__init__(tex_root, output, builder_settings, platform_settings) 
+		super(TraditionalBuilder, self).__init__(tex_root, output, tex_directives, builder_settings, platform_settings) 
 		# Now do our own initialization: set our name
 		self.name = "Script Builder"
 		# Display output?

--- a/builders/simpleBuilder.py
+++ b/builders/simpleBuilder.py
@@ -29,7 +29,7 @@ class SimpleBuilder(PdfBuilder):
 
 	def __init__(self, tex_root, output, builder_settings, platform_settings):
 		# Sets the file name parts, plus internal stuff
-		super(SimpleBuilder, self).__init__(tex_root, output, builder_settings, platform_settings) 
+		super(SimpleBuilder, self).__init__(tex_root, output, tex_directives, builder_settings, platform_settings) 
 		# Now do our own initialization: set our name, see if we want to display output
 		self.name = "Simple Builder"
 		self.display_log = builder_settings.get("display_log", False)

--- a/builders/simpleBuilder.py
+++ b/builders/simpleBuilder.py
@@ -27,9 +27,12 @@ DEBUG = False
 
 class SimpleBuilder(PdfBuilder):
 
-	def __init__(self, tex_root, output, builder_settings, platform_settings):
+	def __init__(self, tex_root, output, engine, options,
+				 tex_directives, builder_settings, platform_settings):
 		# Sets the file name parts, plus internal stuff
-		super(SimpleBuilder, self).__init__(tex_root, output, tex_directives, builder_settings, platform_settings) 
+		super(SimpleBuilder, self).__init__(tex_root, output, engine, options,
+			tex_directives, builder_settings, platform_settings)
+
 		# Now do our own initialization: set our name, see if we want to display output
 		self.name = "Simple Builder"
 		self.display_log = builder_settings.get("display_log", False)

--- a/builders/traditionalBuilder.py
+++ b/builders/traditionalBuilder.py
@@ -26,10 +26,12 @@ DEFAULT_COMMAND_WINDOWS_MIKTEX = ["texify", "-b", "-p", "--engine=%E",
 #
 class TraditionalBuilder(PdfBuilder):
 
-	def __init__(self, tex_root, output, tex_directives, builder_settings, platform_settings):
+	def __init__(self, tex_root, output, engine, options,
+				 tex_directives, builder_settings, platform_settings):
 		# Sets the file name parts, plus internal stuff
-		super(TraditionalBuilder, self).__init__(tex_root, output, tex_directives, builder_settings, platform_settings) 
-		# Now do our own initialization: set our name
+		super(TraditionalBuilder, self).__init__(tex_root, output, engine,
+			options, tex_directives, builder_settings, platform_settings)
+		#Now do our own initialization: set our name
 		self.name = "Traditional Builder"
 		# Display output?
 		self.display_log = builder_settings.get("display_log", False)

--- a/builders/traditionalBuilder.py
+++ b/builders/traditionalBuilder.py
@@ -1,19 +1,13 @@
 # ST2/ST3 compat
-from __future__ import print_function 
+from __future__ import print_function
 import sublime
 if sublime.version() < '3000':
-    # we are on ST2 and Python 2.X
+	# we are on ST2 and Python 2.X
 	_ST3 = False
-	strbase = basestring
 else:
 	_ST3 = True
-	strbase = str
 
 from pdfBuilder import PdfBuilder
-import sublime_plugin
-import re
-import os, os.path
-import codecs
 
 DEBUG = False
 
@@ -22,8 +16,6 @@ DEFAULT_COMMAND_LATEXMK = ["latexmk", "-cd", "-e", "-f", "-%E",
 
 DEFAULT_COMMAND_WINDOWS_MIKTEX = ["texify", "-b", "-p", "--engine=%E",
 					"--tex-option=\"--synctex=1\""]
-
-DOCUMENTCLASS_RE = re.compile(r'\\documentclass(?:\[[^\]]+\])?\{[^\}]+\}')
 
 
 #----------------------------------------------------------------
@@ -34,9 +26,9 @@ DOCUMENTCLASS_RE = re.compile(r'\\documentclass(?:\[[^\]]+\])?\{[^\}]+\}')
 #
 class TraditionalBuilder(PdfBuilder):
 
-	def __init__(self, tex_root, output, builder_settings, platform_settings):
+	def __init__(self, tex_root, output, tex_directives, builder_settings, platform_settings):
 		# Sets the file name parts, plus internal stuff
-		super(TraditionalBuilder, self).__init__(tex_root, output, builder_settings, platform_settings) 
+		super(TraditionalBuilder, self).__init__(tex_root, output, tex_directives, builder_settings, platform_settings) 
 		# Now do our own initialization: set our name
 		self.name = "Traditional Builder"
 		# Display output?
@@ -56,14 +48,6 @@ class TraditionalBuilder(PdfBuilder):
 		else: # osx, linux, windows/texlive, everything else really!
 			default_command = DEFAULT_COMMAND_LATEXMK
 		self.cmd = builder_settings.get("command", default_command)
-		# Default tex engine (pdflatex if none specified)
-		self.engine = builder_settings.get("program", "pdflatex")
-		# Sanity check: if "strange" engine, default to pdflatex (silently...)
-		if not(self.engine in ['pdflatex', "pdftex", 'xelatex', 'xetex', 'lualatex', 'luatex']):
-			self.engine = 'pdflatex'
-		self.options = builder_settings.get("options", [])
-		if isinstance(self.options, strbase):
-			self.options = [self.options]
 
 	#
 	# Very simple here: we yield a single command
@@ -84,30 +68,13 @@ class TraditionalBuilder(PdfBuilder):
 				engine_used = True
 				break
 
-		# load the header from the root file to check for engine or options
-		texroot_header = []
-		for line in codecs.open(self.tex_root, "r", "UTF-8", "ignore").readlines():
-			m = DOCUMENTCLASS_RE.search(line)
-			if m:
-				texroot_header.append(line[:m.start()])
-				break
-			elif not line.startswith('%'):
-				continue
-
-			texroot_header.append(line)
-
 		texify = cmd[0] == 'texify'
 		latexmk = cmd[0] == 'latexmk'
 
 		if not engine_used:
 			self.display("Your custom command does not allow the engine to be selected\n\n")
 		else:
-			for line in texroot_header:
-				# We have a comment match; check for a TS-program match
-				mroot = re.match(r"%+\s*!TEX\s+(?:TS-)?program *= *(xe(la)?tex|lua(la)?tex|pdf(la)?tex)\s*$",line)
-				if mroot:
-					engine = mroot.group(1)
-					break
+			self.display("Engine: {0}. ".format(engine))
 
 			if texify:
 				# texify's --engine option takes pdftex/xetex/luatex as acceptable values
@@ -121,9 +88,6 @@ class TraditionalBuilder(PdfBuilder):
 						"luatex": "lualatex"
 					}[engine]
 
-			if engine != self.engine:
-				self.display("Engine: " + self.engine + " -> " + engine + ". ")
-
 			for i, c in enumerate(cmd):
 				cmd[i] = c.replace(
 					"-%E", "-" + engine if texify or engine != 'pdflatex' else '-pdf'
@@ -131,14 +95,6 @@ class TraditionalBuilder(PdfBuilder):
 
 		# handle any options
 		if texify or latexmk:
-			for line in texroot_header:
-				m = re.match(r'%+\s*!TEX\s+option *= *([-\w]+)\s*$', line)
-				if m:
-					if texify:
-						cmd.append("--tex-option=\"" + m.group(1) + "\"")
-					else:
-						cmd.append("-latexoption=\"" + m.group(1) + "\"")
-
 			for option in self.options:
 				if texify:
 					cmd.append("--tex-option=\"" + option + "\"")
@@ -149,7 +105,7 @@ class TraditionalBuilder(PdfBuilder):
 		yield (cmd + [self.tex_name], "Invoking " + cmd[0] + "... ")
 
 		self.display("done.\n")
-		
+
 		# This is for debugging purposes 
 		if self.display_log:
 			self.display("\nCommand results:\n")

--- a/getTeXRoot.py
+++ b/getTeXRoot.py
@@ -1,18 +1,16 @@
 # ST2/ST3 compat
-from __future__ import print_function 
+from __future__ import print_function
+import os
 import sublime
 if sublime.version() < '3000':
 	# we are on ST2 and Python 2.X
 	_ST3 = False
-	from latextools_utils.is_tex_file import get_tex_extensions
+	from latextools_utils.is_tex_file import is_tex_file
+	from latextools_utils import parse_tex_directives
 else:
 	_ST3 = True
-	from .latextools_utils.is_tex_file import get_tex_extensions
-
-
-import os.path, re
-import codecs
-
+	from .latextools_utils.is_tex_file import is_tex_file
+	from .latextools_utils import parse_tex_directives
 
 # Parse magic comments to retrieve TEX root
 # Stops searching for magic comments at first non-comment line of file
@@ -20,6 +18,7 @@ import codecs
 # and the current buffer is an unnamed unsaved file)
 
 # Contributed by Sam Finn
+
 
 def get_tex_root(view):
 	try:
@@ -30,48 +29,19 @@ def get_tex_root(view):
 	except:
 		pass
 
-
-	texFile = view.file_name()
-	root = texFile
-	if texFile is None:
-		# We are in an unnamed, unsaved file.
-		# Read from the buffer instead.
-		if view.substr(0) != '%':
-			return None
-		reg = view.find(r"^%[^\n]*(\n%[^\n]*)*", 0)
-		if not reg:
-			return None
-		line_regs = view.lines(reg)
-		lines = map(view.substr, line_regs)
-		is_file = False
-
+	view_file = view.file_name()
+	root = view_file
+	directives = parse_tex_directives(view, only_for=['root'])
+	try:
+		root = directives['root']
+	except KeyError:
+		pass
 	else:
-		# This works on ST2 and ST3, but does not automatically convert line endings.
-		# We should be OK though.
-		lines = codecs.open(texFile, "r", "UTF-8")
-		is_file = True
+		if not is_tex_file(root):
+			return view_file
 
-	for line in lines:
-		if not line.startswith('%'):
-			break
-		else:
-			# We have a comment match; check for a TEX root match
-			tex_exts = '|'.join([re.escape(ext) for ext in get_tex_extensions()])
-			mroot = re.match(r"(?i)%\s*!TEX\s+root *= *(.*({0}))\s*$".format(tex_exts), line)
-			if mroot:
-				# we have a TEX root match 
-				# Break the match into path, file and extension
-				# Create TEX root file name
-				# If there is a TEX root path, use it
-				# If the path is not absolute and a src path exists, pre-pend it
-				root = mroot.group(1)
-				if not os.path.isabs(root) and texFile is not None:
-					(texPath, texName) = os.path.split(texFile)
-					root = os.path.join(texPath,root)
-				root = os.path.normpath(root)
-				break
-
-	if is_file: # Not very Pythonic, but works...
-		lines.close()
+		if not os.path.isabs(root) and view_file is not None:
+			file_path, _ = os.path.split(view_file)
+			root = os.path.normpath(os.path.join(file_path, root))
 
 	return root

--- a/latextools_utils/__init__.py
+++ b/latextools_utils/__init__.py
@@ -4,3 +4,8 @@ try:
 	from latextools_utils.settings import get_setting
 except ImportError:
 	from .settings import get_setting
+
+try:
+	from latextools_utils.tex_directives import parse_tex_directives
+except ImportError:
+	from .tex_directives import parse_tex_directives

--- a/latextools_utils/tex_directives.py
+++ b/latextools_utils/tex_directives.py
@@ -94,9 +94,8 @@ def parse_tex_directives(view_or_path, multi_values=[], key_maps={},
                 if key in key_maps:
                     key = key_maps[key]
 
-                if has_only_for:
-                    if key not in only_for:
-                        continue
+                if has_only_for and key not in only_for:
+                    continue
 
                 if key in multi_values:
                     if key in result:

--- a/latextools_utils/tex_directives.py
+++ b/latextools_utils/tex_directives.py
@@ -113,4 +113,4 @@ def parse_tex_directives(view_or_path, multi_values=[], key_maps={},
         return result
     finally:
         if is_file:
-            line.close()
+            lines.close()

--- a/latextools_utils/tex_directives.py
+++ b/latextools_utils/tex_directives.py
@@ -34,8 +34,8 @@ def parse_tex_directives(view_or_path, multi_values=[], key_maps={},
     parameters:
         view_or_path    -   either a ST view or a path to a file to parse
         multi_values    -   a list of directives to allow to have multiple
-                            values if not included in this list, only a single
-                            value(the first encountered) will be honored
+                            if not included in this list, only the first
+                            encountered value is retained
         key_maps        -   a dict mapping from a directive to the directive
                             to be returned. intended to allow directives to
                             be renamed (e.g. ts-program -> program)

--- a/latextools_utils/tex_directives.py
+++ b/latextools_utils/tex_directives.py
@@ -26,7 +26,7 @@ LATEX_COMMAND = re.compile(r'\\[a-zA-Z]+\*?(?:\[[^\]]+\])*\{[^\}]+\}')
 def parse_tex_directives(view_or_path, multi_values=[], key_maps={},
                          only_for=[]):
     '''
-    Parses a view or file for any %!TEX parse_tex_directives
+    Parses a view or file for any %!TEX directives
 
     Returns a dictionary of directives keyed from the directive name in
     lower-case

--- a/latextools_utils/tex_directives.py
+++ b/latextools_utils/tex_directives.py
@@ -1,0 +1,110 @@
+from __future__ import print_function
+
+import codecs
+import re
+import sublime
+import sys
+import traceback
+
+if sys.version_info < (3, 0):
+    strbase = basestring
+else:
+    strbase = str
+
+TEX_DIRECTIVE = re.compile(
+    r'%+\s*!(?:T|t)(?:E|e)(?:X|x)\s+([\w-]+)\s*=\s*' +
+    r'(.*?)\s*$',
+    re.UNICODE
+)
+
+# this is obviously imperfect, but is intended as a heuristic. we 
+# can tolerate false negatives, but not false positives that match, e.g.,
+# Windows paths or parts of Windows paths.
+LATEX_COMMAND = re.compile(r'\\[a-zA-Z]+\*?(?:\[[^\]]+\])*\{[^\}]+\}')
+
+
+def parse_tex_directives(view_or_path, multi_values=[], key_maps={},
+                         only_for=[]):
+    '''
+    Parses a view or file for any %!TEX parse_tex_directives
+
+    Returns a dictionary of directives keyed from the directive name in
+    lower-case
+
+    parameters:
+        view_or_path    -   either a ST view or a path to a file to parse
+        multi_values    -   a list of directives to allow to have multiple
+                            values if not included in this list, only a single
+                            value(the first encountered) will be honored
+        key_maps        -   a dict mapping from a directive to the directive
+                            to be returned. intended to allow directives to
+                            be renamed (e.g. ts-program -> program)
+        only_for        -   a list of the directives we are interested in
+                            if only a single value is present and no
+                            multi_values are specified, this will exit once
+                            a match is found
+    '''
+    result = {}
+
+    if isinstance(view_or_path, sublime.View):
+        lines = view_or_path.substr(
+            sublime.Region(0, view_or_path.size())).split('\n')
+    elif isinstance(view_or_path, strbase):
+        try:
+            with codecs.open(view_or_path, "r", "utf-8", "ignore") as f:
+                lines = f.readlines()
+        except IOError:
+            # fail (relatively) silently if view_or_path is not a valid path
+            print('Caught IOError while handling {0} as file'.format(
+                view_or_path))
+            traceback.print_exc()
+            return result
+    else:
+        print('{0} is not supported by parse_tex_directives()'.format(
+            type(view_or_path)))
+        return result
+
+    # precompute some conditions that do not vary while looping
+
+    # indicates that there is a list of only_for values
+    has_only_for = only_for is not None and len(only_for) > 0
+
+    # whether or not we should break on the first value encountered
+    # we do so if only a single directive is being searched for
+    # and it is not multi-valued
+    break_on_first = has_only_for and len(only_for) == 1 and \
+        (multi_values is None or only_for[0] not in multi_values)
+
+    for line in lines:
+        # read up until the first LaTeX command
+        m = LATEX_COMMAND.search(line)
+        if m:
+            break
+        elif not line.startswith('%'):
+            continue
+
+        m = TEX_DIRECTIVE.match(line)
+        if m:
+            key = m.group(1).lower()
+            value = m.group(2)
+
+            if key in key_maps:
+                key = key_maps[key]
+
+            if has_only_for:
+                if key not in only_for:
+                    continue
+
+            if key in multi_values:
+                if key in result:
+                    result[key].append(value)
+                else:
+                    result[key] = [value]
+            else:
+                if key not in result:
+                    result[key] = value
+
+                    if break_on_first:
+                        break
+
+    return result

--- a/makePDF.py
+++ b/makePDF.py
@@ -7,13 +7,13 @@ if sublime.version() < '3000':
 	import getTeXRoot
 	import parseTeXlog
 	from latextools_utils.is_tex_file import is_tex_file
-	from latextools_utils import get_setting
+	from latextools_utils import get_setting, parse_tex_directives
 else:
 	_ST3 = True
 	from . import getTeXRoot
 	from . import parseTeXlog
 	from .latextools_utils.is_tex_file import is_tex_file
-	from .latextools_utils import get_setting
+	from .latextools_utils import get_setting, parse_tex_directives
 
 import sublime_plugin
 import sys
@@ -332,6 +332,13 @@ class make_pdfCommand(sublime_plugin.WindowCommand):
 			sublime.error_message("Platform as yet unsupported. Sorry!")
 			return
 
+		# parse root for any %!TEX directives
+		tex_directives = parse_tex_directives(
+			self.file_name,
+			multi_values=['options'],
+			key_maps={'ts-program': 'program'}
+		)
+
 		# Get platform settings, builder, and builder settings
 		platform_settings  = get_setting(self.plat, {})
 		builder_name = get_setting("builder", "traditional")
@@ -391,7 +398,13 @@ class make_pdfCommand(sublime_plugin.WindowCommand):
 		builder_class = getattr(builder_module, builder_class_name)
 		print(repr(builder_class))
 		# We should now be able to construct the builder object
-		self.builder = builder_class(self.file_name, self.output, builder_settings, platform_settings)
+		self.builder = builder_class(
+			self.file_name,
+			self.output,
+			tex_directives,
+			builder_settings,
+			platform_settings
+		)
 		
 		# Restore Python system path
 		sys.path[:] = syspath_save


### PR DESCRIPTION
Some back-end changes that do two things:

1) It moves all the parsing code for `%!TEX` directives to a single place

2) It extracts the code for determining the `engine` and `options` settings used by the traditional builder and makes them available to all builders