### PR TITLE
Change default value for `hide_build_panel` to `no_warnings`

### DIFF
--- a/LaTeXTools.sublime-settings
+++ b/LaTeXTools.sublime-settings
@@ -49,7 +49,7 @@
 	// "no_errors" (only hide the panel if the build was successful even with warnings),
 	// "no_warnings" (only hide the panel if no warnings occur) and
 	// "never" (default, never hide the build panel)
-	"hide_build_panel": "never",
+	"hide_build_panel": "no_warnings",
 
 	// valid texfile extensions
 	"tex_file_exts": [".tex"],


### PR DESCRIPTION
This PR just changes the default settings for `hide_build_panel` from `never` to `no_warnings`, because this seems to be the better default value.
I uses the default value `never` to not change the current behavior unless explicitly wished. However on the hindsight most users seems to wish to hide the build panel and does not read all settings.
The value `no_warnings` seems to be reasonable, because without warnings the build panel only contains the file name, build engine and that the build is succeded. The success can also be indicated by hiding the build panel and the other information is redundant in every build.