### PR TITLE
System Check

### DIFF
--- a/01_reload_submodules.py
+++ b/01_reload_submodules.py
@@ -22,7 +22,6 @@ LOAD_ORDER = [
     'external.latex_chars',
 
     'latextools_plugin_internal',
-    'latextools_plugin',
 
     # reloaded here so that makePDF imports the current version
     'parseTeXlog',
@@ -49,7 +48,9 @@ LOAD_ORDER = [
     'latextools_utils.analysis',
     'latextools_utils.ana_utils',
     'latextools_utils.bibcache',
-    'latextools_utils.output_directory'
+    'latextools_utils.output_directory',
+
+    'latextools_plugin'
 ]
 
 for suffix in LOAD_ORDER:

--- a/01_reload_submodules.py
+++ b/01_reload_submodules.py
@@ -48,7 +48,6 @@ LOAD_ORDER = [
     # depend on any previous
     'latextools_utils.analysis',
     'latextools_utils.ana_utils',
-    'latextools_utils.output_directory',
     'latextools_utils.bibcache',
     'latextools_utils.output_directory'
 ]

--- a/01_reload_submodules.py
+++ b/01_reload_submodules.py
@@ -43,6 +43,7 @@ LOAD_ORDER = [
     'latextools_utils.sublime_utils',
     'latextools_utils.cache',
     'latextools_utils.quickpanel',
+    'latextools_utils.external_command',
 
     # depend on any previous
     'latextools_utils.analysis',

--- a/01_reload_submodules.py
+++ b/01_reload_submodules.py
@@ -47,6 +47,8 @@ LOAD_ORDER = [
 
     # depend on any previous
     'latextools_utils.analysis',
+    'latextools_utils.ana_utils',
+    'latextools_utils.output_directory',
     'latextools_utils.bibcache',
     'latextools_utils.output_directory'
 ]

--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -148,6 +148,14 @@ LaTeX Package keymap for Linux
 			{"key": "lt_fill_all_env.open_curly", "operator": "equal", "operand": true, "match_all": true}],
 		"command": "latex_fill_all", "args": {"completion_type": "env", "insert_char": "{"}},
 
+	{	"keys": ["{"],
+		"context":  [
+			{"key": "setting.disable_latex_ref_cite_auto_trigger", "operator": "not_equal", "operand": true},
+			{"key": "selector", "operator": "equal", "operand": "text.tex.latex - comment"},
+			{"key": "selection_empty", "operator": "equal", "operand": true, "match_all": true},
+			{"key": "lt_fill_all_glossary.open_curly", "operator": "equal", "operand": true, "match_all": true}],
+		"command": "latex_fill_all", "args": {"completion_type": "glossary", "insert_char": "{"}},
+
 	{	"keys": ["="],
 		"context":  [
 			{"key": "setting.disable_latex_ref_cite_auto_trigger", "operator": "not_equal", "operand": true},

--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -2,6 +2,19 @@
 LaTeX Package keymap for Linux
 */
 [
+	// these also override ST3 commands, but we simply run the same commands
+	// it is necessary so on ST2 we can implement our build selector
+	{	"keys": ["ctrl+b"],
+		"context": [
+			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"},
+			{"key": "ltt_st_build", "operator": "equal", "operand": "<3080"}],
+		"command": "latextools_build_selector"},
+	{	"keys": ["ctrl+shift+b"],
+		"context": [
+			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"},
+			{"key": "ltt_st_build", "operator": "equal", "operand": "<3080"}],
+		"command": "latextools_build_selector",
+			"args": {"select": true}},
 
 	// New-style keybindings use "ctrl+l" as a prefix
 	// This overrides "extend selection to line", which is remapped to

--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -294,13 +294,30 @@ LaTeX Package keymap for Linux
 	"context":  
 		[
 			{ "key": "setting.command_mode", "operator": "equal", "operand": false },
-			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"},
+			{ "key": "selector", "operator": "equal", "operand": "text.tex.latex" },
 			{ "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
 			{ "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
-			/*{ "key": "following_text", "operator": "regex_contains", "operand": "^(?:\t| |\\)|])", "match_all": true },*/
-			{ "key": "preceding_text", "operator": "not_regex_contains", "operand": "[\"a-zA-Z0-9_]$", "match_all": true },
-			{ "key": "eol_selector", "operator": "not_equal", "operand": "string.quoted.double", "match_all": true }
+			// do not insert this if it is escaped
+			{ "key": "preceding_text", "operator": "not_regex_contains", "operand": "(?:\\\\\\\\)*(?:\\\\|\\$)$", "match_all": true },
+			// don't insert, it inside math environments
+			{ "key": "selector", "operator": "not_equal", "operand": "meta.environment.math, string.other.math", "match_all": true },
+			// don't insert, if there is an open dollar math environment at the end of the line
+			{ "key": "eol_selector", "operator": "not_equal", 
+			  "operand": "meta.environment.math.inline.dollar - punctuation.definition.string.end, string.other.math - punctuation.definition.string.end",
+			  "match_all": true }
 		] 
+	},
+	// fully close $$ environments
+	{ "keys": ["$"], "command": "insert", "args": {"characters": "$$"}, 
+	"context":
+		[
+			{ "key": "setting.command_mode", "operator": "equal", "operand": false },
+			{ "key": "selector", "operator": "equal", "operand": "text.tex.latex meta.environment.math.block.dollar" },
+			{ "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
+			{ "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
+			// do not insert this if it is escaped
+			{ "key": "preceding_text", "operator": "not_regex_contains", "operand": "(?:\\\\\\\\)*(?:\\\\|\\$)$", "match_all": true }
+		]
 	},
 	// wrap in $
 	{ "keys": ["$"], "command": "insert_snippet", "args": {"contents": "\\$${0:$SELECTION}\\$"}, "context":

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -148,6 +148,14 @@ LaTeX Package keymap for OS X
 			{"key": "lt_fill_all_env.open_curly", "operator": "equal", "operand": true, "match_all": true}],
 		"command": "latex_fill_all", "args": {"completion_type": "env", "insert_char": "{"}},
 
+	{	"keys": ["{"],
+		"context":  [
+			{"key": "setting.disable_latex_ref_cite_auto_trigger", "operator": "not_equal", "operand": true},
+			{"key": "selector", "operator": "equal", "operand": "text.tex.latex - comment"},
+			{"key": "selection_empty", "operator": "equal", "operand": true, "match_all": true},
+			{"key": "lt_fill_all_glossary.open_curly", "operator": "equal", "operand": true, "match_all": true}],
+		"command": "latex_fill_all", "args": {"completion_type": "glossary", "insert_char": "{"}},
+
 	{	"keys": ["="],
 		"context":  [
 			{"key": "setting.disable_latex_ref_cite_auto_trigger", "operator": "not_equal", "operand": true},

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -294,13 +294,30 @@ LaTeX Package keymap for OS X
 	"context":  
 		[
 			{ "key": "setting.command_mode", "operator": "equal", "operand": false },
-			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"},
+			{ "key": "selector", "operator": "equal", "operand": "text.tex.latex" },
 			{ "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
 			{ "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
-			/*{ "key": "following_text", "operator": "regex_contains", "operand": "^(?:\t| |\\)|])", "match_all": true },*/
-			{ "key": "preceding_text", "operator": "not_regex_contains", "operand": "[\"a-zA-Z0-9_]$", "match_all": true },
-			{ "key": "eol_selector", "operator": "not_equal", "operand": "string.quoted.double", "match_all": true }
+			// do not insert this if it is escaped
+			{ "key": "preceding_text", "operator": "not_regex_contains", "operand": "(?:\\\\\\\\)*(?:\\\\|\\$)$", "match_all": true },
+			// don't insert, it inside math environments
+			{ "key": "selector", "operator": "not_equal", "operand": "meta.environment.math, string.other.math", "match_all": true },
+			// don't insert, if there is an open dollar math environment at the end of the line
+			{ "key": "eol_selector", "operator": "not_equal", 
+			  "operand": "meta.environment.math.inline.dollar - punctuation.definition.string.end, string.other.math - punctuation.definition.string.end",
+			  "match_all": true }
 		] 
+	},
+	// fully close $$ environments
+	{ "keys": ["$"], "command": "insert", "args": {"characters": "$$"}, 
+	"context":
+		[
+			{ "key": "setting.command_mode", "operator": "equal", "operand": false },
+			{ "key": "selector", "operator": "equal", "operand": "text.tex.latex meta.environment.math.block.dollar" },
+			{ "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
+			{ "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
+			// do not insert this if it is escaped
+			{ "key": "preceding_text", "operator": "not_regex_contains", "operand": "(?:\\\\\\\\)*(?:\\\\|\\$)$", "match_all": true }
+		]
 	},
 	// wrap in $
 	{ "keys": ["$"], "command": "insert_snippet", "args": {"contents": "\\$${0:$SELECTION}\\$"}, "context":

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -2,6 +2,19 @@
 LaTeX Package keymap for OS X
 */
 [
+	// these also override ST3 commands, but we simply run the same commands
+	// it is necessary so on ST2 we can implement our build selector
+	{	"keys": ["super+b"],
+		"context": [
+			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"},
+			{"key": "ltt_st_build", "operator": "equal", "operand": "<3080"}],
+		"command": "latextools_build_selector"},
+	{	"keys": ["super+shift+b"],
+		"context": [
+			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"},
+			{"key": "ltt_st_build", "operator": "equal", "operand": "<3080"}],
+		"command": "latextools_build_selector",
+			"args": {"select": true}},
 
 	// New-style keybindings use "cmd+l" as a prefix
 	// This overrides "extend selection to line", which is remapped to

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -2,6 +2,19 @@
 LaTeX Package keymap for Windows
 */
 [
+	// these also override ST3 commands, but we simply run the same commands
+	// it is necessary so on ST2 we can implement our build selector
+	{	"keys": ["ctrl+b"],
+		"context": [
+			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"},
+			{"key": "ltt_st_build", "operator": "equal", "operand": "<3080"}],
+		"command": "latextools_build_selector"},
+	{	"keys": ["ctrl+shift+b"],
+		"context": [
+			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"},
+			{"key": "ltt_st_build", "operator": "equal", "operand": "<3080"}],
+		"command": "latextools_build_selector",
+			"args": {"select": true}},
 
 	// New-style keybindings use "ctrl+l" as a prefix
 	// This overrides "extend selection to line", which is remapped to

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -294,13 +294,30 @@ LaTeX Package keymap for Windows
 	"context":  
 		[
 			{ "key": "setting.command_mode", "operator": "equal", "operand": false },
-			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"},
+			{ "key": "selector", "operator": "equal", "operand": "text.tex.latex" },
 			{ "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
 			{ "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
-			/*{ "key": "following_text", "operator": "regex_contains", "operand": "^(?:\t| |\\)|])", "match_all": true },*/
-			{ "key": "preceding_text", "operator": "not_regex_contains", "operand": "[\"a-zA-Z0-9_]$", "match_all": true },
-			{ "key": "eol_selector", "operator": "not_equal", "operand": "string.quoted.double", "match_all": true }
+			// do not insert this if it is escaped
+			{ "key": "preceding_text", "operator": "not_regex_contains", "operand": "(?:\\\\\\\\)*(?:\\\\|\\$)$", "match_all": true },
+			// don't insert, it inside math environments
+			{ "key": "selector", "operator": "not_equal", "operand": "meta.environment.math, string.other.math", "match_all": true },
+			// don't insert, if there is an open dollar math environment at the end of the line
+			{ "key": "eol_selector", "operator": "not_equal", 
+			  "operand": "meta.environment.math.inline.dollar - punctuation.definition.string.end, string.other.math - punctuation.definition.string.end",
+			  "match_all": true }
 		] 
+	},
+	// fully close $$ environments
+	{ "keys": ["$"], "command": "insert", "args": {"characters": "$$"}, 
+	"context":
+		[
+			{ "key": "setting.command_mode", "operator": "equal", "operand": false },
+			{ "key": "selector", "operator": "equal", "operand": "text.tex.latex meta.environment.math.block.dollar" },
+			{ "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
+			{ "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
+			// do not insert this if it is escaped
+			{ "key": "preceding_text", "operator": "not_regex_contains", "operand": "(?:\\\\\\\\)*(?:\\\\|\\$)$", "match_all": true }
+		]
 	},
 	// wrap in $
 	{ "keys": ["$"], "command": "insert_snippet", "args": {"contents": "\\$${0:$SELECTION}\\$"}, "context":

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -148,6 +148,14 @@ LaTeX Package keymap for Windows
 			{"key": "lt_fill_all_env.open_curly", "operator": "equal", "operand": true, "match_all": true}],
 		"command": "latex_fill_all", "args": {"completion_type": "env", "insert_char": "{"}},
 
+	{	"keys": ["{"],
+		"context":  [
+			{"key": "setting.disable_latex_ref_cite_auto_trigger", "operator": "not_equal", "operand": true},
+			{"key": "selector", "operator": "equal", "operand": "text.tex.latex - comment"},
+			{"key": "selection_empty", "operator": "equal", "operand": true, "match_all": true},
+			{"key": "lt_fill_all_glossary.open_curly", "operator": "equal", "operand": true, "match_all": true}],
+		"command": "latex_fill_all", "args": {"completion_type": "glossary", "insert_char": "{"}},
+
 	{	"keys": ["="],
 		"context":  [
 			{"key": "setting.disable_latex_ref_cite_auto_trigger", "operator": "not_equal", "operand": true},

--- a/LaTeX.sublime-build
+++ b/LaTeX.sublime-build
@@ -25,5 +25,51 @@
 	"linux":
 		{
 			"file_regex": "^(...*?):([0-9]+): ([0-9]*)([^\\.]+)"
+		},
+
+	"variants":
+	[
+		{
+			"name": "Traditional",
+			"builder": "traditional"
+		},
+		{
+			"name": "PdfLaTeX",
+			"builder": "traditional",
+			"program": "pdflatex"
+		},
+		{
+			"name": "XeLaTeX",
+			"builder": "traditional",
+			"program": "xelatex"
+		},
+		{
+			"name": "LuaLaTeX",
+			"builder": "traditional",
+			"program": "lualatex"
+		},
+		{
+			"name": "Basic Builder",
+			"builder": "basic"
+		},
+		{
+			"name": "Basic Builder - PdfLaTeX",
+			"builder": "basic",
+			"program": "pdflatex"
+		},
+		{
+			"name": "Basic Builder - XeLaTeX",
+			"builder": "basic",
+			"program": "xelatex"
+		},
+		{
+			"name": "Basic Builder - LuaLaTeX",
+			"builder": "basic",
+			"program": "lualatex"
+		},
+		{
+			"name": "Script Builder",
+			"builder": "script"
 		}
+	]
 }

--- a/LaTeX.sublime-commands
+++ b/LaTeX.sublime-commands
@@ -4,6 +4,7 @@
 	{ "caption": "LaTeXTools: Jump to PDF", "command": "jump_to_pdf"},
 	{ "caption": "LaTeXTools: Show Word Count", "command": "texcount"},
 	{ "caption": "LaTeXTools: Show toggles", "command": "toggle_show"},
+	{ "caption": "LaTeXTools: Input commands an scan document", "command": "latex_search_command_input"},
 	{ "caption": "LaTeXTools: Reset user settings to default", "command": "latextools_migrate"},
 	{ "caption": "LaTeXTools: Create mousemap in user folder", "command": "latextools_create_mousemap"},
 	{ "caption": "LaTeXTools: View TeX package documentation", "command": "latex_pkg_doc"},

--- a/LaTeX.sublime-commands
+++ b/LaTeX.sublime-commands
@@ -4,7 +4,7 @@
 	{ "caption": "LaTeXTools: Jump to PDF", "command": "jump_to_pdf"},
 	{ "caption": "LaTeXTools: Show Word Count", "command": "texcount"},
 	{ "caption": "LaTeXTools: Show toggles", "command": "toggle_show"},
-	{ "caption": "LaTeXTools: Input commands an scan document", "command": "latex_search_command_input"},
+	{ "caption": "LaTeXTools: Search for commands in document", "command": "latex_search_command_input"},
 	{ "caption": "LaTeXTools: Reset user settings to default", "command": "latextools_migrate"},
 	{ "caption": "LaTeXTools: Create mousemap in user folder", "command": "latextools_create_mousemap"},
 	{ "caption": "LaTeXTools: View TeX package documentation", "command": "latex_pkg_doc"},

--- a/LaTeX.sublime-commands
+++ b/LaTeX.sublime-commands
@@ -1,8 +1,9 @@
 [
-	{ "caption": "LaTeXTools: Delete temporary files", "command": "delete_temp_files"},
+	{ "caption": "LaTeXTools: Check system", "command": "latextools_system_check"},
+	{ "caption": "LaTexTools: Delete temporary files", "command": "delete_temp_files"},
 	{ "caption": "LaTeXTools: View PDF", "command": "view_pdf"},
 	{ "caption": "LaTeXTools: Jump to PDF", "command": "jump_to_pdf"},
-	{ "caption": "LaTeXTools: Show Word Count", "command": "texcount"},
+	{ "caption": "LaTeXTools: Show word count", "command": "texcount"},
 	{ "caption": "LaTeXTools: Show toggles", "command": "toggle_show"},
 	{ "caption": "LaTeXTools: Search for commands in document", "command": "latex_search_command_input"},
 	{ "caption": "LaTeXTools: Reset user settings to default", "command": "latextools_migrate"},

--- a/LaTeXTools.sublime-settings
+++ b/LaTeXTools.sublime-settings
@@ -30,6 +30,9 @@
 	// You can also use toggle: C-l,t,a,e
 	"env_auto_trigger": false,
 
+	// Fill-helper autocompletion trigger for glossary entries \gls{ and \acrfull{
+	"glossary_auto_trigger": true,
+
 	// Fill-helper autocompletion trigger for tex directive values after TEX directive=
 	// You can also use toggle: C-l,t,a,d
 	"tex_directive_auto_trigger": true,

--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -22,6 +22,11 @@
                             },
                             { "caption": "-" },
                             {
+                                "command": "latextools_system_check",
+                                "caption": "Check System"
+                            },
+                            { "caption": "-" },
+                            {
                                 "command": "open_latextools_default_settings",
                                 "caption": "Settings – Default (read-only)"
                             },

--- a/README.markdown
+++ b/README.markdown
@@ -435,6 +435,7 @@ Selecting any entry in the list will take you to the corresponding place in the 
 This is an IDE-like mouse navigation, which executes a jump depending on the context around the cursor. It is easy to use and intuitive. Just click with the mouse on a command while pressing the modifier key. The corresponding jump will be executed. Supported jump types are:
 
 - Jump to referenced labels (e.g. `\ref`)
+- Show and jump to label usages (e.g. `\label`)
 - Jump to citation entries in bibliography files (e.g. `\cite`)
 - Open included files (e.g. `\input` or `\include`)
 - Open root file from `%!TEX root =...` magic comment

--- a/README.markdown
+++ b/README.markdown
@@ -286,8 +286,17 @@ The default ST Build command takes care of the following:
 * It parses the tex log file and lists all errors, warnings and, if enabled, bad boxes in an output panel at the bottom of the ST window: click on any error/warning/bad boxes to jump to the corresponding line in the text, or use the ST-standard Next Error/Previous Error commands.
 * It invokes the PDF viewer for your platform and performs a forward search: that is, it displays the PDF page where the text corresponding to the current cursor position is located.
 
+### Selecting Build Variant
 
-### Toggling window focus following a build
+**Keybinding:** `C-shift-b` (standard ST3 keybinding)
+
+LaTeXTools offers a range of build variants to select standard build options. These variants can be used to customize the options passed to the LaTeXTools builder, so that you don't need a project file or to use any of the `%!TEX` directives to change, e.g., the build system used. Variants are provided for the supported builders and for the supported programs.
+
+In addition, custom Sublime build files can be created to add your own variants to standard LaTeXTools commands. For more on this, see the section on [Sublime Build Files](#sublime-build-files).
+
+**Note**: The settings provided by build variants *override* settings specified in the file itself or in your settings. This means, for example, if you select a build variant that changes the program, `%!TEX program` directives or `program` settings will be ignored. If you want to return LaTeXTools back to its default behavior, please select the **LaTeX** build variant.
+
+### Toggling window focus following a build ###
 
 **Keybinding:** `C-l,t,f` (yes, this means `C-l`, then `t`, then `f`)
 
@@ -822,7 +831,46 @@ In addition, to ensure that forward and backward sync work, you need to ensure t
 
 Finally, please remember that script commands on Windows are run using `cmd.exe` which means that if your script uses any UNC paths will have to use `pushd` and `popd` to properly map and unmap a network drive.
 
-### Customizing the Build System
+### Sublime Build Files
+
+LaTeXTools now has some support for custom `.sublime-build` files or builders specified in your project settings. For an overview of `.sublime-build` files in general, please see [the Unofficial Documentation](http://sublime-text-unofficial-documentation.readthedocs.io/en/latest/reference/build_systems.html) (which is generally a great resource about Sublime Text). For more on adding builders to project files, see [the relevant section of the Sublime documentation](https://www.sublimetext.com/docs/3/projects.html). This section will cover the basics of creating a `.sublime-build` file that works with LaTeXTools.
+
+At a minimum, your `.sublime-build` file must have the following elements:
+
+```json
+{
+	"target": "make_pdf",
+	"selector": "text.tex.latex",
+
+	"osx":
+		{
+			"file_regex": "^(...*?):([0-9]+): ([0-9]*)([^\\.]+)"
+		},
+
+	"windows":
+		{
+			"file_regex": "^((?:.:)?[^:\n\r]*):([0-9]+):?([0-9]+)?:? (.*)$"
+		},
+
+	"linux":
+		{
+			"file_regex": "^(...*?):([0-9]+): ([0-9]*)([^\\.]+)"
+		}
+}
+```
+
+Otherwise, other features may not work as expected. In addition, you can specify the following other parameters:
+
+|Parameter|Description|
+|-----------------|------------------------------------------------------------|
+|`builder`|Overrides the `builder` setting. May refer to any valid LaTeXTools builder.|
+|`program`|Overrides the `program` setting or `%!TEX program` macro. May be one of `pdflatex`, `xelatex`, or `lualatex`|
+|`command`|Overrides the `command` setting, providing the command run by the builder. This is only useful if you use the `traditional` builder. For the format, see the relevant [builder setting](#builder-settings).|
+|`env`|Overrides the `env` setting. Should be a dictionary similar to `env`, but note that when specified in a `.sublime-build` file, it is not, by default, platform-specific.|
+|`path`|Overrides the `texpath` settings. Note that if you set this, you are responsible for ensuring that the appropriate LaTeX install can still be found.|
+|`script_commands`|Overrides the `script_commands` setting used by the `script` builder. This is only useful if the `builder` is also changed to `script`.|
+
+### Custom Builders
 
 Since the release on March 13, 2014 ([v3.1.0](https://github.com/SublimeText/LaTeXTools/tree/v3.1.0)), LaTeXTools has had support for custom build systems, in addition to the default build system, called the "traditional" builder. Details on how to customize the traditional builder are documented above. If neither the traditional builder nor the script builder meet your needs you can also create a completely custom builder which should be able to support just about anything you can imagine. Let me know if you are interested in writing a custom builder!
 

--- a/README.markdown
+++ b/README.markdown
@@ -437,6 +437,7 @@ This is an IDE-like mouse navigation, which executes a jump depending on the con
 - Jump to referenced labels (e.g. `\ref`)
 - Show and jump to label usages (e.g. `\label`)
 - Jump to citation entries in bibliography files (e.g. `\cite`)
+- Jump to glossary entries (e.g. `\gls`)
 - Open included files (e.g. `\input` or `\include`)
 - Open root file from `%!TEX root =...` magic comment
 - Open bibliographies (e.g. `\bibliography` or `\addbibresource`)
@@ -554,7 +555,9 @@ The following options are currently available (defaults in parentheses):
 - `cite_auto_trigger` (`true`): if `true`, typing e.g. `\cite{` brings up the citation completion quick panel, without the need to type `C-l,x`. If `false`, you must explicitly type `C-l,x`.
 - `ref_auto_trigger` (`true`): ditto, but for `\ref{` and similar reference commands
 - `fill_auto_trigger` (`true`): ditto, but for package and file inclusion commands (see Fill Helper feature above)
-- `env_auto_trigger` (`true`): ditto, but for environment completions
+- `env_auto_trigger` (`false`): ditto, but for environment completions
+- `glossary_auto_trigger` (`true`): ditto, but for glossary completions
+- `tex_directive_auto_trigger` (`true`): ditto, but for tex directive completions
 - `cwl_autoload` (`true`): whether to load cwl completions based on packages (see the LaTeX-cwl feature) 
 - `cwl_completion` (`prefixed`): when to activate the cwl completion poput (see LaTeX-cwl feature above)
 - `cwl_list` (`["latex-document.cwl", "tex.cwl", "latex-dev", "latex-209.cwl", "latex-l2tabu.cwl", "latex-mathsymbols.cwl"]`): list of cwl files to load

--- a/builders/basicBuilder.py
+++ b/builders/basicBuilder.py
@@ -23,11 +23,12 @@ else:
 
 import os
 import re
-import subprocess
 import sys
 # This will work because makePDF.py puts the appropriate
 # builders directory in sys.path
 from pdfBuilder import PdfBuilder
+
+from latextools_utils.external_command import external_command
 
 # Standard LaTeX warning
 CITATIONS_REGEX = re.compile(r"Warning: Citation `.+' on page \d+ undefined")
@@ -227,26 +228,11 @@ class BasicBuilder(PdfBuilder):
             # NOTE this cwd is not reused by any of the other command
             cwd = output_directory
 
-        startupinfo = None
-        preexec_fn = None
-
-        if sublime.platform() == 'windows':
-            startupinfo = subprocess.STARTUPINFO()
-            startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
-        else:
-            preexec_fn = os.setsid
-
         command.append(self.job_name)
-        print(command)
-        bib_proc = subprocess.Popen(
+        return external_command(
             command,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
-            startupinfo=startupinfo,
-            shell=False,
             env=env,
             cwd=cwd,
-            preexec_fn=preexec_fn
+            preexec_fn=os.setid if sublime.platform() != 'windows' else None,
+            use_texpath=False
         )
-
-        return bib_proc

--- a/builders/basicBuilder.py
+++ b/builders/basicBuilder.py
@@ -28,7 +28,7 @@ import sys
 # builders directory in sys.path
 from pdfBuilder import PdfBuilder
 
-from latextools_utils.external_command import external_command
+from latextools_utils.external_command import external_command, get_texpath
 
 # Standard LaTeX warning
 CITATIONS_REGEX = re.compile(r"Warning: Citation `.+' on page \d+ undefined")
@@ -227,6 +227,7 @@ class BasicBuilder(PdfBuilder):
             # now we modify cwd to be the output directory
             # NOTE this cwd is not reused by any of the other command
             cwd = output_directory
+        env['PATH'] = get_texpath()
 
         command.append(self.job_name)
         return external_command(

--- a/builders/scriptBuilder.py
+++ b/builders/scriptBuilder.py
@@ -1,15 +1,15 @@
 from pdfBuilder import PdfBuilder
 import sublime
 
-import subprocess
-from subprocess import Popen, PIPE, STDOUT
-
-from copy import copy
 import os
 import re
 import sys
 
 from string import Template
+
+from latextools_utils.external_command import (
+	external_command, get_texpath, update_env
+)
 
 if sys.version_info < (3, 0):
 	strbase = basestring
@@ -45,6 +45,8 @@ class ScriptBuilder(PdfBuilder):
 		plat = sublime.platform()
 		self.cmd = self.builder_settings.get(plat, {}).get("script_commands", None)
 		self.env = self.builder_settings.get(plat, {}).get("env", None)
+		# Loaded here so it is calculated on the main thread
+		self.texpath = get_texpath() or os.environ['PATH']
 
 	# Very simple here: we yield a single command
 	# Also add environment variables
@@ -55,9 +57,10 @@ class ScriptBuilder(PdfBuilder):
 		# create an environment to be used for all subprocesses
 		# adds any settings from the `env` dict to the current
 		# environment
-		env = copy(os.environ)
+		env = dict(os.environ)
+		env['PATH'] = self.texpath
 		if self.env is not None and isinstance(self.env, dict):
-			env.update(self.env)
+			update_env(env, self.env)
 
 		if self.cmd is None:
 			sublime.error_message(
@@ -97,32 +100,20 @@ class ScriptBuilder(PdfBuilder):
 				else:
 					self.display("Invoking '{0}'... ".format(cmd))
 
-			startupinfo = None
-			preexec_fn = None
-
-			if sublime.platform() == 'windows':
-				startupinfo = subprocess.STARTUPINFO()
-				startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
-			else:
-				preexec_fn = os.setsid
-
-			p = Popen(
-				cmd,
-				stdout=PIPE,
-				stderr=STDOUT,
-				startupinfo=startupinfo,
-				shell=True,
-				env=env,
-				cwd=self.tex_dir,
-				preexec_fn=preexec_fn
+			yield (
+				# run with use_texpath=False as we have already configured
+				# the environment above, including the texpath
+				external_command(
+					cmd, env=env, cwd=self.tex_dir, use_texpath=False,
+					shell=True
+				),
+				""
 			)
-
-			yield (p, "")
 
 			self.display("done.\n")
 
 			# This is for debugging purposes
-			if self.display_log and p.stdout is not None:
+			if self.display_log and self.out is not None:
 				self.display("\nCommand results:\n")
 				self.display(self.out)
 				self.display("\n\n")

--- a/builders/traditionalBuilder.py
+++ b/builders/traditionalBuilder.py
@@ -4,10 +4,13 @@ import sublime
 if sublime.version() < '3000':
 	# we are on ST2 and Python 2.X
 	_ST3 = False
+	strbase = basestring
 else:
 	_ST3 = True
+	strbase = str
 
 from pdfBuilder import PdfBuilder
+import shlex
 
 DEBUG = False
 
@@ -29,25 +32,25 @@ class TraditionalBuilder(PdfBuilder):
 	def __init__(self, *args):
 		# Sets the file name parts, plus internal stuff
 		super(TraditionalBuilder, self).__init__(*args)
-		#Now do our own initialization: set our name
+		# Now do our own initialization: set our name
 		self.name = "Traditional Builder"
 		# Display output?
 		self.display_log = self.builder_settings.get("display_log", False)
 		# Build command, with reasonable defaults
 		plat = sublime.platform()
 		# Figure out which distro we are using
-		try:
-			distro = self.platform_settings["distro"]
-		except KeyError: # default to miktex on windows and texlive elsewhere
-			if plat == 'windows':
-				distro = "miktex"
-			else:
-				distro = "texlive"
+		distro = self.platform_settings.get(
+			"distro",
+			"miktex" if plat == "windows" else "texlive"
+		)
 		if distro in ["miktex", ""]:
 			default_command = DEFAULT_COMMAND_WINDOWS_MIKTEX
-		else: # osx, linux, windows/texlive, everything else really!
+		else:  # osx, linux, windows/texlive, everything else really!
 			default_command = DEFAULT_COMMAND_LATEXMK
+
 		self.cmd = self.builder_settings.get("command", default_command)
+		if isinstance(self.cmd, strbase):
+			self.cmd = shlex.split(self.cmd)
 
 	#
 	# Very simple here: we yield a single command
@@ -59,7 +62,7 @@ class TraditionalBuilder(PdfBuilder):
 
 		# See if the root file specifies a custom engine
 		engine = self.engine
-		cmd = self.cmd[:] # Warning! If I omit the [:], cmd points to self.cmd!
+		cmd = self.cmd[:]  # Warning! If I omit the [:], cmd points to self.cmd!
 
 		# check if the command even wants the engine selected
 		engine_used = False

--- a/jumpToPDF.py
+++ b/jumpToPDF.py
@@ -1,13 +1,19 @@
 # ST2/ST3 compat
 from __future__ import print_function 
 import sublime
-import sys
+import sublime_plugin
+
+import os
+import traceback
+import re
+
 if sublime.version() < '3000':
     # we are on ST2 and Python 2.X
 	_ST3 = False
 	import getTeXRoot
 	from latextools_utils.is_tex_file import is_tex_file
 	from latextools_utils import get_setting
+	from latextools_utils.external_command import external_command
 	from latextools_utils.output_directory import (
 		get_output_directory, get_jobname
 	)
@@ -21,6 +27,7 @@ else:
 	from . import getTeXRoot
 	from .latextools_utils.is_tex_file import is_tex_file
 	from .latextools_utils import get_setting
+	from .latextools_utils.external_command import external_command
 	from .latextools_utils.output_directory import (
 		get_output_directory, get_jobname
 	)
@@ -29,10 +36,6 @@ else:
 		get_plugin, add_plugin_path, NoSuchPluginException,
 		add_whitelist_module
 	)
-
-import sublime_plugin, os.path, subprocess, time
-import traceback
-import re
 
 SUBLIME_VERSION = re.compile(r'Build (\d{4})', re.UNICODE)
 DEFAULT_VIEWERS = {
@@ -94,18 +97,9 @@ def focus_st():
 		wait_time = plat_settings.get('keep_focus_delay', 0.5)
 
 		def keep_focus():
-			startupinfo = None
-			shell = False
-			if platform == 'windows':
-				startupinfo = subprocess.STARTUPINFO()
-				startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
-				shell = _ST3
-
-			subprocess.Popen(
+			external_command(
 				sublime_command,
-				startupinfo=startupinfo,
-				shell=shell,
-				env=os.environ
+				use_texpath=False
 			)
 
 		if hasattr(sublime, 'set_async_timeout'):

--- a/jumpto_anywhere.py
+++ b/jumpto_anywhere.py
@@ -7,7 +7,7 @@ import sublime_plugin
 try:
     _ST3 = True
     from .getTeXRoot import get_tex_root
-    from .latextools_utils import analysis, utils
+    from .latextools_utils import analysis, ana_utils, quickpanel, utils
     from .latextools_utils.tex_directives import TEX_DIRECTIVE
     from .latex_cite_completions import NEW_STYLE_CITE_REGEX
     from .latex_ref_completions import NEW_STYLE_REF_REGEX
@@ -16,7 +16,7 @@ try:
 except:
     _ST3 = False
     from getTeXRoot import get_tex_root
-    from latextools_utils import analysis, utils
+    from latextools_utils import analysis, ana_utils, quickpanel, utils
     from latextools_utils.tex_directives import TEX_DIRECTIVE
     from latex_cite_completions import NEW_STYLE_CITE_REGEX
     from latex_ref_completions import NEW_STYLE_REF_REGEX
@@ -73,6 +73,31 @@ def _get_selected_arg(view, com_reg, pos):
     arg = arg.strip()
 
     return arg
+
+
+def _show_usage_label(view, args):
+    tex_root = get_tex_root(view)
+    if tex_root is None:
+        return False
+    ana = analysis.analyze_document(tex_root)
+
+    def is_correct_ref(c):
+        command = ("\\" + c.command + "{")[::-1]
+        return NEW_STYLE_REF_REGEX.match(command) and c.args == args
+
+    refs = ana.filter_commands(is_correct_ref)
+
+    if len(refs) == 0:
+        sublime.error_message("No references for '{0}' found.".format(args))
+        return
+    elif len(refs) == 1:
+        ref = refs[0]
+        utils.open_and_select_region(view, ref.file_name, ref.region)
+        return
+
+    captions = [ana_utils.create_rel_file_str(ana, r) for r in refs]
+
+    quickpanel.show_quickpanel(captions, refs)
 
 
 def _jumpto_ref(view, com_reg, pos):
@@ -263,6 +288,8 @@ class JumptoTexAnywhereCommand(sublime_plugin.TextCommand):
         elif NEW_STYLE_CITE_REGEX.match(reversed_command):
             sublime.status_message("Jump to citation '{0}'".format(args))
             _jumpto_cite(view, com_reg, pos)
+        elif command == "label":
+            _show_usage_label(view, args)
         # check if it is any kind of input command
         elif any(reg.match(com_reg.group(0)) for reg in INPUT_REG_EXPS):
             kwargs = {

--- a/jumpto_anywhere.py
+++ b/jumpto_anywhere.py
@@ -10,6 +10,7 @@ try:
     from .latextools_utils import analysis, ana_utils, quickpanel, utils
     from .latextools_utils.tex_directives import TEX_DIRECTIVE
     from .latex_cite_completions import NEW_STYLE_CITE_REGEX
+    from .latex_glossary_completions import ACR_LINE_RE, GLO_LINE_RE
     from .latex_ref_completions import NEW_STYLE_REF_REGEX
     from .jumpto_tex_file import INPUT_REG, BIB_REG, IMAGE_REG
     from . import jumpto_tex_file
@@ -19,6 +20,7 @@ except:
     from latextools_utils import analysis, ana_utils, quickpanel, utils
     from latextools_utils.tex_directives import TEX_DIRECTIVE
     from latex_cite_completions import NEW_STYLE_CITE_REGEX
+    from latex_glossary_completions import ACR_LINE_RE, GLO_LINE_RE
     from latex_ref_completions import NEW_STYLE_REF_REGEX
     from jumpto_tex_file import INPUT_REG, BIB_REG, IMAGE_REG
     import jumpto_tex_file
@@ -169,6 +171,31 @@ def _jumpto_cite(view, com_reg, pos):
     sublime.status_message(message)
 
 
+def _jumpto_glo(view, com_reg, pos, acr=False):
+    tex_root = get_tex_root(view)
+    if not tex_root:
+        return
+    ana = analysis.analyze_document(tex_root)
+    if not acr:
+        commands = ana.filter_commands(
+            ["newglossaryentry", "longnewglossaryentry"])
+    else:
+        commands = ana.filter_commands("newacronym")
+
+    iden = com_reg.group("args")
+    try:
+        entry = next(c for c in commands if c.args == iden)
+    except:
+        message = "Glossary definition not found for '{0}'".format(iden)
+        print(message)
+        sublime.status_message(message)
+        return
+    message = "Jumping to Glossary '{0}'.".format(iden)
+    print(message)
+    sublime.status_message(message)
+    utils.open_and_select_region(view, entry.file_name, entry.args_region)
+
+
 def _jumpto_pkg_doc(view, com_reg, pos):
     def view_doc(package):
         message = "Try opening documentation for package '{0}'".format(package)
@@ -290,6 +317,12 @@ class JumptoTexAnywhereCommand(sublime_plugin.TextCommand):
             _jumpto_cite(view, com_reg, pos)
         elif command == "label":
             _show_usage_label(view, args)
+        elif GLO_LINE_RE.match(reversed_command):
+            sublime.status_message("Jump to glossary '{0}'".format(args))
+            _jumpto_glo(view, com_reg, pos)
+        elif ACR_LINE_RE.match(reversed_command):
+            sublime.status_message("Jump to acronym '{0}'".format(args))
+            _jumpto_glo(view, com_reg, pos, acr=True)
         # check if it is any kind of input command
         elif any(reg.match(com_reg.group(0)) for reg in INPUT_REG_EXPS):
             kwargs = {

--- a/jumpto_tex_file.py
+++ b/jumpto_tex_file.py
@@ -20,7 +20,7 @@ except:
 
 
 INPUT_REG = re.compile(
-    r"\\(?:input|include|subfile)"
+    r"\\(?:input|include|subfile|loadglsentries)"
     r"\{(?P<file>[^}]+)\}",
     re.UNICODE
 )

--- a/jumpto_tex_file.py
+++ b/jumpto_tex_file.py
@@ -1,7 +1,6 @@
 import re
 import os
 import codecs
-import subprocess
 import shlex
 import traceback
 
@@ -12,10 +11,12 @@ try:
     _ST3 = True
     from .getTeXRoot import get_tex_root
     from .latextools_utils import get_setting, utils
+    from .latextools_utils.external_command import external_command
 except:
     _ST3 = False
     from getTeXRoot import get_tex_root
     from latextools_utils import get_setting, utils
+    from latextools_utils.external_command import external_command
 
 
 INPUT_REG = re.compile(
@@ -161,8 +162,8 @@ def _jumpto_image_file(view, window, tex_root, file_name):
             # if $file is not used, append the file path
             else:
                 command.append(file_path)
-            print("RUN: {0}".format(command))
-            subprocess.Popen(command)
+
+            external_command(command)
 
     psystem = sublime.platform()
     commands = get_setting("open_image_command", {}).get(psystem, None)

--- a/kpsewhich.py
+++ b/kpsewhich.py
@@ -1,27 +1,21 @@
 from __future__ import print_function
-import subprocess
-from subprocess import Popen, PIPE
-import os
+
 import sublime
-import sys
+import traceback
 
 if sublime.version() < '3000':
     _ST3 = False
-    from latextools_utils import get_setting
+    from latextools_utils.external_command import (
+        check_output, CalledProcessError
+    )
 else:
     _ST3 = True
-    from .latextools_utils import get_setting
+    from .latextools_utils.external_command import (
+        check_output, CalledProcessError
+    )
 
 __all__ = ['kpsewhich']
 
-def get_texpath():
-    platform_settings = get_setting(sublime.platform(), {})
-    texpath = platform_settings.get('texpath', '')
-
-    if not _ST3:
-        return os.path.expandvars(texpath).encode(sys.getfilesystemencoding())
-    else:
-        return os.path.expandvars(texpath)
 
 def kpsewhich(filename, file_format=None):
     # build command
@@ -30,36 +24,21 @@ def kpsewhich(filename, file_format=None):
         command.append('-format=%s' % (file_format))
     command.append(filename)
 
-    # setup the environment to run the subprocess in
-    texpath = get_texpath() or os.environ['PATH']
-    env = dict(os.environ)
-    env['PATH'] = texpath
-
     try:
-        # Windows-specific adjustments
-        startupinfo = None
-        shell = False
-        if sublime.platform() == 'windows':
-            # ensure console window doesn't show
-            startupinfo = subprocess.STARTUPINFO()
-            startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
-            shell = True
-
-        print('Running %s' % (' '.join(command)))
-        p = Popen(
-            command,
-            stdout=PIPE,
-            stdin=PIPE,
-            startupinfo=startupinfo,
-            shell=shell,
-            env=env
+        return check_output(command)
+    except CalledProcessError as e:
+        sublime.error_message(
+            'An error occurred while trying to run kpsewhich. '
+            'Files in your TEXINPUTS could not be accessed.'
         )
-        path = p.communicate()[0].decode('utf-8').rstrip()
-        if p.returncode == 0:
-            return path
-        else:
-            sublime.error_message('An error occurred while trying to run kpsewhich. TEXMF tree could not be accessed.')
+        if e.output:
+            print(e.output)
+        traceback.print_exc()
     except OSError:
-        sublime.error_message('Could not run kpsewhich. Please ensure that your texpath setting is configured correctly in the LaTeXTools settings.')
+        sublime.error_message(
+            'Could not run kpsewhich. Please ensure that your texpath '
+            'setting is correct.'
+        )
+        traceback.print_exc()
 
     return None

--- a/latexDocumentationViewer.py
+++ b/latexDocumentationViewer.py
@@ -2,34 +2,22 @@ from __future__ import print_function
 
 import sublime
 import sublime_plugin
-
-import os
-import subprocess
-from subprocess import Popen
+import traceback
 
 try:
     from latextools_utils import get_setting
-    from latextools_utils.distro_utils import using_miktex
+    from latextools_utils.external_command import external_command
 except ImportError:
     from .latextools_utils import get_setting
-    from .latextools_utils.distro_utils import using_miktex
+    from .latextools_utils.external_command import external_command
 
 if sublime.version() < '3000':
     _ST3 = False
     strbase = basestring
-    import sys
 else:
     _ST3 = True
     strbase = str
 
-def get_texpath():
-    platform_settings = get_setting(sublime.platform(), {})
-    texpath = platform_settings.get('texpath', '')
-
-    if not _ST3:
-        return os.path.expandvars(texpath).encode(sys.getfilesystemencoding())
-    else:
-        return os.path.expandvars(texpath)
 
 def _view_texdoc(file):
     if file is None:
@@ -38,41 +26,14 @@ def _view_texdoc(file):
         raise TypeError('File must be a string')
 
     command = ['texdoc']
-
-    texpath = get_texpath() or os.environ['PATH']
-    env = dict(os.environ)
-    env['PATH'] = texpath
+    if sublime.platform() == 'windows' and using_miktex():
+        command.append('--view')
+    command.append(file)
 
     try:
-        # Windows-specific adjustments
-        startupinfo = None
-        shell = False
-        if sublime.platform() == 'windows':
-            # ensure console window doesn't show
-            startupinfo = subprocess.STARTUPINFO()
-            startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
-            shell = True
-
-            if using_miktex():
-                command.append('--view')
-
-        command.append(file)
-
-        print('Running %s' % (' '.join(command)))
-        p = Popen(
-            command,
-            stdout=None,
-            stdin=None,
-            startupinfo=startupinfo,
-            shell=shell,
-            env=env
-        )
-
-        if not using_miktex():  # see http://sourceforge.net/p/miktex/bugs/2367/
-            p.communicate()     # cannot rely on texdoc --view from MiKTeX returning
-            if p.returncode != 0:
-                sublime.error_message('An error occurred while trying to run texdoc.')
+        external_command(command)
     except OSError:
+        traceback.print_exc()
         sublime.error_message('Could not run texdoc. Please ensure that your texpath setting is configured correctly in the LaTeXTools settings.')
 
 class LatexPkgDocCommand(sublime_plugin.WindowCommand):
@@ -84,8 +45,7 @@ class LatexPkgDocCommand(sublime_plugin.WindowCommand):
                 isinstance(file, strbase) and
                 file != ''
             ):
-                window.run_command('latex_view_doc',
-                    {'file': file})
+                window.run_command('latex_view_doc', {'file': file})
 
         window.show_input_panel(
             'View documentation for which package?',

--- a/latex_cwl_completions.py
+++ b/latex_cwl_completions.py
@@ -500,7 +500,7 @@ def parse_line_as_environment(line):
 
 
 def parse_line_as_command(line):
-    return line, command_to_snippet(line)
+    return command_to_snippet(line)
 
 
 # actually does the parsing of the cwl files
@@ -533,10 +533,19 @@ def parse_cwl_file(cwl, s, parse_line=parse_line_as_command):
         # tracking purposes, but we can ignore it
         line = line.split('#', 1)[0]
 
+        # trailing spaces aren't relevant (done here in case they precede)
+        # a # char
+        line = line.rstrip()
+
         result = parse_line(line)
         if result is None:
             continue
-        (keyword, insertion) = result
+        keyword, insertion = result
+
+        # pad the keyword with spaces; this is to keep the size of the
+        # autocompletions consistent regardless of the returned results
+        keyword = keyword.ljust(50)
+
         item = (u'%s\t%s' % (keyword, method), insertion)
         completions.append(item)
 

--- a/latex_glossary_completions.py
+++ b/latex_glossary_completions.py
@@ -1,0 +1,104 @@
+import re
+
+import sublime
+
+
+_ST3 = sublime.version() >= "3000"
+
+if _ST3:
+    from .latex_fill_all import FillAllHelper
+    from .latextools_utils import analysis, cache, get_setting
+    from .latextools_utils.tex_directives import get_tex_root
+
+else:
+    from latextools_utils.internal_types import FillAllHelper
+    from latextools_utils import analysis, cache, get_setting
+    from latextools_utils.tex_directives import get_tex_root
+
+
+GLO_LINE_RE = re.compile(
+    r"([^{}\[\]]*)\{*?(?:lp|lobmys)?sl(?:G|g)\\"
+)
+ACR_LINE_RE = re.compile(
+    r"([^{}\[\]]*)\{(?:lluf|gnol|trohs)rca\\"
+)
+
+
+def _get_glo_completions(ana, prefix, ac):
+    comp = []
+    glo_commands = ana.filter_commands(
+        ["newglossaryentry", "longnewglossaryentry"])
+    if ac:
+        comp = [(a.args + "\tGlossary", a.args) for a in glo_commands]
+    else:
+        glo_commands = [a for a in glo_commands if a.args.startswith(prefix)]
+        comp = [
+            [a.args]
+            for a in glo_commands
+        ], [
+            a.args for a in glo_commands
+        ]
+    return comp
+
+
+def _get_acr_completions(ana, prefix, ac):
+    acr_commands = ana.filter_commands("newacronym")
+    if ac:
+        comp = [(a.args + "\tAcronym", a.args) for a in acr_commands]
+    else:
+        acr_commands = [a for a in acr_commands if a.args.startswith(prefix)]
+        comp = [
+            [a.args, "{0} - {1}".format(a.args2 or "", a.args3 or "")]
+            for a in acr_commands
+        ], [
+            a.args for a in acr_commands
+        ]
+    return comp
+
+
+class GlossaryFillAllHelper(FillAllHelper):
+    def _get_completions(self, view, prefix, line, comp_type="glo", ac=False):
+        tex_root = get_tex_root(view)
+        if not tex_root:
+            return []
+
+        cache_name = "glocomp_{0}_{1}".format(comp_type, "ac" if ac else "kbd")
+
+        def make_compl():
+            ana = analysis.get_analysis(tex_root)
+            if comp_type == "glo":
+                comp = _get_glo_completions(ana, prefix, ac)
+            elif comp_type == "acr":
+                comp = _get_acr_completions(ana, prefix, ac)
+            else:
+                comp = []
+            return comp
+
+        comp = cache.cache(tex_root, cache_name, make_compl)
+        return comp
+
+    def get_compl_type(self, line):
+        if GLO_LINE_RE.match(line[::-1]):
+            return "glo"
+        elif ACR_LINE_RE.match(line[::-1]):
+            return "acr"
+        else:
+            return "glo"
+
+    def get_auto_completions(self, view, prefix, line):
+        comp_type = self.get_compl_type(line)
+        comp = self._get_completions(
+            view, prefix, line, comp_type=comp_type, ac=True)
+        return comp
+
+    def get_completions(self, view, prefix, line):
+        comp_type = self.get_compl_type(line)
+        comp = self._get_completions(
+            view, prefix, line, comp_type=comp_type, ac=False)
+        return comp
+
+    def matches_line(self, line):
+        return bool(GLO_LINE_RE.match(line) or ACR_LINE_RE.match(line))
+
+    def is_enabled(self):
+        return get_setting("glossary_auto_trigger", True)

--- a/latextools_sublime_version_listener.py
+++ b/latextools_sublime_version_listener.py
@@ -1,0 +1,67 @@
+from __future__ import print_function
+
+import sublime
+import sublime_plugin
+
+import operator as opi
+import re
+
+VERSION = sublime.version()
+
+
+class LatextoolsSublimeVersionEventListener(sublime_plugin.EventListener):
+
+    def __init__(self, *args, **kwargs):
+        super(LatextoolsSublimeVersionEventListener, self).__init__(
+            *args, **kwargs
+        )
+
+        self.ops = {
+            sublime.OP_EQUAL: self._equal,
+            sublime.OP_NOT_EQUAL: self._not_equal,
+            sublime.OP_REGEX_MATCH: self._regex_match,
+            sublime.OP_NOT_REGEX_MATCH: self._not_regex_match,
+            sublime.OP_REGEX_CONTAINS: self._regex_contains,
+            sublime.OP_NOT_REGEX_CONTAINS: self._not_regex_contains
+        }
+
+    def on_query_context(self, view, key, operator, operand, match_all):
+        if not key == 'ltt_st_build':
+            return None
+
+        try:
+            return self.ops[operator](operand)
+        # caution
+        except KeyError:
+            return None
+
+    def _equal(self, operand):
+        # if the operand starts with <, >, <=, >=, (=, or ==)
+        # change the compare operator correspondingly and strip the operand
+        if operand[0:1] in "<>=":
+            i = 1 if operand[1:2] != "=" else 2
+            comp_str, operand = operand[:i], operand[i:]
+            compare = {
+                "<": opi.lt,
+                ">": opi.gt,
+                "<=": opi.le,
+                ">=": opi.ge
+            }.get(comp_str, opi.eq)
+        else:
+            compare = opi.eq
+        return compare(VERSION, operand.strip())
+
+    def _not_equal(self, operand):
+        return not self._equal(operand)
+
+    def _regex_match(self, operand):
+        return re.match(operand, VERSION, re.UNICODE) is not None
+
+    def _not_regex_match(self, operand):
+        return re.match(operand, VERSION, re.UNICODE) is None
+
+    def _regex_contains(self, operand):
+        return re.search(operand, VERSION, re.UNICODE) is not None
+
+    def _not_regex_contains(self, operand):
+        return re.search(operand, VERSION, re.UNICODE) is None

--- a/latextools_utils/ana_utils.py
+++ b/latextools_utils/ana_utils.py
@@ -1,0 +1,41 @@
+import os
+
+import sublime
+
+
+def line_nr(ana, entry):
+    """
+    Return the line number of the start of a command.
+
+    ATTENTION: This is not the row of the command. If you want that
+        use rowcol!
+    ana -- The analysis, which contains the entry
+    entry -- The command entry to get the line number for
+    """
+    rowcol = ana.rowcol(entry.file_name)
+    return rowcol(entry.region.begin())[0] + 1
+
+
+def create_rel_file_str(ana, entry):
+    """
+    Create a nice string "rel_path/to/file.tex:line" to show the command
+    position to the users.
+
+    tex_root -- The path to the root file
+    ana -- The analysis, which contains the entry
+    entry -- The command entry to get the line number for
+    """
+    tex_root = ana.tex_root()
+    file_name = entry.file_name
+    file_dir, file_base = os.path.split(file_name)
+    root_dir, _ = os.path.split(tex_root)
+    if file_dir == root_dir:
+        show_path = file_base
+    else:
+        show_path = os.path.relpath(file_dir, root_dir)
+        show_path = os.path.join(show_path, file_base)
+        # prettify on windows
+        if sublime.platform() == "windows":
+            show_path = show_path.replace('\\', '/')
+    line = line_nr(ana, entry)
+    return "{show_path}:{line}".format(**locals())

--- a/latextools_utils/analysis.py
+++ b/latextools_utils/analysis.py
@@ -73,7 +73,7 @@ _RE_COMMENT = re.compile(
 )
 # the analysis will walk recursively into the included files
 # i.e. the 'args' field of the command
-_input_commands = ["input", "include", "subfile"]
+_input_commands = ["input", "include", "subfile", "loadglsentries"]
 
 
 # FLAGS

--- a/latextools_utils/cache.py
+++ b/latextools_utils/cache.py
@@ -307,7 +307,6 @@ def _create_cache_timestamp(cache_path):
 
 def _validate_life_span(cache_path):
     life_span = _read_life_span()
-    print(u"life_span: '{0}'".format(life_span))
     # if life span is none: only manual deletion
     if life_span is None:
         return
@@ -336,7 +335,6 @@ def _read_cache_timestamp(cache_path):
 def _read_life_span():
     try:
         life_span_string = get_setting("local_cache_life_span")
-        print(u"life_span_string: '{0}'".format(repr(life_span_string)))
         if not life_span_string:
             raise Exception(u"No lifespan defined")
         if life_span_string == "infinite":
@@ -362,8 +360,6 @@ def _convert_life_span_string(life_span_string):
     """Converts a TIME_RE compatible life span string,
     raises an exception if it is not compatible"""
     (d, h, m, s) = TIME_RE.match(life_span_string).groups()
-    print(u"User options: (days: {0}, hours: {1}, minutes: {2}, seconds: {3}):"
-          .format(repr(d), repr(h), repr(m), repr(s)))
     # time conversions in seconds
     times = [(s, 1), (m, 60), (h, 3600), (d, 86400)]
     # sum the converted times

--- a/latextools_utils/external_command.py
+++ b/latextools_utils/external_command.py
@@ -1,0 +1,319 @@
+# This module provides tools for running external commands.
+# It is mainly a wrapper around subprocess calls with some defaults
+# specific to LaTeXTools. In particular:
+#
+#  * it executes commands using the PATH defined by the texpath setting
+#  * STDOUT is set to PIPE
+#  * it redirects STDERR to STDOUT
+#  * it hides the console window on Windows
+#
+# All of these, except hiding the console window, can be overridden via
+# parameters passed to the method. The point is to simplify running things
+# the way we normally do.
+#
+# All of the above can be overridden using optional parameters
+#
+# It provides six functions:
+#   update_env() - takes two dict-like objects and updates first with the
+#       values from the second. It should be OS-encoding safe on ST2 which
+#       does not automatically handle this.
+#   get_texpath() - returns the user configured texpath, properly encoded with
+#       any environment variables expanded
+#   external_command() - essentially the equivalent of subprocess.Popen()
+#       provides the greatest degree of flexibility
+#   execute_command() - calls external_command() and then
+#       subprocess.communicate(), returning the returncode, stdout and stderr
+#       output
+#   check_call() - a version of subprocess.check_call() implemented on top of
+#       execute_command()
+#   check_output() - a version of subprocess.check_output() implemented on top
+#       of execute_command()
+#
+# In addition to a subset of standard Popen parameters, all the functions built
+# on external_command() accept a `use_texpath` parameter which indicates
+# whether or not to run the executable with the PATH set to the current value
+# of texpath.
+
+import sublime
+
+import os
+import re
+import sys
+from shlex import split
+
+import subprocess
+from subprocess import Popen, PIPE, STDOUT, CalledProcessError
+
+try:
+    from latextools_utils.settings import get_setting
+    from latextools_utils.utils import run_on_main_thread
+except ImportError:
+    from .settings import get_setting
+    from .utils import run_on_main_thread
+
+if sys.version_info < (3,):
+    from pipes import quote
+
+    def expand_vars(texpath):
+        return os.path.expandvars(texpath).encode(sys.getfilesystemencoding())
+
+    def update_env(old_env, new_env):
+        encoding = sys.getfilesystemencoding()
+        old_env.update(
+            dict((k.encode(encoding), v) for (k, v) in new_env.items())
+        )
+
+    # reraise implementation from 6
+    exec("""def reraise(tp, value, tb=None):
+    raise tp, value, tb
+""")
+
+    strbase = basestring
+else:
+    from imp import reload
+    from shlex import quote
+
+    def expand_vars(texpath):
+        return os.path.expandvars(texpath)
+
+    def update_env(old_env, new_env):
+        old_env.update(new_env)
+
+    # reraise implementation from 6
+    def reraise(tp, value, tb=None):
+        if value is None:
+            value = tp()
+        if value.__traceback__ is not tb:
+            raise value.with_traceback(tb)
+        raise value
+
+    strbase = str
+
+_ST3 = sublime.version() >= '3000'
+
+__all__ = ['external_command', 'execute_command', 'check_call', 'check_output',
+           'get_texpath', 'update_env']
+
+
+def get_texpath():
+    '''
+    Returns the texpath setting with any environment variables expanded
+    '''
+    def _get_texpath():
+        try:
+            texpath = get_setting(sublime.platform(), {}).get('texpath')
+        except AttributeError:
+            # hack to reload this module in case the calling module was
+            # reloaded
+            exc_info = sys.exc_info
+            try:
+                reload(sys.modules[get_texpath.__module__])
+                texpath = get_setting(sublime.platform(), {}).get('texpath')
+            except:
+                reraise(*exc_info)
+
+        return expand_vars(texpath) if texpath is not None else None
+
+    # ensure _get_texpath() is run in a thread-safe manner
+    return run_on_main_thread(_get_texpath, default_value=None)
+
+# marker object used to indicate default behaviour
+__sentinel__ = object()
+
+
+# wrapper to handle common logic for executing subprocesses
+def external_command(command, cwd=None, shell=False, env=None,
+                     stdin=__sentinel__, stdout=__sentinel__,
+                     stderr=__sentinel__, preexec_fn=None,
+                     use_texpath=True):
+    '''
+    Takes a command object to be passed to subprocess.Popen.
+
+    Returns a subprocess.Popen object for the corresponding process.
+
+    Raises OSError if command not found
+    '''
+    if command is None:
+        raise ValueError('command must be a string or list of strings')
+
+    _env = dict(os.environ)
+
+    if use_texpath:
+        _env['PATH'] = get_texpath() or os.environ['PATH']
+
+    if env is not None:
+        update_env(_env, env)
+
+    # if command is a string rather than a list
+    if isinstance(command, strbase):
+        if sys.version_info < (3,):
+            command = str(command)
+
+        command = split(command)
+
+        if sys.version_info < (3,):
+            command = [unicode(c) for c in command]
+
+    # Windows-specific adjustments
+    startupinfo = None
+    if sublime.platform() == 'windows':
+        # ensure console window doesn't show
+        startupinfo = subprocess.STARTUPINFO()
+        startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
+
+    if stdin is __sentinel__:
+        stdin = None
+
+    if stdout is __sentinel__:
+        stdout = PIPE
+
+    if stderr is __sentinel__:
+        stderr = STDOUT
+
+    try:
+        print(u'Running "{0}"'.format(u' '.join([quote(s) for s in command])))
+    except UnicodeError:
+        try:
+            print(u'Running "{0}"'.format(command))
+        except:
+            pass
+
+    p = Popen(
+        command,
+        stdin=stdin,
+        stdout=stdout,
+        stderr=stderr,
+        startupinfo=startupinfo,
+        preexec_fn=preexec_fn,
+        shell=shell,
+        env=_env,
+        cwd=cwd
+    )
+
+    return p
+
+
+def execute_command(command, cwd=None, shell=False, env=None,
+                    stdin=__sentinel__, stdout=__sentinel__,
+                    stderr=__sentinel__, preexec_fn=None,
+                    use_texpath=True):
+    '''
+    Takes a command to be passed to subprocess.Popen and runs it. This is
+    similar to subprocess.call().
+
+    Returns a tuple consisting of
+        (return_code, stdout, stderr)
+
+    By default stderr is redirected to stdout, so stderr will normally be
+    blank. This can be changed by calling execute_command with stderr set
+    to subprocess.PIPE or any other valid value.
+
+    Raises OSError if the executable is not found
+    '''
+    def convert_stream(stream):
+        if stream is None:
+            return u''
+        else:
+            return u'\n'.join(
+                re.split(r'\r?\n', stream.decode('utf-8').rstrip())
+            )
+
+    p = external_command(
+        command,
+        cwd=cwd,
+        shell=shell,
+        env=env,
+        stdin=stdin,
+        stdout=stdout,
+        stderr=stderr,
+        preexec_fn=preexec_fn,
+        use_texpath=use_texpath
+    )
+
+    stdout, stderr = p.communicate()
+    return (
+        p.returncode,
+        convert_stream(stdout),
+        convert_stream(stderr)
+    )
+
+
+def check_call(command, cwd=None, shell=False, env=None,
+               stdin=__sentinel__, stdout=__sentinel__,
+               stderr=__sentinel__, preexec_fn=None,
+               use_texpath=True):
+    '''
+    Takes a command to be passed to subprocess.Popen.
+
+    Raises CalledProcessError if the command returned a non-zero value
+    Raises OSError if the executable is not found
+
+    This is pretty much identical to subprocess.check_call(), but
+    implemented here to take advantage of LaTeXTools-specific tooling.
+    '''
+    # since we don't do anything with the output, by default just ignore it
+    if stdout is __sentinel__:
+        stdout = open(os.devnull, 'w')
+    if stderr is __sentinel__:
+        stderr = open(os.devnull, 'w')
+
+    returncode, stdout, stderr = execute_command(
+        command,
+        cwd=cwd,
+        shell=shell,
+        env=env,
+        stdin=stdin,
+        stderr=stderr,
+        preexec_fn=preexec_fn,
+        use_texpath=use_texpath
+    )
+
+    if returncode:
+        e = CalledProcessError(
+            returncode,
+            command
+        )
+        raise e
+
+    return 0
+
+
+def check_output(command, cwd=None, shell=False, env=None,
+                 stdin=__sentinel__, stderr=__sentinel__,
+                 preexec_fn=None, use_texpath=True):
+    '''
+    Takes a command to be passed to subprocess.Popen.
+
+    Returns the output if the command was successful.
+
+    By default stderr is redirected to stdout, so this will return any output
+    to either stream. This can be changed by calling execute_command with
+    stderr set to subprocess.PIPE or any other valid value.
+
+    Raises CalledProcessError if the command returned a non-zero value
+    Raises OSError if the executable is not found
+
+    This is pretty much identical to subprocess.check_output(), but
+    implemented here since it is unavailable in Python 2.6's library.
+    '''
+    returncode, stdout, stderr = execute_command(
+        command,
+        cwd=cwd,
+        shell=shell,
+        env=env,
+        stdin=stdin,
+        stderr=stderr,
+        preexec_fn=preexec_fn,
+        use_texpath=use_texpath
+    )
+
+    if returncode:
+        e = CalledProcessError(
+            returncode,
+            command
+        )
+        e.output = stdout
+        e.stderr = stderr
+        raise e
+
+    return stdout

--- a/latextools_utils/external_command.py
+++ b/latextools_utils/external_command.py
@@ -161,6 +161,12 @@ def external_command(command, cwd=None, shell=False, env=None,
         startupinfo = subprocess.STARTUPINFO()
         startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
 
+        # encode cwd in the file system encoding; this is necessary to support
+        # some non-ASCII paths; see PR #878. Thanks to anamewing for the
+        # suggested fix
+        if not _ST3 and cwd:
+            cwd = cwd.encode(sys.getfilesystemencoding())
+
     if stdin is __sentinel__:
         stdin = None
 

--- a/latextools_utils/parser_utils.py
+++ b/latextools_utils/parser_utils.py
@@ -1,9 +1,14 @@
 import re
 
 # used to convert arguments and optional arguments into fields
-BRACES_MATCH_REGEX = re.compile(r'\{([^\{\}\[\]]*)\}|\[([^\{\}\[\]]*)\]')
+BRACES_MATCH_RX = re.compile(r'\{([^\}]*)\}|\[([^\]]*)\]')
 
-ALPHAS_REGEX = re.compile(r'^[a-zA-Z]+$')
+ALPHAS_RX = re.compile(r'^[a-zA-Z]+$')
+
+BEGIN_ENV_RX = re.compile(
+    r'\\begin{(?P<name>[^\}]*)\}'
+    r'(?:(?P<remainder1>.*)(?P<item>\\item)|(?P<remainder2>.*))'
+)
 
 
 def command_to_snippet(keyword):
@@ -11,7 +16,8 @@ def command_to_snippet(keyword):
     converts a LaTeX command, like \dosomething{arg1}{arg2} into a ST snippet
     like \dosomething{$1:arg1}{$2:arg2}
     '''
-    # Replace strings in [] and {} with snippet syntax
+
+    # replace strings in [] and {} with snippet syntax
     def replace_braces(matchobj):
         replace_braces.index += 1
         if matchobj.group(1) is not None:
@@ -23,13 +29,45 @@ def command_to_snippet(keyword):
 
     replace_braces.index = 0
 
-    replace, n = BRACES_MATCH_REGEX.subn(
-        replace_braces, keyword
-    )
+    # \begin{}...\end{} pairs should be inserted together
+    m = BEGIN_ENV_RX.match(keyword)
+    if m:
+        item = bool(m.group('item'))
+        name = m.group('name')
 
-    # I do not understand why sometimes the input will eat the '\' charactor
-    # before it! This code is to avoid these things.
-    if n == 0 and ALPHAS_REGEX.search(keyword[1:].strip()) is not None:
-        return keyword
+        # \begin{}, no environment
+        if not name:
+            replace, n = BRACES_MATCH_RX.subn(replace_braces, keyword)
+            final = replace + u'\n${0}\n\\end{{$1}}$0'.format(
+                replace_braces.index + 1
+            )
+
+            return keyword, final
+        # \begin{} with environment
+        # only create fields for any other items
+        else:
+            remainder = m.group('remainder1') or m.group('remainder2') or ''
+            replace, n = BRACES_MATCH_RX.subn(replace_braces, remainder)
+
+            final = u'\\begin{{{0}}}{1}\n'.format(name, replace or '')
+            if item:
+                final += u'\\item ${0}\n'.format(replace_braces.index + 1)
+            else:
+                final += u'${0}\n'.format(replace_braces.index + 1)
+            final += u'\\end{{{0}}}$0'.format(name)
+
+            # having \item at the end of the display value messes with
+            # completions thus, we cut the \item off the end
+            if item:
+                return keyword[:-5], final
+            else:
+                return keyword, final
     else:
-        return replace
+        replace, n = BRACES_MATCH_RX.subn(replace_braces, keyword)
+
+        # I do not understand why sometimes the input will eat the '\'
+        # character before it! This code is to avoid these things.
+        if n == 0 and ALPHAS_RX.search(keyword[1:].strip()) is not None:
+            return keyword, keyword
+        else:
+            return keyword, replace

--- a/latextools_utils/sublime_utils.py
+++ b/latextools_utils/sublime_utils.py
@@ -3,6 +3,7 @@
 # already available in ST3.
 from __future__ import print_function
 
+import codecs
 import json
 import os
 import re
@@ -10,16 +11,18 @@ import sublime
 import sys
 
 try:
-	from latextools_utils.external_command import check_output
-	from latextools_utils.settings import get_setting
-	from latextools_utils.system import which
+    from latextools_utils.external_command import check_output
+    from latextools_utils.settings import get_setting
+    from latextools_utils.system import which
 except ImportError:
-	from .external_command import check_output
-	from .settings import get_setting
-	from .system import which
+    from .external_command import check_output
+    from .settings import get_setting
+    from .system import which
 
 
 __all__ = ['normalize_path', 'get_project_file_name']
+
+_ST3 = sublime.version() >= '3000'
 
 # used by get_sublime_exe()
 SUBLIME_VERSION = re.compile(r'Build (\d{4})', re.UNICODE)
@@ -31,12 +34,12 @@ SUBLIME_VERSION = re.compile(r'Build (\d{4})', re.UNICODE)
 # to:
 # 	c:\path\to\file.ext
 def normalize_path(path):
-	if sublime.platform() == 'windows':
-		return os.path.normpath(
-			path.lstrip('/').replace('/', ':/', 1)
-		)
-	else:
-		return path
+    if sublime.platform() == 'windows':
+        return os.path.normpath(
+            path.lstrip('/').replace('/', ':/', 1)
+        )
+    else:
+        return path
 
 
 # returns the path to the sublime executable
@@ -178,102 +181,175 @@ def get_sublime_exe():
 
 
 def get_project_file_name(view):
-	try:
-		return view.window().project_file_name()
-	except AttributeError:
-		return _get_project_file_name(view)
+    try:
+        return view.window().project_file_name()
+    except AttributeError:
+        return _get_project_file_name(view)
 
 
 # long, complex hack for ST2 to load the project file from the current session
 def _get_project_file_name(view):
-	try:
-		window_id = view.window().id()
-	except AttributeError:
-		print('Could not determine project file as view does not seem to have an associated window.')
-		return None
+    try:
+        window_id = view.window().id()
+    except AttributeError:
+        print('Could not determine project file as view does not seem to have an associated window.')
+        return None
 
-	if window_id is None:
-		return None
+    if window_id is None:
+        return None
 
-	session = os.path.normpath(
-		os.path.join(
-			sublime.packages_path(),
-			'..',
-			'Settings',
-			'Session.sublime_session'
-		)
-	)
+    session = os.path.normpath(
+        os.path.join(
+            sublime.packages_path(),
+            '..',
+            'Settings',
+            'Session.sublime_session'
+        )
+    )
 
-	auto_save_session = os.path.normpath(
-		os.path.join(
-			sublime.packages_path(),
-			'..',
-			'Settings',
-			'Auto Save Session.sublime_session'
-		)
-	)
+    auto_save_session = os.path.normpath(
+        os.path.join(
+            sublime.packages_path(),
+            '..',
+            'Settings',
+            'Auto Save Session.sublime_session'
+        )
+    )
 
-	session = auto_save_session if os.path.exists(auto_save_session) else session
+    session = auto_save_session if os.path.exists(auto_save_session) else session
 
-	if not os.path.exists(session):
-		return None
+    if not os.path.exists(session):
+        return None
 
-	project_file = None
+    project_file = None
 
-	# we tell that we have found the current project's project file by
-	# looking at the folders registered for that project and comparing it
-	# to the open directorys in the current window
-	found_all_folders = False
-	try:
-		with open(session, 'r') as f:
-			session_data = f.read().replace('\t', ' ')
-		j = json.loads(session_data, strict=False)
-		projects = j.get('workspaces', {}).get('recent_workspaces', [])
+    # we tell that we have found the current project's project file by
+    # looking at the folders registered for that project and comparing it
+    # to the open directorys in the current window
+    found_all_folders = False
+    try:
+        with open(session, 'r') as f:
+            session_data = f.read().replace('\t', ' ')
+        j = json.loads(session_data, strict=False)
+        projects = j.get('workspaces', {}).get('recent_workspaces', [])
 
-		for project_file in projects:
-			found_all_folders = True
+        for project_file in projects:
+            found_all_folders = True
 
-			project_file = normalize_path(project_file)
-			try:
-				with open(project_file, 'r') as fd:
-					project_json = json.loads(fd.read(), strict=False)
+            project_file = normalize_path(project_file)
+            try:
+                with open(project_file, 'r') as fd:
+                    project_json = json.loads(fd.read(), strict=False)
 
-				if 'folders' in project_json:
-					project_folders = project_json['folders']
-					for directory in view.window().folders():
-						found = False
-						for folder in project_folders:
-							folder_path = normalize_path(folder['path'])
-							# handle relative folder paths
-							if not os.path.isabs(folder_path):
-								folder_path = os.path.normpath(
-									os.path.join(os.path.dirname(project_file), folder_path)
-								)
+                if 'folders' in project_json:
+                    project_folders = project_json['folders']
+                    for directory in view.window().folders():
+                        found = False
+                        for folder in project_folders:
+                            folder_path = normalize_path(folder['path'])
+                            # handle relative folder paths
+                            if not os.path.isabs(folder_path):
+                                folder_path = os.path.normpath(
+                                    os.path.join(os.path.dirname(project_file), folder_path)
+                                )
 
-							if folder_path == directory:
-								found = True
-								break
+                            if folder_path == directory:
+                                found = True
+                                break
 
-						if not found:
-							found_all_folders = False
-							break
+                        if not found:
+                            found_all_folders = False
+                            break
 
-					if found_all_folders:
-						break
-			except:
-				found_all_folders = False
-	except:
-		pass
+                    if found_all_folders:
+                        break
+            except:
+                found_all_folders = False
+    except:
+        pass
 
-	if not found_all_folders:
-		project_file = None
+    if not found_all_folders:
+        project_file = None
 
-	if (
-		project_file is None or
-		not project_file.endswith('.sublime-project') or
-		not os.path.exists(project_file)
-	):
-		return None
+    if (
+        project_file is None or
+        not project_file.endswith('.sublime-project') or
+        not os.path.exists(project_file)
+    ):
+        return None
 
-	print('Using project file: %s' % project_file)
-	return project_file
+    print('Using project file: %s' % project_file)
+    return project_file
+
+
+# tokens used to clean-up JSON files
+TOKENIZER = re.compile(r'(?<![^\\]\\)"|(/\*)|(//)|(#)')
+QUOTE = re.compile(r'(?<![^\\]\\)"')
+NEWLINE = re.compile(r'\r?\n')
+
+
+def _parse_json_with_comments(filename):
+    with codecs.open(filename, 'r', 'utf-8', 'ignore') as f:
+        content = f.read()
+
+    try:
+        return json.loads(content)
+    except:
+        pass
+
+    # pre-process to strip comments
+    new_content = []
+    index = 0
+
+    content_length = len(content) - 1
+
+    match = TOKENIZER.search(content, index)
+    while match:
+        new_content.append(content[index:match.start()])
+
+        index = match.end()
+        value = match.group()
+
+        if value == '/*':
+            comment_end = content.find('*/', index)
+            if comment_end == -1:
+                # unbalanced comment
+                break
+            else:
+                new_lines = len(content[index:comment_end].split('\n')) - 1
+                new_content.extend(['\n'] * new_lines)
+                index = comment_end + 2
+        elif value == '//' or value == '#':
+            comment_end = NEWLINE.search(content, index)
+            if comment_end:
+                index = comment_end.end()
+            else:
+                break
+        elif value == '"':
+            new_content.append('"')
+            next_quote = QUOTE.search(content, index)
+            if next_quote:
+                new_content.append(content[index:next_quote.end()])
+                index = next_quote.end()
+            else:
+                # unclosed quote; return to generate json error
+                break
+
+        if index < content_length:
+            match = TOKENIZER.search(content, index)
+        else:
+            break
+
+    if index < content_length:
+        new_content.append(content[index:])
+
+    return json.loads(''.join(new_content))
+
+
+if _ST3:
+    def parse_json_with_comments(filename):
+        with codecs.open(filename, 'r', 'utf-8', 'ignore') as f:
+            content = f.read()
+        return sublime.decode_value(content)
+else:
+    parse_json_with_comments = _parse_json_with_comments

--- a/latextools_utils/utils.py
+++ b/latextools_utils/utils.py
@@ -108,7 +108,6 @@ def get_file_content(file_name, encoding="utf8", ignore=True,
 class TimeoutError(Exception):
     pass
 
-
 __sentinel__ = object()
 
 
@@ -116,8 +115,10 @@ def run_on_main_thread(func, timeout=10, default_value=__sentinel__):
     """
     Ensures the function, func is run on the main thread and returns the rsult
     of that function call.
+
     Note that this function blocks the thread it is executed on and should only
     be used when the result of the function call is necessary to continue.
+
     Arguments:
     func (callable): a no-args callable; functions that need args should
         be wrapped in a `functools.partial`
@@ -125,6 +126,7 @@ def run_on_main_thread(func, timeout=10, default_value=__sentinel__):
         TimeoutError is raised if this limit is reached a no `default_value`
         is specified
     default_value (any): the value to be returned if a timeout occurs
+
     Note that both timeout and default value are ignored when run in ST3 or
     from the main thread.
     """

--- a/makePDF.py
+++ b/makePDF.py
@@ -21,6 +21,9 @@ if sublime.version() < '3000':
 		get_aux_directory, get_output_directory, get_jobname
 	)
 	from latextools_utils.progress_indicator import ProgressIndicator
+	from latextools_utils.sublime_utils import (
+		get_project_file_name, parse_json_with_comments
+	)
 	from latextools_utils.utils import run_on_main_thread
 
 	strbase = basestring
@@ -42,6 +45,9 @@ else:
 		get_aux_directory, get_output_directory, get_jobname
 	)
 	from .latextools_utils.progress_indicator import ProgressIndicator
+	from .latextools_utils.sublime_utils import (
+		get_project_file_name, parse_json_with_comments
+	)
 	from .latextools_utils.utils import run_on_main_thread
 
 	strbase = str
@@ -57,6 +63,7 @@ import subprocess
 import types
 import traceback
 import shutil
+import glob
 import re
 
 DEBUG = False
@@ -74,14 +81,167 @@ if _HAS_PHANTOMS:
 # Encoding: especially useful for Windows
 # TODO: counterpart for OSX? Guess encoding of files?
 def getOEMCP():
-    # Windows OEM/Ansi codepage mismatch issue.
-    # We need the OEM cp, because texify and friends are console programs
-    import ctypes
-    codepage = ctypes.windll.kernel32.GetOEMCP()
-    return str(codepage)
+	# Windows OEM/Ansi codepage mismatch issue.
+	# We need the OEM cp, because texify and friends are console programs
+	import ctypes
+	codepage = ctypes.windll.kernel32.GetOEMCP()
+	return str(codepage)
 
 
+class LatextoolsBuildSelector(sublime_plugin.WindowCommand):
 
+	# stores last settings for build
+	WINDOWS = {}
+
+	if _ST3:
+		def load_build_system(self, build_system):
+			build_system = sublime.load_resource(build_system)
+	else:
+		def load_build_system(self, build_system):
+			build_system = os.path.normpath(
+				build_system.replace('Packages', sublime.packages_path())
+			)
+
+			return self.parse_json_with_comments(build_system)
+
+	def run(self, select=False):
+		select = False if select not in (True, False) else select
+		view = self.view = self.window.active_view()
+		if not select:
+			window_settings = self.WINDOWS.get(self.window.id(), {})
+			build_system = window_settings.get('build_system')
+
+			if build_system:
+				build_variant = window_settings.get('build_variant', '')
+				self.run_build(build_system, build_variant)
+				return
+
+		# no previously selected build system or select is True
+		# find all .sublime-build files
+		if _ST3:
+			sublime_build_files = sublime.find_resources('*.sublime-build')
+			project_settings = self.window.project_data()
+		else:
+			sublime_build_files = glob.glob(os.path.join(
+				sublime.packages_path(), '*', '*.sublime-build'
+			))
+			project_file_name = get_project_file_name(view)
+			if project_file_name is not None:
+				try:
+					project_settings = \
+						parse_json_with_comments(project_file_name)
+				except:
+					print('Error parsing project file')
+					traceback.print_exc()
+					project_settings = {}
+			else:
+				project_settings = {}
+
+		builders = []
+		for i, build_system in enumerate(
+			project_settings.get('build_systems', [])
+		):
+			if (
+				'selector' not in build_system or
+				view.score_selector(0, project_settings['selector']) > 0
+			):
+				try:
+					build_system['name']
+				except:
+					print('Could not determine name for build system {0}'.format(
+						build_system
+					))
+					continue
+
+				build_system['index'] = i
+				builders.append(build_system)
+
+		for filename in sublime_build_files:
+			try:
+				sublime_build = parse_json_with_comments(filename)
+			except:
+				print(u'Error parsing file {0}'.format(filename))
+				continue
+
+			if (
+				'selector' not in sublime_build or
+				view.score_selector(0, sublime_build['selector']) > 0
+			):
+				sublime_build['file'] = filename.replace(
+					sublime.packages_path(), 'Packages', 1
+				).replace(os.path.sep, '/')
+
+				sublime_build['name'] = os.path.splitext(
+					os.path.basename(sublime_build['file'])
+				)[0]
+
+				builders.append(sublime_build)
+
+		formatted_entries = []
+		build_system_variants = []
+		for builder in builders:
+			build_system_name = builder['name']
+			build_system_internal_name = builder.get(
+				'index', builder.get('file')
+			)
+
+			formatted_entries.append(build_system_name)
+			build_system_variants.append((build_system_internal_name, ''))
+
+			for variant in builder.get('variants', []):
+				try:
+					formatted_entries.append(
+						"{0} - {1}".format(
+							build_system_name,
+							variant['name']
+						)
+					)
+				except KeyError:
+					continue
+
+				build_system_variants.append(
+					(build_system_internal_name, variant['name'])
+				)
+
+		entries = len(formatted_entries)
+		if entries == 0:
+			self.window.run_command('build')
+		elif entries == 1:
+			build_system, build_variant = build_system_variants[0]
+			self.WINDOWS[self.window.id()] = {
+				'build_system': build_system,
+				'build_variant': build_variant
+			}
+			self.run_build(build_system, build_variant)
+		else:
+			def on_done(index):
+				# cancel
+				if index == -1:
+					return
+
+				build_system, build_variant = build_system_variants[index]
+				self.WINDOWS[self.window.id()] = {
+					'build_system': build_system,
+					'build_variant': build_variant
+				}
+				self.run_build(build_system, build_variant)
+
+			self.window.show_quick_panel(formatted_entries, on_done)
+
+	def run_build(self, build_system, build_variant):
+		if build_system.isdigit():
+			self.window.run_command(
+				'set_build_system', {'index': int(build_system)}
+			)
+		else:
+			self.window.run_command(
+				'set_build_system', {'file': build_system}
+			)
+
+		if build_variant:
+			self.window.run_command('build', {'variant': build_variant})
+		else:
+			self.window.run_command('build')
 
 
 # First, define thread class for async processing
@@ -385,13 +545,13 @@ class make_pdfCommand(sublime_plugin.WindowCommand):
 		self.proc = None
 		self.proc_lock = threading.Lock()
 
-	def run(self,
-			cmd="",
-			file_regex="",
-			path="",
-			update_phantoms_only=False,
-			hide_phantoms_only=False):
-
+	# **kwargs is unused but there so run can safely ignore any unknown
+	# parameters
+	def run(
+		self, file_regex="", program=None, builder=None, command=None,
+		env=None, path=None, script_commands=None, update_phantoms_only=False,
+		hide_phantoms_only=False, **kwargs
+	):
 		if update_phantoms_only:
 			if self.show_errors_inline:
 				self.update_phantoms()
@@ -492,18 +652,13 @@ class make_pdfCommand(sublime_plugin.WindowCommand):
 			return
 
 		# Get platform settings, builder, and builder settings
-		platform_settings  = get_setting(self.plat, {})
-		builder_name = get_setting("builder", "traditional")
+		platform_settings = get_setting(self.plat, {})
 		self.display_bad_boxes = get_setting("display_bad_boxes", False)
-		# This *must* exist, so if it doesn't, the user didn't migrate
-		if builder_name is None:
-			sublime.error_message(
-				"LaTeXTools: you need to migrate your preferences. See the README file for instructions."
-			)
-			self.window.run_command(
-				'hide_panel', {"panel": "output.latextools"}
-			)
-			return
+
+		if builder is not None:
+			builder_name = builder
+		else:
+			builder_name = get_setting("builder", "traditional")
 
 		# Default to 'traditional' builder
 		if builder_name in ['', 'default']:
@@ -515,6 +670,10 @@ class make_pdfCommand(sublime_plugin.WindowCommand):
 
 		builder_settings = get_setting("builder_settings", {})
 
+		# override the command
+		if command is not None:
+			builder_settings.set("command", command)
+
 		# parse root for any %!TEX directives
 		tex_directives = parse_tex_directives(
 			self.file_name,
@@ -523,8 +682,13 @@ class make_pdfCommand(sublime_plugin.WindowCommand):
 		)
 
 		# determine the engine
-		engine = tex_directives.get('program',
-			builder_settings.get("program", "pdflatex"))
+		if program is not None:
+			engine = program
+		else:
+			engine = tex_directives.get(
+				'program',
+				builder_settings.get("program", "pdflatex")
+			)
 
 		engine = engine.lower()
 
@@ -553,19 +717,22 @@ class make_pdfCommand(sublime_plugin.WindowCommand):
 		self.output_directory = get_output_directory(self.file_name)
 
 		# Read the env option (platform specific)
-		builder_platform_settings = builder_settings.get(self.plat)
-		if builder_platform_settings:
+		builder_platform_settings = builder_settings.get(self.plat, {})
+
+		if env is not None:
+			self.env = env
+		elif builder_platform_settings:
 			self.env = builder_platform_settings.get("env", None)
 		else:
 			self.env = None
-
-		# Now actually get the builder
-		builder_path = get_setting("builder_path", "")  # relative to ST packages dir!
 
 		# Safety check: if we are using a built-in builder, disregard
 		# builder_path, even if it was specified in the pref file
 		if builder_name in ['simple', 'traditional', 'script', 'basic']:
 			builder_path = None
+		else:
+			# relative to ST packages dir!
+			builder_path = get_setting("builder_path", "")
 
 		if builder_path:
 			bld_path = os.path.join(sublime.packages_path(), builder_path)
@@ -574,10 +741,16 @@ class make_pdfCommand(sublime_plugin.WindowCommand):
 		try:
 			builder = get_plugin('{0}_builder'.format(builder_name))
 		except NoSuchPluginException:
-			sublime.error_message("Cannot find builder " + builder_name + ".\n" \
-							      "Check your LaTeXTools Preferences")
+			sublime.error_message(
+				"Cannot find builder {0}.\n"
+				"Check your LaTeXTools Preferences".format(builder_name)
+			)
 			self.window.run_command('hide_panel', {"panel": "output.latextools"})
 			return
+
+		if builder_name == 'script' and script_commands:
+			builder_platform_settings['script_commands'] = script_commands
+			builder_settings[self.plat] = builder_platform_settings
 
 		print(repr(builder))
 		self.builder = builder(
@@ -595,7 +768,10 @@ class make_pdfCommand(sublime_plugin.WindowCommand):
 
 		# Now get the tex binary path from prefs, change directory to
 		# that of the tex root file, and run!
-		self.path = get_texpath() or os.environ['PATH']
+		if path is not None:
+			self.path = path
+		else:
+			self.path = get_texpath() or os.environ['PATH']
 
 		thread = CmdThread(self)
 		thread.start()
@@ -831,6 +1007,7 @@ class DoOutputEditCommand(sublime_plugin.TextCommand):
         self.view.insert(edit, self.view.size(), data)
         if selection_was_at_end:
             self.view.show(self.view.size())
+
 
 class DoFinishEditCommand(sublime_plugin.TextCommand):
     def run(self, edit):

--- a/makePDF.py
+++ b/makePDF.py
@@ -14,6 +14,9 @@ if sublime.version() < '3000':
 	from latextools_utils.is_tex_file import is_tex_file
 	from latextools_utils import get_setting
 	from latextools_utils.tex_directives import parse_tex_directives
+	from latextools_utils.external_command import (
+		execute_command, external_command, get_texpath, update_env
+	)
 	from latextools_utils.output_directory import (
 		get_aux_directory, get_output_directory, get_jobname
 	)
@@ -32,6 +35,9 @@ else:
 	from .latextools_utils.is_tex_file import is_tex_file
 	from .latextools_utils import get_setting
 	from .latextools_utils.tex_directives import parse_tex_directives
+	from .latextools_utils.external_command import (
+		execute_command, external_command, get_texpath, update_env
+	)
 	from .latextools_utils.output_directory import (
 		get_aux_directory, get_output_directory, get_jobname
 	)
@@ -92,32 +98,13 @@ class CmdThread ( threading.Thread ):
 		print ("Welcome to thread " + self.getName())
 		self.caller.output("[Compiling " + self.caller.file_name + "]")
 
+		env = dict(os.environ)
+		if self.caller.path:
+			env['PATH'] = self.caller.path
+
 		# Handle custom env variables
 		if self.caller.env:
-			old_env = os.environ;
-			if not _ST3:
-				os.environ.update(dict((k.encode(sys.getfilesystemencoding()), v) for (k, v) in self.caller.env.items()))
-			else:
-				os.environ.update(self.caller.env.items());
-
-		# Handle path; copied from exec.py
-		if self.caller.path:
-			# if we had an env, the old path is already backuped in the env
-			if not self.caller.env:
-				old_path = os.environ["PATH"]
-			# The user decides in the build system  whether he wants to append $PATH
-			# or tuck it at the front: "$PATH;C:\\new\\path", "C:\\new\\path;$PATH"
-			# Handle differently in Python 2 and 3, to be safe:
-			if not _ST3:
-				os.environ["PATH"] = os.path.expandvars(self.caller.path).encode(sys.getfilesystemencoding())
-			else:
-				os.environ["PATH"] = os.path.expandvars(self.caller.path)
-
-		# Set up Windows-specific parameters
-		if self.caller.plat == "windows":
-			# make sure console does not come up
-			startupinfo = subprocess.STARTUPINFO()
-			startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
+			update_env(env, self.caller.env)
 
 		# Now, iteratively call the builder iterator
 		#
@@ -138,31 +125,13 @@ class CmdThread ( threading.Thread ):
 					print(cmd)
 					# Now create a Popen object
 					try:
-						if self.caller.plat == "windows":
-							proc = subprocess.Popen(
-								cmd,
-								startupinfo=startupinfo,
-								stderr=subprocess.STDOUT,
-								stdout=subprocess.PIPE,
-								cwd=self.caller.tex_dir
-							)
-						elif self.caller.plat == "osx":
-							proc = subprocess.Popen(
-								cmd,
-								stderr=subprocess.STDOUT,
-								stdout=subprocess.PIPE,
-								env=os.environ,
-								preexec_fn=os.setsid,
-								cwd=self.caller.tex_dir
-							)
-						else:  # Must be linux
-							proc = subprocess.Popen(
-								cmd,
-								stderr=subprocess.STDOUT,
-								stdout=subprocess.PIPE,
-								preexec_fn=os.setsid,
-								cwd=self.caller.tex_dir
-							)
+						proc = external_command(
+							cmd,
+							env=env,
+							use_texpath=False,
+							preexec_fn=os.setsid if self.caller.plat != 'windows' else None,
+							cwd=self.caller.tex_dir
+						)
 					except:
 						self.caller.show_output_panel()
 						self.caller.output("\n\nCOULD NOT COMPILE!\n\n")
@@ -210,12 +179,6 @@ class CmdThread ( threading.Thread ):
 			self.caller.proc = None
 			traceback.print_exc()
 			return
-		finally:
-			# restore environment
-			if self.caller.env:
-				os.environ = old_env
-			elif self.caller.path:
-				os.environ['PATH'] = old_path
 
 		# Clean up
 		cmd_iterator.close()
@@ -440,18 +403,20 @@ class make_pdfCommand(sublime_plugin.WindowCommand):
 
 		# Try to handle killing
 		with self.proc_lock:
-			if self.proc: # if we are running, try to kill running process
+			if self.proc:  # if we are running, try to kill running process
 				self.output("\n\n### Got request to terminate compilation ###")
-				if sublime.platform() == 'windows':
-					startupinfo = subprocess.STARTUPINFO()
-					startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
-					subprocess.call(
-						'taskkill /t /f /pid {pid}'.format(pid=self.proc.pid),
-						startupinfo=startupinfo,
-						shell=True
-					)
-				else:
-					os.killpg(self.proc.pid, signal.SIGTERM)
+				try:
+					if sublime.platform() == 'windows':
+						execute_command(
+							'taskkill /t /f /pid {pid}'.format(pid=self.proc.pid),
+							use_texpath=False
+						)
+					else:
+						os.killpg(self.proc.pid, signal.SIGTERM)
+				except:
+					print('Exception occurred while killing build')
+					traceback.print_exc()
+
 				self.proc = None
 				return
 			else: # either it's the first time we run, or else we have no running processes
@@ -630,7 +595,8 @@ class make_pdfCommand(sublime_plugin.WindowCommand):
 
 		# Now get the tex binary path from prefs, change directory to
 		# that of the tex root file, and run!
-		self.path = platform_settings['texpath']
+		self.path = get_texpath() or os.environ['PATH']
+
 		thread = CmdThread(self)
 		thread.start()
 		print(threading.active_count())

--- a/search_commands.py
+++ b/search_commands.py
@@ -1,0 +1,47 @@
+import sublime_plugin
+
+try:
+    _ST3 = True
+    from .getTeXRoot import get_tex_root
+    from .latextools_utils import analysis, ana_utils, quickpanel
+except:
+    _ST3 = False
+    from getTeXRoot import get_tex_root
+    from latextools_utils import analysis, ana_utils, quickpanel
+
+
+def _make_caption(ana, entry):
+    text = entry.text
+    file_pos_str = ana_utils.create_rel_file_str(ana, entry)
+    return "{text} ({file_pos_str})".format(**locals())
+
+
+class LatexSearchCommandCommand(sublime_plugin.WindowCommand):
+    def run(self, commands):
+        window = self.window
+        view = window.active_view()
+        tex_root = get_tex_root(view)
+
+        ana = analysis.analyze_document(tex_root)
+        entries = ana.filter_commands(commands, flags=analysis.ALL_COMMANDS)
+
+        captions = [_make_caption(ana, e) for e in entries]
+        quickpanel.show_quickpanel(captions, entries)
+
+
+class LatexSearchCommandInputCommand(sublime_plugin.WindowCommand):
+    def is_visible(self, *args):
+        view = self.window.active_view()
+        return bool(view.score_selector(0, "text.tex"))
+
+    def run(self):
+        window = self.window
+
+        def on_done(text):
+            commands = [c.strip() for c in text.split(",")]
+            window.run_command("latex_search_command", {"commands": commands})
+
+        def do_nothing(text):
+            pass
+        caption = "Search for commands in a comma (,) separated list"
+        window.show_input_panel(caption, "", on_done, do_nothing, do_nothing)

--- a/system_check.hidden-tmLanguage
+++ b/system_check.hidden-tmLanguage
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>fileTypes</key>
+	<array>
+		<string>latextools-system-check</string>
+	</array>
+	<key>name</key>
+	<string>LaTeXTools System Check</string>
+	<key>hidden</key>
+	<true/>
+	<key>patterns</key>
+	<array>
+		<dict>
+			<key>match</key>
+			<string>-{3,}</string>
+			<key>name</key>
+			<string>comment.other.latextools-system-check.header</string>
+		</dict>
+		<dict>
+			<key>match</key>
+			<string>^(?:Variable|Program\s+Location|Builder|Viewer|LaTeX Output Setting)\s+.+$</string>
+			<key>name</key>
+			<string>comment.other.latextools-system-check.header</string>
+		</dict>
+		<dict>
+			<key>match</key>
+			<string>^(?:TeX Root|LaTeX Engine|LaTeX Options)\s*$</string>
+			<key>name</key>
+			<string>comment.other.latextools-system-check.header</string>
+		</dict>
+		<dict>
+			<key>match</key>
+			<string>\bavailable\b</string>
+			<key>name</key>
+			<string>markup.inserted.latextools-system-check.available</string>
+		</dict>
+		<dict>
+			<key>match</key>
+			<string>\bmissing\b</string>
+			<key>name</key>
+			<string>keyword.control.latextools-system-check.available</string>
+		</dict>
+		<dict>
+			<key>match</key>
+			<string>\bunavailable\b</string>
+			<key>name</key>
+			<string>keyword.control.latextools-system-check.available</string>
+		</dict>
+		<dict>
+			<key>match</key>
+			<string>True|False</string>
+			<key>name</key>
+			<string>constant.language.latextools-system-check.available</string>
+		</dict>
+	</array>
+	<key>scopeName</key>
+	<string>text.latextools-system-check</string>
+</dict>
+</plist>

--- a/system_check.py
+++ b/system_check.py
@@ -1,0 +1,670 @@
+from __future__ import print_function
+
+import sublime
+import sublime_plugin
+
+import copy
+from functools import partial
+import os
+import re
+import signal
+import subprocess
+import sys
+import textwrap
+import threading
+import traceback
+
+try:
+    from io import StringIO
+except ImportError:
+    # support ST2 on Linux
+    from StringIO import StringIO
+
+try:
+    from latextools_plugin import (
+        add_plugin_path, get_plugin, NoSuchPluginException,
+        _classname_to_internal_name
+    )
+    from latextools_utils import get_setting
+    from latextools_utils.distro_utils import using_miktex
+    from latextools_utils.output_directory import (
+        get_aux_directory, get_output_directory, get_jobname
+    )
+    from latextools_utils.progress_indicator import ProgressIndicator
+    from latextools_utils.system import which
+    from latextools_utils.tex_directives import parse_tex_directives
+    from latextools_utils.sublime_utils import get_sublime_exe
+    from latextools_utils.utils import run_on_main_thread
+    from jumpToPDF import DEFAULT_VIEWERS
+    from getTeXRoot import get_tex_root
+except ImportError:
+    from .latextools_plugin import (
+        add_plugin_path, get_plugin, NoSuchPluginException,
+        _classname_to_internal_name
+    )
+    from .latextools_utils import get_setting
+    from .latextools_utils.distro_utils import using_miktex
+    from .latextools_utils.output_directory import (
+        get_aux_directory, get_output_directory, get_jobname
+    )
+    from .latextools_utils.progress_indicator import ProgressIndicator
+    from .latextools_utils.system import which
+    from .latextools_utils.tex_directives import parse_tex_directives
+    from .latextools_utils.sublime_utils import get_sublime_exe
+    from .latextools_utils.utils import run_on_main_thread
+    from .jumpToPDF import DEFAULT_VIEWERS
+    from .getTeXRoot import get_tex_root
+
+if sys.version_info >= (3,):
+    unicode = str
+
+    def expand_vars(texpath):
+        return os.path.expandvars(texpath)
+
+    def update_environment(old, new):
+        old.update(new.items())
+
+    # reraise implementation from 6
+    def reraise(tp, value, tb=None):
+        if value is None:
+            value = tp()
+        if value.__traceback__ is not tb:
+            raise value.with_traceback(tb)
+        raise value
+else:
+    def expand_vars(texpath):
+        return os.path.expandvars(texpath).encode(sys.getfilesystemencoding())
+
+    def update_environment(old, new):
+        old.update(dict(
+            (k.encode(sys.getfilesystemencoding()), v)
+            for (k, v) in new.items()
+        ))
+
+    # reraise implementation from 6
+    exec("""def reraise(tp, value, tb=None):
+    raise tp, value, tb
+""")
+
+
+def _get_texpath(view):
+    texpath = get_setting(sublime.platform(), {}, view).get('texpath')
+    return expand_vars(texpath) if texpath is not None else None
+
+
+class SubprocessTimeoutThread(threading.Thread):
+    '''
+    A thread for monitoring a subprocess to kill the subprocess after a fixed
+    period of time
+    '''
+
+    def __init__(self, timeout, *args, **kwargs):
+        super(SubprocessTimeoutThread, self).__init__()
+        self.args = args
+        self.kwargs = kwargs
+        # ignore the preexec_fn if specified
+        if 'preexec_fn' in kwargs:
+            del self.kwargs['preexec_fn']
+
+        if 'startupinfo' in kwargs:
+            del self.kwargs['startupinfo']
+
+        if sublime.platform() == 'windows':
+            # ensure console window doesn't show
+            self.kwargs['startupinfo'] = startupinfo = subprocess.STARTUPINFO()
+            startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
+            self.kwargs['shell'] = True
+
+        self.timeout = timeout
+
+        self.returncode = None
+        self.stdout = None
+        self.stderr = None
+
+    def run(self):
+        if sublime.platform() != 'windows':
+            preexec_fn = os.setsid
+        else:
+            preexec_fn = None
+
+        try:
+            self._p = p = subprocess.Popen(
+                *self.args,
+                preexec_fn=preexec_fn,
+                **self.kwargs
+            )
+
+            self.stdout, self.stderr = p.communicate()
+            self.returncode = p.returncode
+        except Exception as e:
+            # just in case...
+            self.kill_process()
+            reraise(e)
+
+    def start(self):
+        super(SubprocessTimeoutThread, self).start()
+        self.join(self.timeout)
+
+        # if the timeout occurred, kill the entire process chain
+        if self.isAlive():
+            self.kill_process()
+
+    def kill_process(self):
+        try:
+            if sublime.platform == 'windows':
+                startupinfo = subprocess.STARTUPINFO()
+                startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
+                subprocess.call(
+                    'taskkill /t /f /pid {pid}'.format(pid=self._p.pid),
+                    startupinfo=startupinfo,
+                    shell=True
+                )
+            else:
+                os.killpg(self._p.pid, signal.SIGKILL)
+        except:
+            traceback.print_exc()
+
+
+def get_version_info(executable, env=None):
+    print('Checking {0}...'.format(executable))
+
+    if env is None:
+        env = os.environ
+
+    try:
+        t = SubprocessTimeoutThread(
+            30,  # wait 30 seconds
+            [executable, '--version'],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            shell=False,
+            env=env
+        )
+
+        t.start()
+
+        stdout = t.stdout
+        if stdout is None:
+            return None
+
+        return re.split(r'\r?\n', stdout.decode('utf-8').strip(), 1)[0]
+    except:
+        return None
+
+
+def get_tex_path_variable_texlive(variable, env=None):
+    '''
+    Uses kpsewhich to read the value of a given TeX PATH variable, such as
+    TEXINPUTS.
+    '''
+    print('Reading path for {0}...'.format(variable))
+
+    if env is None:
+        env = os.environ
+
+    try:
+        t = SubprocessTimeoutThread(
+            30,  # wait up to 30 seconds
+            ['kpsewhich', '--expand-path=$' + variable],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            shell=False,
+            env=env
+        )
+
+        t.start()
+
+        stdout = t.stdout
+        if stdout is None:
+            return None
+
+        return u'\n'.join(re.split(r'\r?\n', stdout.decode('utf-8').strip()))
+    except:
+        return None
+
+
+def get_tex_path_variable_miktex(variable, env=None):
+    '''
+    Uses findtexmf to find the values of a given TeX PATH variable, such as
+    TEXINPUTS
+    '''
+    print('Reading path for {0}...'.format(variable))
+
+    if env is None:
+        env = os.environ
+
+    try:
+        command = ['findtexmf', '-alias=latex']
+        command.append(
+            '-show-path={' + variable + '}'.format(
+                TEXINPUTS='tex',
+                BIBINPUTS='bib',
+                BSTINPUTS='bst'
+            )
+        )
+
+        t = SubprocessTimeoutThread(
+            30,  # wait up to 30 seconds
+            command,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            shell=False,
+            env=env
+        )
+
+        t.start()
+
+        stdout = t.stdout
+        if stdout is None:
+            return None
+
+        output = u'\n'.join(re.split(r'\r?\n', stdout.decode('utf-8').strip()))
+        return os.pathsep.join([
+            os.path.normpath(p) for p in output.split(os.pathsep)
+        ])
+    except:
+        return None
+
+
+def get_max_width(table, column):
+    return max(len(unicode(row[column])) for row in table)
+
+
+def tabulate(table, wrap_column=0, output=sys.stdout):
+    '''
+    Utility function to layout a table. A table is a list of list, with each
+    sub-list representing a row of values. The first row in the table is taken
+    to be the header row.
+
+    Format looks like this:
+
+    Header1  Header2
+    -------  -------
+    Value1   Value2
+
+    i.e., each column is displayed at the maximum number of characters of any
+    field in that column; the spacing between two columns is two spaces from
+    the length of the longest entry; and each header is followed by a series
+    of dashes as long as the header.
+
+    Args:
+        table: a list of lists containg the data to be formatted
+        wrap_column: if a positive number, specifies the maximum number of
+            characters to allow in any column
+        output: the output stream to write to; defaults to sys.stdout
+    '''
+    column_widths = [get_max_width(table, i) for i in range(len(table[0]))]
+    # Ensure the *last* column is only as long as it needs to be
+    # This is necessary for the syntax to work properly
+    column_widths[-1] = len(table[0][-1])
+    if wrap_column is not None and wrap_column > 0:
+        column_widths = [width if width <= wrap_column else wrap_column
+                         for width in column_widths]
+
+    headers = table.pop(0)
+
+    for i in range(len(headers)):
+        padding = 2 if i < len(headers) - 1 else 0
+        output.write(unicode(headers[i]).ljust(column_widths[i] + padding))
+    output.write(u'\n')
+
+    for i in range(len(headers)):
+        padding = 2 if i < len(headers) - 1 else 0
+        if headers[i]:
+            output.write(
+                (u'-' * len(headers[i])).ljust(column_widths[i] + padding)
+            )
+        else:
+            output.write(u''.ljust(column_widths[i] + padding))
+    output.write(u'\n')
+
+    added_row = False
+    for j, row in enumerate(table):
+        for i in range(len(row)):
+            padding = 2 if i < len(row) - 1 else 0
+            column = unicode(row[i])
+            if wrap_column is not None and wrap_column != 0 and \
+                    len(column) > wrap_column:
+                wrapped = textwrap.wrap(column, wrap_column)
+                column = wrapped.pop(0)
+                lines = u''.join(wrapped)
+
+                if added_row:
+                    table[j + 1][i] = lines
+                else:
+                    table.insert(j + 1, [u''] * len(row))
+                    table[j + 1][i] = lines
+                    added_row = True
+
+            output.write(column.ljust(column_widths[i] + padding))
+
+        added_row = False
+        output.write(u'\n')
+    output.write(u'\n')
+
+
+class SystemCheckThread(threading.Thread):
+
+    def __init__(self, sublime_exe=None, uses_miktex=False, texpath=None,
+                 build_env=None, view=None, on_done=None):
+        super(SystemCheckThread, self).__init__()
+        self.sublime_exe = sublime_exe
+        self.uses_miktex = uses_miktex
+        self.texpath = texpath
+        self.build_env = build_env
+        self.view = view
+        self.on_done = on_done
+
+    def run(self):
+        texpath = self.texpath
+        results = []
+
+        env = copy.deepcopy(os.environ)
+
+        if texpath is not None:
+            env['PATH'] = texpath
+        if self.build_env is not None:
+            update_environment(env, self.build_env)
+
+        table = [
+            ['Variable', 'Value']
+        ]
+
+        table.append(['PATH', env.get('PATH', '')])
+
+        if self.uses_miktex:
+            get_tex_path_variable = get_tex_path_variable_miktex
+            should_run = which('findtexmf', path=texpath) is not None
+        else:
+            get_tex_path_variable = get_tex_path_variable_texlive
+            should_run = which('kpsewhich', path=texpath) is not None
+
+        if should_run:
+            for var in ['TEXINPUTS', 'BIBINPUTS', 'BSTINPUTS']:
+                table.append([var, get_tex_path_variable(var, env)])
+
+        if self.uses_miktex:
+            for var in ['BIBTEX', 'LATEX', 'PDFLATEX', 'MAKEINDEX',
+                        'MAKEINFO', 'TEX', 'PDFTEX', 'TEXINDEX']:
+                value = env.get(var, None)
+                if value is not None:
+                    table.append([var, value])
+
+        results.append(table)
+
+        table = [
+            ['Program', 'Location', 'Status', 'Version']
+        ]
+
+        # skip sublime_exe on OS X
+        # we only use this for the hack to re-focus on ST
+        # which doesn't work on OS X anyway
+        if sublime.platform() != 'osx':
+            sublime_exe = self.sublime_exe
+            available = sublime_exe is not None
+
+            if available:
+                if not os.path.isabs(sublime_exe):
+                    sublime_exe = which(sublime_exe)
+
+                basename, extension = os.path.splitext(sublime_exe)
+                if extension is not None:
+                    sublime_exe = ''.join((basename, extension.lower()))
+
+            version_info = get_version_info(
+                sublime_exe, env=env
+            ) if available else None
+
+            table.append([
+                'sublime',
+                sublime_exe,
+                (u'available'
+                    if available and version_info is not None else u'missing'),
+                version_info if version_info is not None else u'unavailable'
+            ])
+
+        for program in ['latexmk' if not self.uses_miktex else 'texify',
+                        'pdflatex', 'xelatex', 'lualatex', 'biber',
+                        'bibtex', 'bibtex8', 'kpsewhich']:
+            location = which(program, path=texpath)
+            available = location is not None
+
+            if available:
+                basename, extension = os.path.splitext(location)
+                if extension is not None:
+                    location = ''.join((basename, extension.lower()))
+
+            version_info = get_version_info(
+                location, env=env
+            ) if available else None
+
+            table.append([
+                program,
+                location,
+                (u'available'
+                    if available and version_info is not None else u'missing'),
+                version_info if version_info is not None else u'unavailable'
+            ])
+
+        results.append(table)
+
+        run_on_main_thread(partial(self._on_main_thread, results), timeout=30)
+
+    def _on_main_thread(self, results):
+        builder_name = get_setting(
+            'builder', 'traditional', view=self.view
+        )
+
+        if builder_name in ['', 'default']:
+            builder_name = 'traditional'
+
+        builder_settings = get_setting('builder_settings', view=self.view)
+        builder_path = get_setting('builder_path', view=self.view)
+
+        if builder_name in ['simple', 'traditional', 'script']:
+            builder_path = None
+        else:
+            bld_path = os.path.join(sublime.packages_path(), builder_path)
+            add_plugin_path(bld_path)
+
+        builder_name = _classname_to_internal_name(builder_name)
+
+        try:
+            get_plugin('{0}_builder'.format(builder_name))
+            builder_available = True
+        except NoSuchPluginException:
+            traceback.print_exc()
+            builder_available = False
+
+        results.append([
+            [u'Builder', u'Status'],
+            [
+                builder_name,
+                u'available' if builder_available else u'missing'
+            ]
+        ])
+
+        if builder_path:
+            results.append([[u'Builder Path'], [builder_path]])
+
+        if builder_settings is not None:
+            table = [[u'Builder Setting', u'Value']]
+            for key in sorted(builder_settings.keys()):
+                value = builder_settings[key]
+                table.append([key, value])
+            results.append(table)
+
+        # is current view a TeX file?
+        view = self.view
+        if view.score_selector(0, 'text.tex.latex') != 0:
+            tex_root = get_tex_root(view)
+            tex_directives = parse_tex_directives(
+                tex_root,
+                multi_values=['options'],
+                key_maps={'ts-program': 'program'}
+            )
+
+            results.append([[u'TeX Root'], [tex_root]])
+
+            results.append([
+                [u'LaTeX Engine'],
+                [
+                    tex_directives.get(
+                        'program',
+                        get_setting(
+                            'program', 'pdflatex', self.view
+                        )
+                    )
+                ]
+            ])
+
+            table = [[u'LaTeX Output Setting', u'Value']]
+            output_directory = get_output_directory(tex_root)
+            if output_directory:
+                table.append(
+                    ['output_directory', output_directory]
+                )
+            aux_directory = get_aux_directory(tex_root)
+            if aux_directory:
+                table.append(['aux_directory', aux_directory])
+            jobname = get_jobname(tex_root)
+            if jobname and jobname != os.path.splitext(
+                os.path.basename(tex_root)
+            )[0]:
+                table.append(['jobname', jobname])
+
+            if len(table) > 1:
+                results.append(table)
+
+            options = get_setting('builder_settings', {}, self.view).\
+                get('options', [])
+            options.extend(tex_directives.get('options', []))
+
+            if len(options) > 0:
+                table = [[u'LaTeX Options']]
+                for option in options:
+                    table.append([option])
+
+                results.append(table)
+
+        default_viewer = DEFAULT_VIEWERS.get(sublime.platform(), None)
+        viewer_name = get_setting('viewer', default_viewer)
+        if viewer_name in ['', 'default']:
+            viewer_name = default_viewer
+
+        try:
+            viewer_plugin = get_plugin(viewer_name + '_viewer')
+            viewer_available = True
+        except NoSuchPluginException:
+            viewer_available = False
+
+        if viewer_available:
+            if viewer_name == 'command':
+                # assume the command viewer is always valid
+                viewer_location = 'N/A'
+            elif viewer_name in ('evince', 'okular', 'zathura'):
+                viewer_location = which(viewer_name)
+                viewer_available = bool(viewer_location)
+            elif viewer_name == 'preview':
+                # assume preview always exists
+                pass
+            elif viewer_name == 'skim':
+                viewer_location = '/Applications/Skim.app'
+
+                if not os.path.exists(viewer_location):
+                    viewer_location = subprocess.check_output([
+                        'osascript',
+                        '-e',
+                        'POSIX path of '
+                        '(path to app id "net.sourceforge.skim-app.skim")'
+                    ]).decode("utf8")[:-1]
+
+                viewer_available = os.path.exists(viewer_location)
+            elif viewer_name == 'sumatra':
+                sumatra_exe = get_setting('viewer_settings', {}).\
+                    get('sumatra', get_setting('windows', {}).
+                        get('sumatra', 'SumatraPDF.exe')) or \
+                    'SumatraPDF.exe'
+
+                viewer_location = which(sumatra_exe)
+                if not bool(viewer_location):
+                    viewer_location = viewer_plugin()._find_sumatra_exe()
+                    viewer_available = bool(viewer_location)
+
+        if not viewer_available:
+            viewer_location = 'N/A'
+
+        results.append([
+            [u'Viewer', u'Status', u'Location'],
+            [
+                viewer_name,
+                u'available' if viewer_available else u'missing',
+                viewer_location
+            ]
+        ])
+
+        if callable(self.on_done):
+            self.on_done(results)
+
+
+class LatextoolsSystemCheckCommand(sublime_plugin.ApplicationCommand):
+
+    def run(self):
+        view = sublime.active_window().active_view()
+
+        t = SystemCheckThread(
+            sublime_exe=get_sublime_exe(),
+            uses_miktex=using_miktex(),
+            texpath=_get_texpath(view) or os.environ['PATH'],
+            build_env=get_setting('builder_settings', {}).get(
+                sublime.platform(), {}
+            ).get('env'),
+            view=view,
+            on_done=self.on_done
+        )
+
+        t.start()
+
+        ProgressIndicator(t, 'Checking system...', 'System check complete')
+
+    def on_done(self, results):
+        def _on_done():
+            buf = StringIO()
+            for item in results:
+                tabulate(item, output=buf)
+
+            new_view = sublime.active_window().new_file()
+            new_view.set_scratch(True)
+            new_view.settings().set('word_wrap', False)
+            new_view.settings().set('line_numbers', False)
+            new_view.settings().set('gutter', False)
+            new_view.set_name('LaTeXTools System Check')
+            if sublime.version() < '3103':
+                new_view.settings().set(
+                    'syntax',
+                    'Packages/LaTeXTools/system_check.hidden-tmLanguage'
+                )
+            else:
+                new_view.settings().set(
+                    'syntax', 'Packages/LaTeXTools/system_check.sublime-syntax'
+                )
+
+            new_view.set_encoding('UTF-8')
+
+            new_view.run_command(
+                'latextools_insert_text',
+                {'text': buf.getvalue().rstrip()}
+            )
+
+            new_view.set_read_only(True)
+
+            buf.close()
+
+        sublime.set_timeout(_on_done, 0)
+
+
+class LatextoolsInsertTextCommand(sublime_plugin.TextCommand):
+
+    def run(self, edit, text=''):
+        view = self.view
+        view.insert(edit, 0, text)

--- a/system_check.sublime-syntax
+++ b/system_check.sublime-syntax
@@ -1,0 +1,24 @@
+%YAML 1.2
+---
+# http://www.sublimetext.com/docs/3/syntax.html
+name: LaTeXTools System Check
+file_extensions:
+  - latextools-system-check
+hidden: true
+scope: text.latextools-system-check
+contexts:
+  main:
+    - match: "-{3,}"
+      scope: comment.other.latextools-system-check.header
+    - match: ^(?:Variable|Program\s+Location|Builder|Viewer|LaTeX Output Setting)\s+.+$
+      scope: comment.other.latextools-system-check.header
+    - match: ^(?:TeX Root|LaTeX Engine|LaTeX Options)\s*$
+      scope: comment.other.latextools-system-check.header
+    - match: \bavailable\b
+      scope: markup.inserted.latextools-system-check.available
+    - match: \bmissing\b
+      scope: keyword.control.latextools-system-check.available
+    - match: \bunavailable\b
+      scope: keyword.control.latextools-system-check.available
+    - match: True|False
+      scope: constant.language.latextools-system-check.available

--- a/toggle_show.py
+++ b/toggle_show.py
@@ -16,6 +16,7 @@ _toggle_settings = [
     "cite_auto_trigger",
     "fill_auto_trigger",
     "env_auto_trigger",
+    "glossary_auto_trigger",
     "tex_directive_auto_trigger",
     "smart_bracket_auto_trigger"
 ]

--- a/viewers/command_viewer.py
+++ b/viewers/command_viewer.py
@@ -1,13 +1,13 @@
 from base_viewer import BaseViewer
 
 from latextools_utils import get_setting
+from latextools_utils.external_command import external_command
 from latextools_utils.sublime_utils import get_sublime_exe
 
 from copy import copy
 import os
 import re
 import shlex
-import subprocess
 import sublime
 import string
 import sys
@@ -137,19 +137,8 @@ class CommandViewer(BaseViewer):
         if not replaced:
             command.append(pdf_file)
 
-        startupinfo = None
-        if sublime.platform() == 'windows':
-            startupinfo = subprocess.STARTUPINFO()
-            startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
-
-        env = copy(os.environ)
-        env['PATH'] = get_texpath() or env['PATH']
-
-        print('Running {0}'.format(quote(' '.join(command))))
-        subprocess.Popen(
+        external_command(
             command,
-            startupinfo=startupinfo,
-            env=env,
             cwd=os.path.split(pdf_file)[0]
         )
 

--- a/viewers/okular_viewer.py
+++ b/viewers/okular_viewer.py
@@ -1,9 +1,8 @@
 from base_viewer import BaseViewer
 
 from latextools_utils import get_setting
+from latextools_utils.external_command import external_command, check_output
 
-import subprocess
-import sys
 import time
 
 
@@ -17,19 +16,19 @@ class OkularViewer(BaseViewer):
         if locator is not None:
             command.append(locator)
 
-        subprocess.Popen(command)
+        external_command(command, use_texpath=False)
 
     def _is_okular_running(self):
-        stdout = subprocess.Popen(
-            ['ps', 'xw'], stdout=subprocess.PIPE
-        ).communicate()[0]
+        try:
+            running_apps = check_output(['ps', 'xv'], use_texpath=False)
+            for app in running_apps.splitlines():
+                if 'okular' not in app:
+                    continue
+                if '--unique' in app:
+                    return True
+        except:
+            pass
 
-        running_apps = stdout.decode(sys.getdefaultencoding(), 'ignore')
-        for app in running_apps.splitlines():
-            if 'okular' not in app:
-                continue
-            if '--unique' in app:
-                return True
         return False
 
     def _ensure_okular(self, **kwargs):

--- a/viewers/preview_viewer.py
+++ b/viewers/preview_viewer.py
@@ -1,11 +1,14 @@
 from base_viewer import BaseViewer
 
-import subprocess
+from latextools_utils.external_command import external_command
 
 
 class PreviewViewer(BaseViewer):
+
     def view_file(self, pdf_file, **kwargs):
-        subprocess.Popen(['open', '-a', 'Preview', pdf_file])
+        external_command(
+            ['open', '-a', 'Preview', pdf_file], use_texpath=False
+        )
 
     def supports_platform(self, platform):
         return platform == 'osx'

--- a/viewers/skim_viewer.py
+++ b/viewers/skim_viewer.py
@@ -1,7 +1,8 @@
 from base_viewer import BaseViewer
 
 import os
-import subprocess
+
+from latextools_utils.external_command import check_output, external_command
 
 
 class SkimViewer(BaseViewer):
@@ -11,11 +12,11 @@ class SkimViewer(BaseViewer):
         path_to_skim = '/Applications/Skim.app'
 
         if not os.path.exists(path_to_skim):
-            path_to_skim = subprocess.check_output([
+            path_to_skim = check_output([
                 'osascript',
                 '-e',
                 'POSIX path of (path to app id "net.sourceforge.skim-app.skim")'
-            ]).decode("utf8")[:-1]
+            ], use_texpath=False)
 
         command = [
             os.path.join(
@@ -34,7 +35,7 @@ class SkimViewer(BaseViewer):
             str(line), pdf_file, tex_file
         ]
 
-        subprocess.Popen(command)
+        external_command(command, use_texpath=False)
 
     def view_file(self, pdf_file, **kwargs):
         keep_focus = kwargs.pop('keep_focus', True)
@@ -57,7 +58,7 @@ class SkimViewer(BaseViewer):
 
         command.append(pdf_file)
 
-        subprocess.Popen(command)
+        external_command(command, use_texpath=False)
 
     def supports_keep_focus(self):
         return True

--- a/viewers/sumatra_viewer.py
+++ b/viewers/sumatra_viewer.py
@@ -95,10 +95,7 @@ class SumatraViewer(BaseViewer):
         # it exists, otherwise, use the platform setting
         sumatra_binary = get_setting('viewer_settings', {}).\
             get('sumatra', get_setting('windows', {}).
-                get('sumatra', 'SumatraPDF.exe'))
-
-        if sumatra_binary == '':
-            sumatra_binary = 'SumatraPDF.exe'
+                get('sumatra', 'SumatraPDF.exe')) or 'SumatraPDF.exe'
 
         try:
             external_command(

--- a/viewers/sumatra_viewer.py
+++ b/viewers/sumatra_viewer.py
@@ -1,10 +1,10 @@
 from base_viewer import BaseViewer
 
 from latextools_utils import get_setting
+from latextools_utils.external_command import external_command
 
 import os
 import sublime
-import subprocess
 import sys
 import traceback
 
@@ -91,10 +91,6 @@ class SumatraViewer(BaseViewer):
         if not isinstance(commands, list):
             commands = [commands]
 
-        startupinfo = subprocess.STARTUPINFO()
-        startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
-        startupinfo.wShowWindow = 4  # SHOWNOACTIVE
-
         # favour 'sumatra' setting under viewer_settings if
         # it exists, otherwise, use the platform setting
         sumatra_binary = get_setting('viewer_settings', {}).\
@@ -105,9 +101,9 @@ class SumatraViewer(BaseViewer):
             sumatra_binary = 'SumatraPDF.exe'
 
         try:
-            subprocess.Popen(
+            external_command(
                 [sumatra_binary] + commands,
-                startupinfo=startupinfo
+                use_texpath=False
             )
         except OSError:
             exc_info = sys.exc_info()
@@ -115,9 +111,9 @@ class SumatraViewer(BaseViewer):
             sumatra_exe = self._find_sumatra_exe()
             if sumatra_exe is not None and sumatra_exe != sumatra_binary:
                 try:
-                    subprocess.Popen(
+                    external_command(
                         [sumatra_exe] + commands,
-                        startupinfo=startupinfo
+                        use_texpath=False
                     )
                 except OSError:
                     traceback.print_exc()

--- a/viewers/zathura_viewer.py
+++ b/viewers/zathura_viewer.py
@@ -1,11 +1,11 @@
 from base_viewer import BaseViewer
 
 from latextools_utils import get_setting
+from latextools_utils.external_command import (
+    check_output, external_command
+)
 from latextools_utils.sublime_utils import get_sublime_exe
 from latextools_utils.system import which
-
-import subprocess
-import sys
 
 
 class ZathuraViewer(BaseViewer):
@@ -20,16 +20,16 @@ class ZathuraViewer(BaseViewer):
         )
 
     def _get_zathura_pid(self, pdf_file):
-        stdout = subprocess.Popen(
-            ['ps', 'xw'], stdout=subprocess.PIPE
-        ).communicate()[0]
+        try:
+            running_apps = check_output(['ps', 'xv'], use_texpath=False)
+            for app in running_apps.splitlines():
+                if 'zathura' not in app:
+                    continue
+                if pdf_file in app:
+                    return app.lstrip().split(' ', 1)[0]
+        except:
+            pass
 
-        running_apps = stdout.decode(sys.getdefaultencoding(), 'ignore')
-        for app in running_apps.splitlines():
-            if 'zathura' not in app:
-                continue
-            if pdf_file in app:
-                return app.lstrip().split(' ', 1)[0]
         return None
 
     def _focus_zathura(self, pid):
@@ -47,27 +47,30 @@ class ZathuraViewer(BaseViewer):
                 pass
 
     def _focus_wmctrl(self, pid):
-        pid = ' {0} '.format(pid)
-        stdout = subprocess.Popen(
-            ['wmctrl', '-l', '-p'], stdout=subprocess.PIPE
-        ).communicate()[0]
-
         window_id = None
-        windows = stdout.decode(sys.getdefaultencoding(), 'ignore')
-        for window in windows.splitlines():
-            if pid in window:
-                window_id = window.split(' ', 1)[0]
-                break
+        try:
+            windows = check_output(
+                ['wmctrl', '-l', '-p'], use_texpath=False
+            )
+        except:
+            pass
+        else:
+            pid = ' {0} '.format(pid)
+            for window in windows.splitlines():
+                if pid in window:
+                    window_id = window.split(' ', 1)[0]
+                    break
 
         if window_id is None:
             raise Exception('Cannot find window for Zathura')
 
-        subprocess.Popen(['wmctrl', '-a', window_id, '-i'])
+        external_command(['wmctrl', '-a', window_id, '-i'], use_texpath=False)
 
     def _focus_xdotool(self, pid):
-        subprocess.Popen(
+        external_command(
             ['xdotool', 'search', '--pid', pid,
-             '--class', 'Zathura', 'windowactivate', '%2']
+             '--class', 'Zathura', 'windowactivate', '%2'],
+            use_texpath=False
         )
 
     def forward_sync(self, pdf_file, tex_file, line, col, **kwargs):
@@ -92,7 +95,7 @@ class ZathuraViewer(BaseViewer):
 
         command.append(pdf_file)
 
-        subprocess.Popen(command)
+        external_command(command, use_texpath=False)
 
         if pid is not None and not keep_focus:
             self._focus_zathura(pid)
@@ -102,11 +105,11 @@ class ZathuraViewer(BaseViewer):
 
         pid = self._get_zathura_pid(pdf_file)
         if pid is None:
-            pid = subprocess.Popen([
+            pid = external_command([
                 'zathura',
                 self._get_synctex_editor(),
                 pdf_file
-            ]).pid
+            ], use_texpath=False).pid
         elif not keep_focus:
             self._focus_zathura(pid)
 


### PR DESCRIPTION
I'm posting this PR for comments.

The majority of issues we get seem to be caused by configuration issues, mostly stemming from Sublime running in an environment that users don't expect it to be. This is generally true of OS X as is well-known and at least possible on Ubuntu  (see #655, where the issue is, in essence, that Unity doesn't inherit it's environment from the login shell). In addition, because of the various places configurations can be made (either the `LaTeXTools.sublime-settings` or the project file) it could conceivably be quite hard to track-down which configuration setting is used. In short, we have (and provide) little visibility into the system so that users can understand what is going on and so we can help them troubleshoot their issues.

So I've created a new command which does some basic sanity checks and displays the information in a (hopefully) clear format.

Below is what it currently looks like:

<img width="828" alt="Screen shot showing the output of the command" src="https://cloud.githubusercontent.com/assets/212893/13236393/f620ae2c-d9bb-11e5-941c-d23749163213.png">

There are some differences depending on configuration, i.e., if a program can't be found or executed the status changes to 'missing'. In addition, on MiKTeX, it checks for `texify` instead of `latexmk` and the various environment variables `texify` uses (`BIBTEX`, `LATEX`, etc.).

Short TODO list:
- [x] Verify it works on:
  - [x] Windows 
    - [x] ST2
    - [x] ST3
  - [x] Linux
    - [x] ST2
    - [x] ST3
  - [x] OS X
    - [x] ST2
    - [x] ST3
- [x] Verify changes to `get_settings()` don't break anything
- [x] Add something to kill potentially hanging processes
- [x] Add checks for engine, tex options, tex root if launched from a tex file
- [x] Update everything for new (v3.7.x) code

Are there any other keys bits of information that are missing or would be useful to have? Could anything be done to make the information displayed clearer?

(I've thought about trying to get the actual commands the builder will run, but that turns out to be a major headache to do without actually running the commands or refactoring the builders which may be a possibility down the line.)
