### PR TITLE
Autodetect Sumatra executable

### DIFF
--- a/LaTeXTools.sublime-settings
+++ b/LaTeXTools.sublime-settings
@@ -110,8 +110,10 @@
 		"texpath" : "",
 		// TeX distro: "miktex" or "texlive"
 		"distro" : "miktex",
-		// Command to invoke Sumatra. If blank, "SumatraPDF.exe" is used (it has to be on your PATH)
-		"sumatra": "",
+		// Command to invoke Sumatra:
+		// If null, LaTeXTools will try to detect the Sumatra installation
+		// If empty string (""), "SumatraPDF.exe" is used (it has to be on your PATH)
+		"sumatra": null,
 		// Command to invoke Sublime Text. Used if the keep_focus toggle is true.
 		// If blank, "subl.exe" or "sublime_text.exe" will be used.
 		"sublime_executable": "",

--- a/README.markdown
+++ b/README.markdown
@@ -442,7 +442,7 @@ The following options are currently available (defaults in parentheses):
   * `texpath`: the path to TeX & friends
 - `windows`-specific settings:
   * `distro`: either `miktex` or `texlive`, depending on your TeX distribution
-  * `sumatra`: leave blank or omit if the SumatraPDF executable is in your `PATH` and is called `SumatraPDF.exe`, as in a default installation; otherwise, specify the *full path and file name* of the SumatraPDF executable.
+  * `sumatra`: set it to `null` to let LaTeXtools guess the installation path; set it to the empty string `""` if the SumatraPDF executable is in your `PATH` and is called `SumatraPDF.exe`, as in a default installation; otherwise, specify the *full path and file name* of the SumatraPDF executable.
   * `sublime_executable`: this is used if `keep_focus` is set to true and the path to your sublime_text executable cannot be discovered automatically. It should point to the full path to your executable `sublime_text.exe`.
   * `keep_focus_delay`: this is used if `keep_focus` is set to true. It controls how long (in seconds) the delay is between the completion of the `jump_to_pdf` command and the attempt to refocus on Sublime Text. This may need to be adjusted depending on your machine or configuration.
 - `linux`-specific settings:


### PR DESCRIPTION
This PR adds the ability to guess the executable of Sumatra by testing whether it is in the system path and checking the default installation paths.

Therefore the default settings for sumatra are changed to `null` (`None`) to trigger the detection. If the empty string `""` is used. it will assume Sumatra to be in the path (this is the current setup).

Additional default installation paths can be added easily.