### PR TITLE
Adds a standard way to run external commands.

### DIFF
--- a/01_reload_submodules.py
+++ b/01_reload_submodules.py
@@ -43,6 +43,7 @@ LOAD_ORDER = [
     'latextools_utils.sublime_utils',
     'latextools_utils.cache',
     'latextools_utils.quickpanel',
+    'latextools_utils.external_command',
 
     # depend on any previous
     'latextools_utils.analysis',

--- a/builders/basicBuilder.py
+++ b/builders/basicBuilder.py
@@ -23,11 +23,12 @@ else:
 
 import os
 import re
-import subprocess
 import sys
 # This will work because makePDF.py puts the appropriate
 # builders directory in sys.path
 from pdfBuilder import PdfBuilder
+
+from latextools_utils.external_command import external_command
 
 # Standard LaTeX warning
 CITATIONS_REGEX = re.compile(r"Warning: Citation `.+' on page \d+ undefined")
@@ -227,26 +228,11 @@ class BasicBuilder(PdfBuilder):
             # NOTE this cwd is not reused by any of the other command
             cwd = output_directory
 
-        startupinfo = None
-        preexec_fn = None
-
-        if sublime.platform() == 'windows':
-            startupinfo = subprocess.STARTUPINFO()
-            startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
-        else:
-            preexec_fn = os.setsid
-
         command.append(self.job_name)
-        print(command)
-        bib_proc = subprocess.Popen(
+        return external_command(
             command,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
-            startupinfo=startupinfo,
-            shell=False,
             env=env,
             cwd=cwd,
-            preexec_fn=preexec_fn
+            preexec_fn=os.setid if sublime.platform() != 'windows' else None,
+            use_texpath=False
         )
-
-        return bib_proc

--- a/builders/basicBuilder.py
+++ b/builders/basicBuilder.py
@@ -28,7 +28,7 @@ import sys
 # builders directory in sys.path
 from pdfBuilder import PdfBuilder
 
-from latextools_utils.external_command import external_command
+from latextools_utils.external_command import external_command, get_texpath
 
 # Standard LaTeX warning
 CITATIONS_REGEX = re.compile(r"Warning: Citation `.+' on page \d+ undefined")
@@ -227,6 +227,7 @@ class BasicBuilder(PdfBuilder):
             # now we modify cwd to be the output directory
             # NOTE this cwd is not reused by any of the other command
             cwd = output_directory
+        env['PATH'] = get_texpath()
 
         command.append(self.job_name)
         return external_command(

--- a/builders/scriptBuilder.py
+++ b/builders/scriptBuilder.py
@@ -1,15 +1,15 @@
 from pdfBuilder import PdfBuilder
 import sublime
 
-import subprocess
-from subprocess import Popen, PIPE, STDOUT
-
-from copy import copy
 import os
 import re
 import sys
 
 from string import Template
+
+from latextools_utils.external_command import (
+	external_command, get_texpath, update_env
+)
 
 if sys.version_info < (3, 0):
 	strbase = basestring
@@ -45,6 +45,8 @@ class ScriptBuilder(PdfBuilder):
 		plat = sublime.platform()
 		self.cmd = self.builder_settings.get(plat, {}).get("script_commands", None)
 		self.env = self.builder_settings.get(plat, {}).get("env", None)
+		# Loaded here so it is calculated on the main thread
+		self.texpath = get_texpath() or os.environ['PATH']
 
 	# Very simple here: we yield a single command
 	# Also add environment variables
@@ -55,9 +57,10 @@ class ScriptBuilder(PdfBuilder):
 		# create an environment to be used for all subprocesses
 		# adds any settings from the `env` dict to the current
 		# environment
-		env = copy(os.environ)
+		env = dict(os.environ)
+		env['PATH'] = self.texpath
 		if self.env is not None and isinstance(self.env, dict):
-			env.update(self.env)
+			update_env(env, self.env)
 
 		if self.cmd is None:
 			sublime.error_message(
@@ -97,32 +100,20 @@ class ScriptBuilder(PdfBuilder):
 				else:
 					self.display("Invoking '{0}'... ".format(cmd))
 
-			startupinfo = None
-			preexec_fn = None
-
-			if sublime.platform() == 'windows':
-				startupinfo = subprocess.STARTUPINFO()
-				startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
-			else:
-				preexec_fn = os.setsid
-
-			p = Popen(
-				cmd,
-				stdout=PIPE,
-				stderr=STDOUT,
-				startupinfo=startupinfo,
-				shell=True,
-				env=env,
-				cwd=self.tex_dir,
-				preexec_fn=preexec_fn
+			yield (
+				# run with use_texpath=False as we have already configured
+				# the environment above, including the texpath
+				external_command(
+					cmd, env=env, cwd=self.tex_dir, use_texpath=False,
+					shell=True
+				),
+				""
 			)
-
-			yield (p, "")
 
 			self.display("done.\n")
 
 			# This is for debugging purposes
-			if self.display_log and p.stdout is not None:
+			if self.display_log and self.out is not None:
 				self.display("\nCommand results:\n")
 				self.display(self.out)
 				self.display("\n\n")

--- a/jumpToPDF.py
+++ b/jumpToPDF.py
@@ -1,13 +1,19 @@
 # ST2/ST3 compat
 from __future__ import print_function 
 import sublime
-import sys
+import sublime_plugin
+
+import os
+import traceback
+import re
+
 if sublime.version() < '3000':
     # we are on ST2 and Python 2.X
 	_ST3 = False
 	import getTeXRoot
 	from latextools_utils.is_tex_file import is_tex_file
 	from latextools_utils import get_setting
+	from latextools_utils.external_command import external_command
 	from latextools_utils.output_directory import (
 		get_output_directory, get_jobname
 	)
@@ -21,6 +27,7 @@ else:
 	from . import getTeXRoot
 	from .latextools_utils.is_tex_file import is_tex_file
 	from .latextools_utils import get_setting
+	from .latextools_utils.external_command import external_command
 	from .latextools_utils.output_directory import (
 		get_output_directory, get_jobname
 	)
@@ -29,10 +36,6 @@ else:
 		get_plugin, add_plugin_path, NoSuchPluginException,
 		add_whitelist_module
 	)
-
-import sublime_plugin, os.path, subprocess, time
-import traceback
-import re
 
 SUBLIME_VERSION = re.compile(r'Build (\d{4})', re.UNICODE)
 DEFAULT_VIEWERS = {
@@ -94,18 +97,9 @@ def focus_st():
 		wait_time = plat_settings.get('keep_focus_delay', 0.5)
 
 		def keep_focus():
-			startupinfo = None
-			shell = False
-			if platform == 'windows':
-				startupinfo = subprocess.STARTUPINFO()
-				startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
-				shell = _ST3
-
-			subprocess.Popen(
+			external_command(
 				sublime_command,
-				startupinfo=startupinfo,
-				shell=shell,
-				env=os.environ
+				use_texpath=False
 			)
 
 		if hasattr(sublime, 'set_async_timeout'):

--- a/jumpto_tex_file.py
+++ b/jumpto_tex_file.py
@@ -1,7 +1,6 @@
 import re
 import os
 import codecs
-import subprocess
 import shlex
 import traceback
 
@@ -12,10 +11,12 @@ try:
     _ST3 = True
     from .getTeXRoot import get_tex_root
     from .latextools_utils import get_setting, utils
+    from .latextools_utils.external_command import external_command
 except:
     _ST3 = False
     from getTeXRoot import get_tex_root
     from latextools_utils import get_setting, utils
+    from latextools_utils.external_command import external_command
 
 
 INPUT_REG = re.compile(
@@ -161,8 +162,8 @@ def _jumpto_image_file(view, window, tex_root, file_name):
             # if $file is not used, append the file path
             else:
                 command.append(file_path)
-            print("RUN: {0}".format(command))
-            subprocess.Popen(command)
+
+            external_command(command)
 
     psystem = sublime.platform()
     commands = get_setting("open_image_command", {}).get(psystem, None)

--- a/kpsewhich.py
+++ b/kpsewhich.py
@@ -1,27 +1,21 @@
 from __future__ import print_function
-import subprocess
-from subprocess import Popen, PIPE
-import os
+
 import sublime
-import sys
+import traceback
 
 if sublime.version() < '3000':
     _ST3 = False
-    from latextools_utils import get_setting
+    from latextools_utils.external_command import (
+        check_output, CalledProcessError
+    )
 else:
     _ST3 = True
-    from .latextools_utils import get_setting
+    from .latextools_utils.external_command import (
+        check_output, CalledProcessError
+    )
 
 __all__ = ['kpsewhich']
 
-def get_texpath():
-    platform_settings = get_setting(sublime.platform(), {})
-    texpath = platform_settings.get('texpath', '')
-
-    if not _ST3:
-        return os.path.expandvars(texpath).encode(sys.getfilesystemencoding())
-    else:
-        return os.path.expandvars(texpath)
 
 def kpsewhich(filename, file_format=None):
     # build command
@@ -30,36 +24,21 @@ def kpsewhich(filename, file_format=None):
         command.append('-format=%s' % (file_format))
     command.append(filename)
 
-    # setup the environment to run the subprocess in
-    texpath = get_texpath() or os.environ['PATH']
-    env = dict(os.environ)
-    env['PATH'] = texpath
-
     try:
-        # Windows-specific adjustments
-        startupinfo = None
-        shell = False
-        if sublime.platform() == 'windows':
-            # ensure console window doesn't show
-            startupinfo = subprocess.STARTUPINFO()
-            startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
-            shell = True
-
-        print('Running %s' % (' '.join(command)))
-        p = Popen(
-            command,
-            stdout=PIPE,
-            stdin=PIPE,
-            startupinfo=startupinfo,
-            shell=shell,
-            env=env
+        return check_output(command)
+    except CalledProcessError as e:
+        sublime.error_message(
+            'An error occurred while trying to run kpsewhich. '
+            'Files in your TEXINPUTS could not be accessed.'
         )
-        path = p.communicate()[0].decode('utf-8').rstrip()
-        if p.returncode == 0:
-            return path
-        else:
-            sublime.error_message('An error occurred while trying to run kpsewhich. TEXMF tree could not be accessed.')
+        if e.output:
+            print(e.output)
+        traceback.print_exc()
     except OSError:
-        sublime.error_message('Could not run kpsewhich. Please ensure that your texpath setting is configured correctly in the LaTeXTools settings.')
+        sublime.error_message(
+            'Could not run kpsewhich. Please ensure that your texpath '
+            'setting is correct.'
+        )
+        traceback.print_exc()
 
     return None

--- a/latexDocumentationViewer.py
+++ b/latexDocumentationViewer.py
@@ -2,34 +2,22 @@ from __future__ import print_function
 
 import sublime
 import sublime_plugin
-
-import os
-import subprocess
-from subprocess import Popen
+import traceback
 
 try:
     from latextools_utils import get_setting
-    from latextools_utils.distro_utils import using_miktex
+    from latextools_utils.external_command import external_command
 except ImportError:
     from .latextools_utils import get_setting
-    from .latextools_utils.distro_utils import using_miktex
+    from .latextools_utils.external_command import external_command
 
 if sublime.version() < '3000':
     _ST3 = False
     strbase = basestring
-    import sys
 else:
     _ST3 = True
     strbase = str
 
-def get_texpath():
-    platform_settings = get_setting(sublime.platform(), {})
-    texpath = platform_settings.get('texpath', '')
-
-    if not _ST3:
-        return os.path.expandvars(texpath).encode(sys.getfilesystemencoding())
-    else:
-        return os.path.expandvars(texpath)
 
 def _view_texdoc(file):
     if file is None:
@@ -38,41 +26,14 @@ def _view_texdoc(file):
         raise TypeError('File must be a string')
 
     command = ['texdoc']
-
-    texpath = get_texpath() or os.environ['PATH']
-    env = dict(os.environ)
-    env['PATH'] = texpath
+    if sublime.platform() == 'windows' and using_miktex():
+        command.append('--view')
+    command.append(file)
 
     try:
-        # Windows-specific adjustments
-        startupinfo = None
-        shell = False
-        if sublime.platform() == 'windows':
-            # ensure console window doesn't show
-            startupinfo = subprocess.STARTUPINFO()
-            startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
-            shell = True
-
-            if using_miktex():
-                command.append('--view')
-
-        command.append(file)
-
-        print('Running %s' % (' '.join(command)))
-        p = Popen(
-            command,
-            stdout=None,
-            stdin=None,
-            startupinfo=startupinfo,
-            shell=shell,
-            env=env
-        )
-
-        if not using_miktex():  # see http://sourceforge.net/p/miktex/bugs/2367/
-            p.communicate()     # cannot rely on texdoc --view from MiKTeX returning
-            if p.returncode != 0:
-                sublime.error_message('An error occurred while trying to run texdoc.')
+        external_command(command)
     except OSError:
+        traceback.print_exc()
         sublime.error_message('Could not run texdoc. Please ensure that your texpath setting is configured correctly in the LaTeXTools settings.')
 
 class LatexPkgDocCommand(sublime_plugin.WindowCommand):
@@ -84,8 +45,7 @@ class LatexPkgDocCommand(sublime_plugin.WindowCommand):
                 isinstance(file, strbase) and
                 file != ''
             ):
-                window.run_command('latex_view_doc',
-                    {'file': file})
+                window.run_command('latex_view_doc', {'file': file})
 
         window.show_input_panel(
             'View documentation for which package?',

--- a/latextools_utils/external_command.py
+++ b/latextools_utils/external_command.py
@@ -1,0 +1,319 @@
+# This module provides tools for running external commands.
+# It is mainly a wrapper around subprocess calls with some defaults
+# specific to LaTeXTools. In particular:
+#
+#  * it executes commands using the PATH defined by the texpath setting
+#  * STDOUT is set to PIPE
+#  * it redirects STDERR to STDOUT
+#  * it hides the console window on Windows
+#
+# All of these, except hiding the console window, can be overridden via
+# parameters passed to the method. The point is to simplify running things
+# the way we normally do.
+#
+# All of the above can be overridden using optional parameters
+#
+# It provides six functions:
+#   update_env() - takes two dict-like objects and updates first with the
+#       values from the second. It should be OS-encoding safe on ST2 which
+#       does not automatically handle this.
+#   get_texpath() - returns the user configured texpath, properly encoded with
+#       any environment variables expanded
+#   external_command() - essentially the equivalent of subprocess.Popen()
+#       provides the greatest degree of flexibility
+#   execute_command() - calls external_command() and then
+#       subprocess.communicate(), returning the returncode, stdout and stderr
+#       output
+#   check_call() - a version of subprocess.check_call() implemented on top of
+#       execute_command()
+#   check_output() - a version of subprocess.check_output() implemented on top
+#       of execute_command()
+#
+# In addition to a subset of standard Popen parameters, all the functions built
+# on external_command() accept a `use_texpath` parameter which indicates
+# whether or not to run the executable with the PATH set to the current value
+# of texpath.
+
+import sublime
+
+import os
+import re
+import sys
+from shlex import split
+
+import subprocess
+from subprocess import Popen, PIPE, STDOUT, CalledProcessError
+
+try:
+    from latextools_utils.settings import get_setting
+    from latextools_utils.utils import run_on_main_thread
+except ImportError:
+    from .settings import get_setting
+    from .utils import run_on_main_thread
+
+if sys.version_info < (3,):
+    from pipes import quote
+
+    def expand_vars(texpath):
+        return os.path.expandvars(texpath).encode(sys.getfilesystemencoding())
+
+    def update_env(old_env, new_env):
+        encoding = sys.getfilesystemencoding()
+        old_env.update(
+            dict((k.encode(encoding), v) for (k, v) in new_env.items())
+        )
+
+    # reraise implementation from 6
+    exec("""def reraise(tp, value, tb=None):
+    raise tp, value, tb
+""")
+
+    strbase = basestring
+else:
+    from imp import reload
+    from shlex import quote
+
+    def expand_vars(texpath):
+        return os.path.expandvars(texpath)
+
+    def update_env(old_env, new_env):
+        old_env.update(new_env)
+
+    # reraise implementation from 6
+    def reraise(tp, value, tb=None):
+        if value is None:
+            value = tp()
+        if value.__traceback__ is not tb:
+            raise value.with_traceback(tb)
+        raise value
+
+    strbase = str
+
+_ST3 = sublime.version() >= '3000'
+
+__all__ = ['external_command', 'execute_command', 'check_call', 'check_output',
+           'get_texpath', 'update_env']
+
+
+def get_texpath():
+    '''
+    Returns the texpath setting with any environment variables expanded
+    '''
+    def _get_texpath():
+        try:
+            texpath = get_setting(sublime.platform(), {}).get('texpath')
+        except AttributeError:
+            # hack to reload this module in case the calling module was
+            # reloaded
+            exc_info = sys.exc_info
+            try:
+                reload(sys.modules[get_texpath.__module__])
+                texpath = get_setting(sublime.platform(), {}).get('texpath')
+            except:
+                reraise(*exc_info)
+
+        return expand_vars(texpath) if texpath is not None else None
+
+    # ensure _get_texpath() is run in a thread-safe manner
+    return run_on_main_thread(_get_texpath, default_value=None)
+
+# marker object used to indicate default behaviour
+__sentinel__ = object()
+
+
+# wrapper to handle common logic for executing subprocesses
+def external_command(command, cwd=None, shell=False, env=None,
+                     stdin=__sentinel__, stdout=__sentinel__,
+                     stderr=__sentinel__, preexec_fn=None,
+                     use_texpath=True):
+    '''
+    Takes a command object to be passed to subprocess.Popen.
+
+    Returns a subprocess.Popen object for the corresponding process.
+
+    Raises OSError if command not found
+    '''
+    if command is None:
+        raise ValueError('command must be a string or list of strings')
+
+    _env = dict(os.environ)
+
+    if use_texpath:
+        _env['PATH'] = get_texpath() or os.environ['PATH']
+
+    if env is not None:
+        update_env(_env, env)
+
+    # if command is a string rather than a list
+    if isinstance(command, strbase):
+        if sys.version_info < (3,):
+            command = str(command)
+
+        command = split(command)
+
+        if sys.version_info < (3,):
+            command = [unicode(c) for c in command]
+
+    # Windows-specific adjustments
+    startupinfo = None
+    if sublime.platform() == 'windows':
+        # ensure console window doesn't show
+        startupinfo = subprocess.STARTUPINFO()
+        startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
+
+    if stdin is __sentinel__:
+        stdin = None
+
+    if stdout is __sentinel__:
+        stdout = PIPE
+
+    if stderr is __sentinel__:
+        stderr = STDOUT
+
+    try:
+        print(u'Running "{0}"'.format(u' '.join([quote(s) for s in command])))
+    except UnicodeError:
+        try:
+            print(u'Running "{0}"'.format(command))
+        except:
+            pass
+
+    p = Popen(
+        command,
+        stdin=stdin,
+        stdout=stdout,
+        stderr=stderr,
+        startupinfo=startupinfo,
+        preexec_fn=preexec_fn,
+        shell=shell,
+        env=_env,
+        cwd=cwd
+    )
+
+    return p
+
+
+def execute_command(command, cwd=None, shell=False, env=None,
+                    stdin=__sentinel__, stdout=__sentinel__,
+                    stderr=__sentinel__, preexec_fn=None,
+                    use_texpath=True):
+    '''
+    Takes a command to be passed to subprocess.Popen and runs it. This is
+    similar to subprocess.call().
+
+    Returns a tuple consisting of
+        (return_code, stdout, stderr)
+
+    By default stderr is redirected to stdout, so stderr will normally be
+    blank. This can be changed by calling execute_command with stderr set
+    to subprocess.PIPE or any other valid value.
+
+    Raises OSError if the executable is not found
+    '''
+    def convert_stream(stream):
+        if stream is None:
+            return u''
+        else:
+            return u'\n'.join(
+                re.split(r'\r?\n', stream.decode('utf-8').rstrip())
+            )
+
+    p = external_command(
+        command,
+        cwd=cwd,
+        shell=shell,
+        env=env,
+        stdin=stdin,
+        stdout=stdout,
+        stderr=stderr,
+        preexec_fn=preexec_fn,
+        use_texpath=use_texpath
+    )
+
+    stdout, stderr = p.communicate()
+    return (
+        p.returncode,
+        convert_stream(stdout),
+        convert_stream(stderr)
+    )
+
+
+def check_call(command, cwd=None, shell=False, env=None,
+               stdin=__sentinel__, stdout=__sentinel__,
+               stderr=__sentinel__, preexec_fn=None,
+               use_texpath=True):
+    '''
+    Takes a command to be passed to subprocess.Popen.
+
+    Raises CalledProcessError if the command returned a non-zero value
+    Raises OSError if the executable is not found
+
+    This is pretty much identical to subprocess.check_call(), but
+    implemented here to take advantage of LaTeXTools-specific tooling.
+    '''
+    # since we don't do anything with the output, by default just ignore it
+    if stdout is __sentinel__:
+        stdout = open(os.devnull, 'w')
+    if stderr is __sentinel__:
+        stderr = open(os.devnull, 'w')
+
+    returncode, stdout, stderr = execute_command(
+        command,
+        cwd=cwd,
+        shell=shell,
+        env=env,
+        stdin=stdin,
+        stderr=stderr,
+        preexec_fn=preexec_fn,
+        use_texpath=use_texpath
+    )
+
+    if returncode:
+        e = CalledProcessError(
+            returncode,
+            command
+        )
+        raise e
+
+    return 0
+
+
+def check_output(command, cwd=None, shell=False, env=None,
+                 stdin=__sentinel__, stderr=__sentinel__,
+                 preexec_fn=None, use_texpath=True):
+    '''
+    Takes a command to be passed to subprocess.Popen.
+
+    Returns the output if the command was successful.
+
+    By default stderr is redirected to stdout, so this will return any output
+    to either stream. This can be changed by calling execute_command with
+    stderr set to subprocess.PIPE or any other valid value.
+
+    Raises CalledProcessError if the command returned a non-zero value
+    Raises OSError if the executable is not found
+
+    This is pretty much identical to subprocess.check_output(), but
+    implemented here since it is unavailable in Python 2.6's library.
+    '''
+    returncode, stdout, stderr = execute_command(
+        command,
+        cwd=cwd,
+        shell=shell,
+        env=env,
+        stdin=stdin,
+        stderr=stderr,
+        preexec_fn=preexec_fn,
+        use_texpath=use_texpath
+    )
+
+    if returncode:
+        e = CalledProcessError(
+            returncode,
+            command
+        )
+        e.output = stdout
+        e.stderr = stderr
+        raise e
+
+    return stdout

--- a/latextools_utils/external_command.py
+++ b/latextools_utils/external_command.py
@@ -161,6 +161,12 @@ def external_command(command, cwd=None, shell=False, env=None,
         startupinfo = subprocess.STARTUPINFO()
         startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
 
+        # encode cwd in the file system encoding; this is necessary to support
+        # some non-ASCII paths; see PR #878. Thanks to anamewing for the
+        # suggested fix
+        if not _ST3 and cwd:
+            cwd = cwd.encode(sys.getfilesystemencoding())
+
     if stdin is __sentinel__:
         stdin = None
 

--- a/latextools_utils/utils.py
+++ b/latextools_utils/utils.py
@@ -108,7 +108,6 @@ def get_file_content(file_name, encoding="utf8", ignore=True,
 class TimeoutError(Exception):
     pass
 
-
 __sentinel__ = object()
 
 
@@ -116,8 +115,10 @@ def run_on_main_thread(func, timeout=10, default_value=__sentinel__):
     """
     Ensures the function, func is run on the main thread and returns the rsult
     of that function call.
+
     Note that this function blocks the thread it is executed on and should only
     be used when the result of the function call is necessary to continue.
+
     Arguments:
     func (callable): a no-args callable; functions that need args should
         be wrapped in a `functools.partial`
@@ -125,6 +126,7 @@ def run_on_main_thread(func, timeout=10, default_value=__sentinel__):
         TimeoutError is raised if this limit is reached a no `default_value`
         is specified
     default_value (any): the value to be returned if a timeout occurs
+
     Note that both timeout and default value are ignored when run in ST3 or
     from the main thread.
     """

--- a/makePDF.py
+++ b/makePDF.py
@@ -14,6 +14,9 @@ if sublime.version() < '3000':
 	from latextools_utils.is_tex_file import is_tex_file
 	from latextools_utils import get_setting
 	from latextools_utils.tex_directives import parse_tex_directives
+	from latextools_utils.external_command import (
+		execute_command, external_command, get_texpath, update_env
+	)
 	from latextools_utils.output_directory import (
 		get_aux_directory, get_output_directory, get_jobname
 	)
@@ -32,6 +35,9 @@ else:
 	from .latextools_utils.is_tex_file import is_tex_file
 	from .latextools_utils import get_setting
 	from .latextools_utils.tex_directives import parse_tex_directives
+	from .latextools_utils.external_command import (
+		execute_command, external_command, get_texpath, update_env
+	)
 	from .latextools_utils.output_directory import (
 		get_aux_directory, get_output_directory, get_jobname
 	)
@@ -92,32 +98,13 @@ class CmdThread ( threading.Thread ):
 		print ("Welcome to thread " + self.getName())
 		self.caller.output("[Compiling " + self.caller.file_name + "]")
 
+		env = dict(os.environ)
+		if self.caller.path:
+			env['PATH'] = self.caller.path
+
 		# Handle custom env variables
 		if self.caller.env:
-			old_env = os.environ;
-			if not _ST3:
-				os.environ.update(dict((k.encode(sys.getfilesystemencoding()), v) for (k, v) in self.caller.env.items()))
-			else:
-				os.environ.update(self.caller.env.items());
-
-		# Handle path; copied from exec.py
-		if self.caller.path:
-			# if we had an env, the old path is already backuped in the env
-			if not self.caller.env:
-				old_path = os.environ["PATH"]
-			# The user decides in the build system  whether he wants to append $PATH
-			# or tuck it at the front: "$PATH;C:\\new\\path", "C:\\new\\path;$PATH"
-			# Handle differently in Python 2 and 3, to be safe:
-			if not _ST3:
-				os.environ["PATH"] = os.path.expandvars(self.caller.path).encode(sys.getfilesystemencoding())
-			else:
-				os.environ["PATH"] = os.path.expandvars(self.caller.path)
-
-		# Set up Windows-specific parameters
-		if self.caller.plat == "windows":
-			# make sure console does not come up
-			startupinfo = subprocess.STARTUPINFO()
-			startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
+			update_env(env, self.caller.env)
 
 		# Now, iteratively call the builder iterator
 		#
@@ -138,31 +125,13 @@ class CmdThread ( threading.Thread ):
 					print(cmd)
 					# Now create a Popen object
 					try:
-						if self.caller.plat == "windows":
-							proc = subprocess.Popen(
-								cmd,
-								startupinfo=startupinfo,
-								stderr=subprocess.STDOUT,
-								stdout=subprocess.PIPE,
-								cwd=self.caller.tex_dir
-							)
-						elif self.caller.plat == "osx":
-							proc = subprocess.Popen(
-								cmd,
-								stderr=subprocess.STDOUT,
-								stdout=subprocess.PIPE,
-								env=os.environ,
-								preexec_fn=os.setsid,
-								cwd=self.caller.tex_dir
-							)
-						else:  # Must be linux
-							proc = subprocess.Popen(
-								cmd,
-								stderr=subprocess.STDOUT,
-								stdout=subprocess.PIPE,
-								preexec_fn=os.setsid,
-								cwd=self.caller.tex_dir
-							)
+						proc = external_command(
+							cmd,
+							env=env,
+							use_texpath=False,
+							preexec_fn=os.setsid if self.caller.plat != 'windows' else None,
+							cwd=self.caller.tex_dir
+						)
 					except:
 						self.caller.show_output_panel()
 						self.caller.output("\n\nCOULD NOT COMPILE!\n\n")
@@ -210,12 +179,6 @@ class CmdThread ( threading.Thread ):
 			self.caller.proc = None
 			traceback.print_exc()
 			return
-		finally:
-			# restore environment
-			if self.caller.env:
-				os.environ = old_env
-			elif self.caller.path:
-				os.environ['PATH'] = old_path
 
 		# Clean up
 		cmd_iterator.close()
@@ -440,18 +403,20 @@ class make_pdfCommand(sublime_plugin.WindowCommand):
 
 		# Try to handle killing
 		with self.proc_lock:
-			if self.proc: # if we are running, try to kill running process
+			if self.proc:  # if we are running, try to kill running process
 				self.output("\n\n### Got request to terminate compilation ###")
-				if sublime.platform() == 'windows':
-					startupinfo = subprocess.STARTUPINFO()
-					startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
-					subprocess.call(
-						'taskkill /t /f /pid {pid}'.format(pid=self.proc.pid),
-						startupinfo=startupinfo,
-						shell=True
-					)
-				else:
-					os.killpg(self.proc.pid, signal.SIGTERM)
+				try:
+					if sublime.platform() == 'windows':
+						execute_command(
+							'taskkill /t /f /pid {pid}'.format(pid=self.proc.pid),
+							use_texpath=False
+						)
+					else:
+						os.killpg(self.proc.pid, signal.SIGTERM)
+				except:
+					print('Exception occurred while killing build')
+					traceback.print_exc()
+
 				self.proc = None
 				return
 			else: # either it's the first time we run, or else we have no running processes
@@ -630,7 +595,8 @@ class make_pdfCommand(sublime_plugin.WindowCommand):
 
 		# Now get the tex binary path from prefs, change directory to
 		# that of the tex root file, and run!
-		self.path = platform_settings['texpath']
+		self.path = get_texpath() or os.environ['PATH']
+
 		thread = CmdThread(self)
 		thread.start()
 		print(threading.active_count())

--- a/viewers/command_viewer.py
+++ b/viewers/command_viewer.py
@@ -1,13 +1,13 @@
 from base_viewer import BaseViewer
 
 from latextools_utils import get_setting
+from latextools_utils.external_command import external_command
 from latextools_utils.sublime_utils import get_sublime_exe
 
 from copy import copy
 import os
 import re
 import shlex
-import subprocess
 import sublime
 import string
 import sys
@@ -137,19 +137,8 @@ class CommandViewer(BaseViewer):
         if not replaced:
             command.append(pdf_file)
 
-        startupinfo = None
-        if sublime.platform() == 'windows':
-            startupinfo = subprocess.STARTUPINFO()
-            startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
-
-        env = copy(os.environ)
-        env['PATH'] = get_texpath() or env['PATH']
-
-        print('Running {0}'.format(quote(' '.join(command))))
-        subprocess.Popen(
+        external_command(
             command,
-            startupinfo=startupinfo,
-            env=env,
             cwd=os.path.split(pdf_file)[0]
         )
 

--- a/viewers/okular_viewer.py
+++ b/viewers/okular_viewer.py
@@ -1,9 +1,8 @@
 from base_viewer import BaseViewer
 
 from latextools_utils import get_setting
+from latextools_utils.external_command import external_command, check_output
 
-import subprocess
-import sys
 import time
 
 
@@ -17,19 +16,19 @@ class OkularViewer(BaseViewer):
         if locator is not None:
             command.append(locator)
 
-        subprocess.Popen(command)
+        external_command(command, use_texpath=False)
 
     def _is_okular_running(self):
-        stdout = subprocess.Popen(
-            ['ps', 'xw'], stdout=subprocess.PIPE
-        ).communicate()[0]
+        try:
+            running_apps = check_output(['ps', 'xv'], use_texpath=False)
+            for app in running_apps.splitlines():
+                if 'okular' not in app:
+                    continue
+                if '--unique' in app:
+                    return True
+        except:
+            pass
 
-        running_apps = stdout.decode(sys.getdefaultencoding(), 'ignore')
-        for app in running_apps.splitlines():
-            if 'okular' not in app:
-                continue
-            if '--unique' in app:
-                return True
         return False
 
     def _ensure_okular(self, **kwargs):

--- a/viewers/preview_viewer.py
+++ b/viewers/preview_viewer.py
@@ -1,11 +1,14 @@
 from base_viewer import BaseViewer
 
-import subprocess
+from latextools_utils.external_command import external_command
 
 
 class PreviewViewer(BaseViewer):
+
     def view_file(self, pdf_file, **kwargs):
-        subprocess.Popen(['open', '-a', 'Preview', pdf_file])
+        external_command(
+            ['open', '-a', 'Preview', pdf_file], use_texpath=False
+        )
 
     def supports_platform(self, platform):
         return platform == 'osx'

--- a/viewers/skim_viewer.py
+++ b/viewers/skim_viewer.py
@@ -1,7 +1,8 @@
 from base_viewer import BaseViewer
 
 import os
-import subprocess
+
+from latextools_utils.external_command import check_output, external_command
 
 
 class SkimViewer(BaseViewer):
@@ -11,11 +12,11 @@ class SkimViewer(BaseViewer):
         path_to_skim = '/Applications/Skim.app'
 
         if not os.path.exists(path_to_skim):
-            path_to_skim = subprocess.check_output([
+            path_to_skim = check_output([
                 'osascript',
                 '-e',
                 'POSIX path of (path to app id "net.sourceforge.skim-app.skim")'
-            ]).decode("utf8")[:-1]
+            ], use_texpath=False)
 
         command = [
             os.path.join(
@@ -34,7 +35,7 @@ class SkimViewer(BaseViewer):
             str(line), pdf_file, tex_file
         ]
 
-        subprocess.Popen(command)
+        external_command(command, use_texpath=False)
 
     def view_file(self, pdf_file, **kwargs):
         keep_focus = kwargs.pop('keep_focus', True)
@@ -57,7 +58,7 @@ class SkimViewer(BaseViewer):
 
         command.append(pdf_file)
 
-        subprocess.Popen(command)
+        external_command(command, use_texpath=False)
 
     def supports_keep_focus(self):
         return True

--- a/viewers/sumatra_viewer.py
+++ b/viewers/sumatra_viewer.py
@@ -1,10 +1,10 @@
 from base_viewer import BaseViewer
 
 from latextools_utils import get_setting
+from latextools_utils.external_command import external_command
 
 import os
 import sublime
-import subprocess
 import sys
 import traceback
 
@@ -91,10 +91,6 @@ class SumatraViewer(BaseViewer):
         if not isinstance(commands, list):
             commands = [commands]
 
-        startupinfo = subprocess.STARTUPINFO()
-        startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
-        startupinfo.wShowWindow = 4  # SHOWNOACTIVE
-
         # favour 'sumatra' setting under viewer_settings if
         # it exists, otherwise, use the platform setting
         sumatra_binary = get_setting('viewer_settings', {}).\
@@ -105,9 +101,9 @@ class SumatraViewer(BaseViewer):
             sumatra_binary = 'SumatraPDF.exe'
 
         try:
-            subprocess.Popen(
+            external_command(
                 [sumatra_binary] + commands,
-                startupinfo=startupinfo
+                use_texpath=False
             )
         except OSError:
             exc_info = sys.exc_info()
@@ -115,9 +111,9 @@ class SumatraViewer(BaseViewer):
             sumatra_exe = self._find_sumatra_exe()
             if sumatra_exe is not None and sumatra_exe != sumatra_binary:
                 try:
-                    subprocess.Popen(
+                    external_command(
                         [sumatra_exe] + commands,
-                        startupinfo=startupinfo
+                        use_texpath=False
                     )
                 except OSError:
                     traceback.print_exc()

--- a/viewers/zathura_viewer.py
+++ b/viewers/zathura_viewer.py
@@ -1,11 +1,11 @@
 from base_viewer import BaseViewer
 
 from latextools_utils import get_setting
+from latextools_utils.external_command import (
+    check_output, external_command
+)
 from latextools_utils.sublime_utils import get_sublime_exe
 from latextools_utils.system import which
-
-import subprocess
-import sys
 
 
 class ZathuraViewer(BaseViewer):
@@ -20,16 +20,16 @@ class ZathuraViewer(BaseViewer):
         )
 
     def _get_zathura_pid(self, pdf_file):
-        stdout = subprocess.Popen(
-            ['ps', 'xw'], stdout=subprocess.PIPE
-        ).communicate()[0]
+        try:
+            running_apps = check_output(['ps', 'xv'], use_texpath=False)
+            for app in running_apps.splitlines():
+                if 'zathura' not in app:
+                    continue
+                if pdf_file in app:
+                    return app.lstrip().split(' ', 1)[0]
+        except:
+            pass
 
-        running_apps = stdout.decode(sys.getdefaultencoding(), 'ignore')
-        for app in running_apps.splitlines():
-            if 'zathura' not in app:
-                continue
-            if pdf_file in app:
-                return app.lstrip().split(' ', 1)[0]
         return None
 
     def _focus_zathura(self, pid):
@@ -47,27 +47,30 @@ class ZathuraViewer(BaseViewer):
                 pass
 
     def _focus_wmctrl(self, pid):
-        pid = ' {0} '.format(pid)
-        stdout = subprocess.Popen(
-            ['wmctrl', '-l', '-p'], stdout=subprocess.PIPE
-        ).communicate()[0]
-
         window_id = None
-        windows = stdout.decode(sys.getdefaultencoding(), 'ignore')
-        for window in windows.splitlines():
-            if pid in window:
-                window_id = window.split(' ', 1)[0]
-                break
+        try:
+            windows = check_output(
+                ['wmctrl', '-l', '-p'], use_texpath=False
+            )
+        except:
+            pass
+        else:
+            pid = ' {0} '.format(pid)
+            for window in windows.splitlines():
+                if pid in window:
+                    window_id = window.split(' ', 1)[0]
+                    break
 
         if window_id is None:
             raise Exception('Cannot find window for Zathura')
 
-        subprocess.Popen(['wmctrl', '-a', window_id, '-i'])
+        external_command(['wmctrl', '-a', window_id, '-i'], use_texpath=False)
 
     def _focus_xdotool(self, pid):
-        subprocess.Popen(
+        external_command(
             ['xdotool', 'search', '--pid', pid,
-             '--class', 'Zathura', 'windowactivate', '%2']
+             '--class', 'Zathura', 'windowactivate', '%2'],
+            use_texpath=False
         )
 
     def forward_sync(self, pdf_file, tex_file, line, col, **kwargs):
@@ -92,7 +95,7 @@ class ZathuraViewer(BaseViewer):
 
         command.append(pdf_file)
 
-        subprocess.Popen(command)
+        external_command(command, use_texpath=False)
 
         if pid is not None and not keep_focus:
             self._focus_zathura(pid)
@@ -102,11 +105,11 @@ class ZathuraViewer(BaseViewer):
 
         pid = self._get_zathura_pid(pdf_file)
         if pid is None:
-            pid = subprocess.Popen([
+            pid = external_command([
                 'zathura',
                 self._get_synctex_editor(),
                 pdf_file
-            ]).pid
+            ], use_texpath=False).pid
         elif not keep_focus:
             self._focus_zathura(pid)
 


### PR DESCRIPTION
This standardises the various ways that we call subprocess.Popen(). My main future intention here is to be able to integrate [shellenv](https://github.com/codexns/shellenv), which should enable us to fully resolve some of the PATH issues, so that things get closer to "just working."

In addition, it ensures some consistency in:
1. Ensuring the PATH is set to `texpath`
2. Ensuring that we do not open a console window on Windows
3. It tries to log any commands executed in as sane a format as possible

I've also added versions of `check_call()` and `check_output()`.

Lastly, to ensure `get_texroot()` could be used wherever, I added a function (`run_on_main_thread`) which ensures that a function is called on the main ST thread on ST2 and returns the result. This enables the function to use the Sublime API, while the main processing can be done on a separate thread. As part of this, I cleaned up the latex_gen_pkg_cache command so it will always be run in a thread. More generally, this will make it possible to write sane threaded code to enable some form of background processing for long-running tasks.
