### PR TITLE
Add support for --output-directory, --aux-directory, and --jobname

### DIFF
--- a/00_reload_submodules.py
+++ b/00_reload_submodules.py
@@ -26,12 +26,14 @@ LOAD_ORDER = [
     'latextools_utils.tex_directives',
 
     # depend on previous only
+    'latextools_utils.distro_utils',
     'latextools_utils.is_tex_file',
     'latextools_utils.sublime_utils',
     'latextools_utils.cache',
 
     # depend on any previous
     'latextools_utils.analysis',
+    'latextools_utils.output_directory',
 
     'latextools_plugin_internal',
 

--- a/01_temp_file_cleanup.py
+++ b/01_temp_file_cleanup.py
@@ -1,0 +1,69 @@
+import json
+import os
+import sublime
+import shutil
+import tempfile
+
+if sublime.version() < '3000':
+    def get_cache_directory():
+        return os.path.join(
+            sublime.packages_path(),
+            'User',
+            '.lt_cache'
+        )
+
+    strbase = basestring
+else:
+    def get_cache_directory():
+        return os.path.join(
+            sublime.cache_path(),
+            'LaTeXTools'
+        )
+
+    strbase = str
+
+
+# unfortunately, there is no reliable way to do clean-up on exit in ST
+# see https://github.com/SublimeTextIssues/Core/issues/10
+# here we cleanup any directories listed in the temporary_output_dirs
+# file as having been previously created by the plugin
+
+def plugin_loaded():
+    temporary_output_dirs = os.path.join(
+        get_cache_directory(),
+        'temporary_output_dirs'
+    )
+
+    if os.path.exists(temporary_output_dirs):
+        with open(temporary_output_dirs, 'r') as f:
+            data = json.load(f)
+
+        tempdir = tempfile.gettempdir()
+
+        try:
+            for directory in data['directories']:
+                # shutil.rmtree is a rather blunt tool, so here we try to
+                # ensure we are only deleting legitimate temporary files
+                if (
+                    directory is None or
+                    not isinstance(directory, strbase) or
+                    not directory.startswith(tempdir)
+                ):
+                    continue
+
+                try:
+                    shutil.rmtree(directory)
+                except OSError:
+                    pass
+                else:
+                    print(u'Deleted old temp directory ' + directory)
+        except KeyError:
+            pass
+
+        try:
+            os.remove(temporary_output_dirs)
+        except OSError:
+            pass
+
+if sublime.version() < '3000':
+    plugin_loaded()

--- a/LaTeXTools.sublime-settings
+++ b/LaTeXTools.sublime-settings
@@ -148,6 +148,96 @@
 	},
 
 // ------------------------------------------------------------------
+// Output Directory settings settings
+// ------------------------------------------------------------------
+
+	// OPTION: "aux_directory"
+	// Specifies the auxiliary directory
+	// Possible values:
+	//
+	// ""				the default; does not use any auxiliary directory
+	//
+	// path				the path to the auxiliary directory; if this is
+	//					not an absolute path it is interpreted as a
+	//					path relative to the main tex file
+	//
+	// "<<temp>>"		the auxiliary directory will be a temporary
+	//					directory generated in as secure a manner as
+	//					possible; note that this temporary directory
+	//					is only valid until ST is restarted and will
+	//					be deleted on the next start-up
+	//
+	// "<<project>>"	this creates an auxiliary directory in the same
+	//					folder as the main tex file; the name is the
+	//					MD5 hash of the absolute path of the main file;
+	//					unlike <<temp>> this directory will persist
+	//
+	// "<<cache>>"		this creates an auxiliary directory in the ST
+	//					cache directory on ST3 or a suitable directory
+	//					on ST2; unlike <<temp>> this directory will
+	//					persist; unlike <<project>>, it will not be
+	//					in the same directory as the main tex file
+	//
+	// NOTE: This setting will be overridden by the corresponding
+	// %!TEX directive if any; also, while it is possible to define
+	// a global value here, it may make more sense to define this
+	// value in your project settings if you use STs project feature
+	// if you do so, however, note that the path will be interpreted
+	// relative to the location of your project file
+
+	"aux_directory": "",
+
+	// OPTION: "output_directory"
+	// Specifies the output directory
+	// Possible values:
+	//
+	// ""				the default; does not use any output directory
+	//
+	// path				the path to the output directory; if this is
+	//					not an absolute path it is interpreted as a
+	//					path relative to the main tex file
+	//
+	// "<<temp>>"		the output directory will be a temporary
+	//					directory generated in as secure a manner as
+	//					possible; note that this temporary directory
+	//					is only valid until ST is restarted and will
+	//					be deleted on the next start-up
+	//
+	// "<<project>>"	this creates an output directory in the same
+	//					folder as the main tex file; the name is the
+	//					MD5 hash of the absolute path of the main file;
+	//					unlike <<temp>> this directory will persist
+	//
+	// "<<cache>>"		this creates an output directory in the ST
+	//					cache directory on ST3 or a suitable directory
+	//					on ST2; unlike <<temp>> this directory will
+	//					persist; unlike <<project>>, it will not be
+	//					in the same directory as the main tex file
+	//
+	// NOTE: This setting will be overridden by the corresponding
+	// %!TEX directive if any; also, while it is possible to define
+	// a global value here, it may make more sense to define this
+	// value in your project settings if you use STs project feature
+	// if you do so, however, note that the path will be interpreted
+	// relative to the location of your project file
+
+	"output_directory": "",
+
+	// OPTION: "jobname"
+	// Specifies the jobname to use when building the document
+
+	"jobname": "",
+
+	// OPTION: "copy_output_on_build"
+	// Specifies whether to copy the final PDF file to the same folder
+	// as the main tex file; if it is neither true nor false it must be
+	// as list of extensions of the files to copy into the same folder as
+	// the main tex file; this  only applies if an output directory is
+	// set via a setting or a `%!TEX` directive
+
+	"copy_output_on_build": true,
+
+// ------------------------------------------------------------------
 // Build engine settings
 // ------------------------------------------------------------------
 

--- a/README.markdown
+++ b/README.markdown
@@ -168,6 +168,9 @@ Note that if you specify a relative path as the `TEXroot` in the project file, t
 
 **Customizing or replacing the compilation command** (`latexmk` or `texify`) is also possible by setting the `command` option under Builder Settings. If you do, the TeX engine selection facility may no longer work because it relies on a specific compilation command. However, if you want to customize or replace `latexmk`/`texify`, you probably know how to select the right TeX engine, so this shouldn't be a concern. Also note that if you are using `latexmk` and you set the `$pdflatex` variable, the TeX options facility will not function, as `latexmk` does not support this. See the Settings option below for details. *Note*: if you change the compilation command, you are responsible for making it work on your setup. Only customize the compilation command if you know what you're doing. 
 
+**Output directory and Aux directory** are supported as far as is possible. If the first few lines of the main file contains the text `%!TEX output_directory = <path>`, the corresponding path is used for the output directory. Similarly,  `%!TEX aux_directory = <path>` will also be interpreted as the auxiliary directory. In addition, you can specify either `--output-directory` or `--aux-directory` in the TeX options (see above) and it will be interpretted accordingly. Finally, these two can also be controlled by a corresponding setting detailed in the section on settings. There are also three special values that can be used, `<<temp>>` `<<project>>` and `<<cache>>`. Their meaning is the same as that found in the settings section and they are described there. **Note** output directory and aux directory are only available when either using latexmk (default on OS X and Linux),  the `basic` builder or the `script` builder (see below [for documentation on using the script builder](#script-builder)). If you are using texify (default when using MiKTeX) or the simple builder, setting an aux directory or output directory will be ignored.
+
+**Jobname** is supported as far as possible. If the first few lines of the main file contains the text `%!TEX jobname = <jobname>`, the corresponding name is used as the `\jobname` for the build. In addition, you can specify `--jobname` in the TeX options (see above), and it will be interpretted accordingly. Finally, jobname can be set by a setting detailed below. **Note** jobname is only availabe either using latexmk (default on OS X and Linux), the `basic` builder or the `script` builder (see below [for documentation on using the script builder](#script-builder)). If you are using texify (default when using MiKTeX) or the simple builder, setting a jobname will be ignored.
 
 ### Toggling window focus following a build ###
 
@@ -198,6 +201,8 @@ This causes the status message to list the default settings of the focus and syn
 This deletes all temporary files from a previous build (the PDF file is kept). Subfolders are traversed recursively.
 
 Two settings allow you to fine-tune the behavior of this command. `temp_files_exts` allows you to specify which file extensions should be considered temporary, and hence deleted. `temp_files_ignored_folders` allows you to specify folders that should not be traversed. A good example are `.git` folders, for people who use git for version control.
+
+**NOTE**: If you use any of the special values with the output directory or auxiliary directory feature, the above is ignored, and the entire directory is simply deleted. If you are using the auxiliary directory feature *without* using an output directory, the auxiliary directory will be cleared and the normal process will be run.
 
 
 ### Automatically hide build panel after build finished ###
@@ -496,6 +501,13 @@ The following options are currently available (defaults in parentheses):
 - `cwl_list` (empty): list of paths to cwl files
 - `keep_focus` (`true`): if `true`, after compiling a tex file, ST retains the focus; if `false`, the PDF viewer gets the focus. Also note that you can *temporarily* toggle this behavior with `C-l,t,f`. **Note**: If you are on either Windows or Linux you may need to adjust the `sublime_executable` setting for this to work properly. See the **Platform settings** below. This can also be overridden via a key-binding by passing a `keep_focus` argument to `jump_to_pdf`.
 - `forward_sync` (`true`): if `true`, after compiling a tex file, the PDF viewer is asked to sync to the position corresponding to the current cursor location in ST. You can also *temporarily* toggle this behavior with `C-l,t,s`. This can also be overridden via a key-binding by passing a `forward_sync` argument to `jump_to_pdf`.
+- `aux_directory` (`""`): specifies the auxiliary directory to store any auxiliary files generated during a LaTeX build. Note that the auxiliary directory option is only useful if you are using MiKTeX. Path can be specified using either an absolute path or a relative path. If `aux_directory` is set from the project file, a relative path will be interpreted as relative to the project file. If it is set in the settings file, it will be interpreted relative to the main tex file. In addition, the following special values are honored:
+  * `<<temp>>`: uses a temporary directory in the system temp directory instead of a specified path; this directory will be unique to each main file, but does not persist across restarts.
+  * `<<cache>>`: uses the ST cache directory (or a suitable directory on ST2) to store the output files; unlike the `<<temp>>` option, this directory can persist across restarts.
+  * `<<project>>`: uses a sub-directory in the same folder as the main tex file with what should be a unique name; note, this is probably not all that useful and you're better off using one of the other two options or a named relative path
+- `output_directory` (`""`): specifies the output directory to store any file generated during a LaTeX build. Path can be specified using either an absolute path or a relative path. If `output_directory` is set from the project file, a relative path will be interpreted as relative to the project file. If it is set in the settings file, it will be interpreted relative to the main tex file. In addition, output_directory honors the same special values as `auxiliary_directory`.
+- `jobname` (`""`): specifies the jobname to use for the build, corresponding to the pdflatex `--jobname` argument.
+- `copy_output_on_build` (`true`): if `true` and you are using an `output_directory`, either set via the setting or the `%!TEX` directive, this instructs LaTeXTools to copy to resulting pdf to the same folder as the main tex file. If you are not using `output_directory` or it is set to `false`, it does nothing. If it is a list of extensions, it will copy each file with the same name as your main tex file and the given extension to the same folder as your main tex file. This is useful for copying, e.g., .synctex.gz or .log files.
 - `temp_files_exts`: list of file extensions to be considered temporary, and hence deleted using the `C-l, backspace` command.
 - `temp_files_ignored_folders`: subdirectories to skip when deleting temp files.
 * `tex_file_exts` (`['.tex']`): a list of extensions that should be considered TeX documents. Any extensions in this list will be treated exactly the same as `.tex` files. See the section on [Support for non-`.tex` files](#support-for-non-tex-files).
@@ -522,7 +534,7 @@ The following options are currently available (defaults in parentheses):
 **Build engine settings**:
 
 NOTE: for the time being, you will need to refer to the `LaTeXTools.sublime-settings` file for detailed explanations. Also, since the new build system is meant to be fully customizable, if you use a third-party builder (which hopefully will become available!), you need to refer to its documentation.
-- `builder`: the builder you want to use. Leave blank (`""`) or set to `"default"` or `"traditional"` for the traditional (`latexmk`/`texify`) behavior.
+- `builder`: the builder you want to use. Leave blank (`""`) or set to `"default"` or `"traditional"` for the traditional (`latexmk`/`texify`) behavior. Set to `"basic"` for the basic builder that supports output and auxiliary directories on MiKTeX.
 - `builder_path`: builders can reside anywhere Sublime Text can access. Specify a path *relative to the Sublime text Packages directory*. In particular, `User` is a good choice. If you use a third-party builder, specify the builder-provided directory.
 - `display_bad_boxes` (`false`): if `true` LaTeXTools will display any bad boxes encountered after a build. Note that this is disabled by default.
 - `builder-settings`: these are builder-specific settings. For the `default`/`traditional` builder, the following settings are useful:
@@ -575,10 +587,16 @@ Some information on the new flexible builder system: to create and use a new bui
 
 Due to time constraints, I have not yet been able to document how to write a builder. The basic idea is that you subclass the `PdfBuilder` class in the file `LaTeXTools/builders/pdfBuilder.py`. The comments in that file describe how builders interact with the build command (hint: they use Pyton's `yield` command). I provide three builders. The code is in the `LaTeXTools/builders` directory. You can use them as examples:
 - `traditional` is the traditional builder. 
+- `basic` (see below) is a simplified build system that tries to run a simple `pdflatex`, `bibtex` (or `biber`), `pdflatex`, `pdflatex` pattern. However, it supports all of the same options as the traditional builder.
 - `simple` does not use external tools, but invokes `pdflatex` and friends, each time checking the log file to figure out what to do next. It is a very, very simple "make" tool, but it demonstrates the back-and-forth interaction between LaTeXTools and a builder.
 - `script` (see below) allows the user to specify a list of compilation commands in the settings file, and just execute them in sequence. 
 
 Let me know if you are interested in writing a custom builder!
+
+Basic Builder
+-------------
+
+The basic builder is a simple, straight-forward build system. It differs from the `simple` builder in that: 1) whereas the simple builder is intended as an example of how to create a builder, the basic builder is intended to be an operational build system, 2) it supports all of the various builder settings that the `traditional` builder does, with the exception of the `command` setting, 3) it supports biber and biblatex more generally, and 4) it supports the output and auxiliary directory behavior on MiKTeX without installing any additional components, as recent versions of `texify` cannot be coerced into passing the necessary options to pdflatex and friends.
 
 Script Builder
 --------------
@@ -652,6 +670,9 @@ Each command can use the following variables which will be expanded before it is
 |`$file_ext`| The extension portion of the main file, e.g., _tex_|
 |`$file_base_name`| The name portion of the main file without the, e.g., _document_|
 |`$file_path`| The directory of the main file, e.g., _C:\Files_|
+|`$aux_directory`| The auxiliary directory set via a `%!TEX` directive or the settings|
+|`$output_directory`| The output directory set via a `%!TEX` directive or the settings|
+|`$jobname`| The jobname set via a `%!TEX` directive or the settings|
 
 For example:
 
@@ -665,13 +686,50 @@ For example:
 
 Note that if none of these variables occur in the command string, the `$file_base_name` will be appended to the end of the command. This may mean that a wrapper script is needed if, for example, using `make`.
 
-Commands are executed in the same path as `$file_path`, i.e. the folder containing the main document.
+Commands are executed in the same path as `$file_path`, i.e. the folder containing the main document. Note, however, on Windows, since commands are launched using `cmd.exe`, you need to be careful if your root document is opened via a UNC path (this doesn't apply if you are simply using a mapped drive). `cmd.exe` doesn't support having the current working directory set to a UNC path and will change the path to `%SYSTEMROOT%`. In such a case, just ensure all the paths you specify are absolute paths and use `pushd` in place of `cd`, as this will create a (temporary) drive mapping.
+
+### Supporting output and auxiliary directories ###
+
+If you are using LaTeXTools output and auxiliary directory behavior there are some caveats to be aware of. First, it is, of course, your responsibility to ensure that the approrpiate variables are passed to the appropriate commands in your script. Second, `pdflatex` and friends do not create output directories as needed. Therefore, at the very least, your script must start with either `"mkdir $output_directory"` (Windows) or `"mkdir -p $output_directory"` and a corresponding command if using a separate `$aux_directory`. Note that if you `\include` (or otherwise attempt anything that will `\@openout` a file in a subfolder), you will need to ensure the subfolder exists. Otherwise, your run of `pdflatex` will fail.
+
+Finally, unlike Biber, bibtex (and bibtex8) does not support an output directory parameter, which can make it difficult to use if you are using the LaTeXTools output directory behavior. The following work-arounds can be used to get BibTeX to do the right thing.
+
+On Windows, run BibTeX like so:
+
+```
+cd $aux_directory & set BIBINPUTS=\"$file_path:%BIBINPUTS%\" & bibtex $file_base_name
+```
+
+And on OS X or Linux, use this:
+
+```
+"cd $output_directory; BIBINPUTS=\"$file_path;$BIBINPUTS\" bibtex $file_base_name"
+```
+
+In either case, these run bibtex *inside* the output / auxiliary directory while making the directory containing your main file available to the `BIBINPUTS` environment variable. Note if you use a custom style file in the same directory, you will need to apply a similar work-around for the `BSTINPUTS` environment variable.
+
+### Support jobname ###
+
+If you are using LaTeXTools jobname behaviour, you should be aware that you are responsible for ensure jobname is set in the appropriate context. In particular, a standard build cycle might look something like this:
+
+```json
+"builder_settings": {
+	"osx": {
+		"script_commands": [
+			"pdflatex -synctex=1 -interaction=nonstopmode -jobname=$jobname $file_base_name",
+			"bibtex $jobname",
+			"pdflatex -synctex=1 -interaction=nonstopmode -jobname=$jobname $file_base_name",
+			"pdflatex -synctex=1 -interaction=nonstopmode -jobname=$jobname $file_base_name"
+		]
+	}
+}
+```
 
 ### Caveats ###
 
 LaTeXTools makes some assumptions that should be adhered to or else things won't work as expected:
-- the final product is a PDF which will be written in the same directory as the main file and named `$file_base_name.pdf`
-- the LaTeX log will be written in the same directory as the main file and named `$file_base_name.log`
+- the final product is a PDF which will be written to the output directory or the same directory as the main file and named `$file_base_name.pdf`
+- the LaTeX log will be written to the output directory or the same directory as the main file and named `$file_base_name.log`
 - if you change the `PATH` in the environment (by using the `env` setting), you need to ensure that the `PATH` is still sane, e.g., that it contains the path for the TeX executables and other command line resources that may be necessary.
 
 In addition, to ensure that forward and backward sync work, you need to ensure that the `-synctex=1` flag is set for your latex command. Again, don't forget the `-interaction=nonstopmode` flag (or whatever is needed for your tex programs not to expect user input in case of error).

--- a/builders/basicBuilder.py
+++ b/builders/basicBuilder.py
@@ -1,0 +1,241 @@
+# ST2/ST3 compat
+import sublime
+if sublime.version() < '3000':
+    # we are on ST2 and Python 2.X
+    _ST3 = False
+    strbase = basestring
+
+    # reraise implementation from 6
+    exec("""def reraise(tp, value, tb=None):
+    raise tp, value, tb
+""")
+else:
+    _ST3 = True
+    strbase = str
+
+    # reraise implementation from 6
+    def reraise(tp, value, tb=None):
+        if value is None:
+            value = tp()
+        if value.__traceback__ is not tb:
+            raise value.with_traceback(tb)
+        raise value
+
+import os
+import re
+import subprocess
+import sys
+# This will work because makePDF.py puts the appropriate
+# builders directory in sys.path
+from pdfBuilder import PdfBuilder
+
+# Standard LaTeX warning
+CITATIONS_REGEX = re.compile(r"Warning: Citation `.+' on page \d+ undefined")
+# BibLaTeX outputs a different message from BibTeX, so we must catch that too
+BIBLATEX_REGEX = re.compile(r"Package biblatex Warning: Please \(re\)run (\S*)")
+# Used to indicate a subdirectory that needs to be made for a file input using
+# \include
+FILE_WRITE_ERROR_REGEX = re.compile(r"! I can't write on file `(.*)/([^/']*)'")
+
+
+#----------------------------------------------------------------
+# BasicBuilder class
+#
+# This is a more fully functional verion of the Simple Builder
+# concept. It implements the same building features as the
+# Traditional builder.
+#
+class BasicBuilder(PdfBuilder):
+
+    def __init__(self, *args):
+        super(BasicBuilder, self).__init__(*args)
+        self.name = "Basic Builder"
+        self.bibtex = self.builder_settings.get('bibtex', 'bibtex')
+        self.display_log = self.builder_settings.get("display_log", False)
+
+    def commands(self):
+        # Print greeting
+        self.display("\n\nBasic Builder: ")
+
+        engine = self.engine
+        if "la" not in engine:
+            # we need the command rather than the engine
+            engine = {
+                "pdftex": u"pdflatex",
+                "xetex": u"xelatex",
+                "luatex": u"lualatex"
+            }.get(engine, u'pdflatex')
+
+        if engine not in ['pdflatex', 'xelatex', 'lualatex']:
+            engine = 'pdflatex'
+
+        latex = [engine, u"-interaction=nonstopmode", u"-synctex=1"]
+        biber = [u"biber"]
+
+        if self.aux_directory is not None:
+            self.make_directory(self.aux_directory)
+
+            if self.aux_directory == self.output_directory:
+                latex.append(u'--output-directory=' + self.aux_directory)
+            else:
+                latex.append(u'--aux-directory=' + self.aux_directory)
+
+            biber.append(u'--output-directory=' + self.aux_directory)
+
+        if (
+            self.output_directory is not None and
+            self.output_directory != self.aux_directory
+        ):
+            self.make_directory(self.aux_directory)
+            latex.append(u'--output-directory=' + self.output_directory)
+
+        if self.job_name != self.base_name:
+            latex.append(u'--jobname=' + self.job_name)
+
+        for option in self.options:
+            latex.append(option)
+
+        latex.append(self.base_name)
+
+        yield (latex, "running {0}...".format(engine))
+        self.display("done.\n")
+        self.log_output()
+
+        # Check if any subfolders need to be created
+        # this adds a number of potential runs as LaTeX treats being unable
+        # to open output files as fatal errors
+        if self.aux_directory is not None:
+            while True:
+                start = 0
+                added_directory = False
+                while True:
+                    match = FILE_WRITE_ERROR_REGEX.search(self.out, start)
+                    if match:
+                        self.make_directory(
+                            os.path.normpath(
+                                os.path.join(
+                                    self.aux_directory,
+                                    match.group(1)
+                                )
+                            )
+                        )
+                        start = match.end(1)
+                        added_directory = True
+                    else:
+                        break
+                if added_directory:
+                    yield (latex, "running {0}...".format(engine))
+                    self.display("done.\n")
+                    self.log_output()
+                else:
+                    break
+
+        # Check for citations
+        # Use search, not match: match looks at the beginning of the string
+        # We need to run pdflatex twice after bibtex
+        if (
+            CITATIONS_REGEX.search(self.out) or
+            "Package natbib Warning: There were undefined citations."
+                in self.out
+        ):
+            yield (self.run_bibtex(), "running bibtex...")
+            self.display("done.\n")
+            self.log_output()
+
+            for i in range(2):
+                yield (latex, "running {0}...".format(engine))
+                self.display("done.\n")
+                self.log_output()
+        else:
+            match = BIBLATEX_REGEX.search(self.out)
+            if match:
+                if match.group(1).lower() == 'biber':
+                    yield (biber + [self.job_name], "running biber...")
+                else:
+                    yield (
+                        self.run_bibtex(match.group(1).lower()),
+                        "running {0}...".format(match.group(1).lower9)
+                    )
+                self.display("done.\n")
+                self.log_output()
+
+                for i in range(2):
+                    yield (latex, "running {0}...".format(engine))
+                    self.display("done.\n")
+                    self.log_output()
+
+        # Check for changed labels
+        # Do this at the end, so if there are also citations to resolve,
+        # we may save one pdflatex run
+        if "Rerun to get cross-references right." in self.out:
+            yield (latex, "running {0}...".format(engine))
+            self.display("done.\n")
+            self.log_output()
+            self.display("done.\n")
+
+    def log_output(self):
+        if self.display_log:
+            self.display("\nCommand results:\n")
+            self.display(self.out)
+            self.display("\n\n")
+
+    def make_directory(self, directory):
+        if not os.path.exists(directory):
+            try:
+                print('making directory ' + directory)
+                os.makedirs(directory)
+            except OSError:
+                if not os.path.exists(directory):
+                    reraise(*sys.exc_info())
+
+    def run_bibtex(self, command=None):
+        if command is None:
+            command = [self.bibtex]
+        elif isinstance(command, strbase):
+            command = [command]
+
+        # to get bibtex to work with the output directory, we change the
+        # cwd to the output directory and add the main directory to
+        # BIBINPUTS and BSTINPUTS
+        env = dict(os.environ)
+        cwd = self.tex_dir
+
+        if self.aux_directory is not None:
+            # cwd is, at the point, the path to the main tex file
+            if _ST3:
+                env['BIBINPUTS'] = cwd + os.pathsep + env.get('BIBINPUTS', '')
+                env['BSTINPUTS'] = cwd + os.pathsep + env.get('BSTINPUTS', '')
+            else:
+                env['BIBINPUTS'] = \
+                    (cwd + os.pathsep + env.get('BIBINPUTS', '')).encode(
+                        sys.getfilesystemencoding())
+                env['BSTINPUTS'] = \
+                    (cwd + os.pathsep + env.get('BSTINPUTS', '')).encode(
+                        sys.getfilesystemencoding())
+            # now we modify cwd to be the output directory
+            # NOTE this cwd is not reused by any of the other command
+            cwd = self.aux_directory
+
+        startupinfo = None
+        preexec_fn = None
+
+        if sublime.platform() == 'windows':
+            startupinfo = subprocess.STARTUPINFO()
+            startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
+        else:
+            preexec_fn = os.setsid
+
+        command.append(self.job_name)
+        print(command)
+        bib_proc = subprocess.Popen(
+            command,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            startupinfo=startupinfo,
+            shell=False,
+            env=env,
+            cwd=cwd,
+            preexec_fn=preexec_fn
+        )
+
+        return bib_proc

--- a/builders/pdfBuilder.py
+++ b/builders/pdfBuilder.py
@@ -38,8 +38,9 @@ class PdfBuilder(latextools_plugin.LaTeXToolsPlugin):
 	# Your __init__ method *must* call this (via super) to ensure that
 	# tex_root is properly split into the root tex file's directory,
 	# its base name, and extension, etc.
-	def __init__(self, tex_root, output, engine, options,
-				 tex_directives, builder_settings, platform_settings):
+	def __init__(self, tex_root, output, engine, options, aux_directory,
+				 output_directory, job_name, tex_directives,
+				 builder_settings, platform_settings):
 		self.tex_root = tex_root
 		self.tex_dir, self.tex_name = os.path.split(tex_root)
 		self.base_name, self.tex_ext = os.path.splitext(self.tex_name)
@@ -47,6 +48,9 @@ class PdfBuilder(latextools_plugin.LaTeXToolsPlugin):
 		self.out = ""
 		self.engine = engine
 		self.options = options
+		self.output_directory = output_directory
+		self.aux_directory = aux_directory
+		self.job_name = job_name
 		self.tex_directives = tex_directives
 		self.builder_settings = builder_settings
 		self.platform_settings = platform_settings

--- a/builders/simpleBuilder.py
+++ b/builders/simpleBuilder.py
@@ -27,15 +27,13 @@ DEBUG = False
 
 class SimpleBuilder(PdfBuilder):
 
-	def __init__(self, tex_root, output, engine, options,
-				 tex_directives, builder_settings, platform_settings):
+	def __init__(self, *args):
 		# Sets the file name parts, plus internal stuff
-		super(SimpleBuilder, self).__init__(tex_root, output, engine, options,
-			tex_directives, builder_settings, platform_settings)
+		super(SimpleBuilder, self).__init__(*args)
 
 		# Now do our own initialization: set our name, see if we want to display output
 		self.name = "Simple Builder"
-		self.display_log = builder_settings.get("display_log", False)
+		self.display_log = self.builder_settings.get("display_log", False)
 
 	def commands(self):
 		# Print greeting

--- a/delete_temp_files.py
+++ b/delete_temp_files.py
@@ -5,16 +5,21 @@ if sublime.version() < '3000':
 	_ST3 = False
 	# we are on ST2 and Python 2.X
 	import getTeXRoot
-
 	from latextools_utils import cache, get_setting
+	from latextools_utils.output_directory import (
+		get_aux_directory, get_output_directory
+	)
 else:
 	_ST3 = True
 	from . import getTeXRoot
 	from .latextools_utils import cache, get_setting
-
+	from .latextools_utils.output_directory import (
+		get_aux_directory, get_output_directory
+	)
 
 import sublime_plugin
 import os
+import shutil
 
 import traceback
 
@@ -39,8 +44,12 @@ class DeleteTempFilesCommand(sublime_plugin.WindowCommand):
 
 		root_file = getTeXRoot.get_tex_root(view)
 		if root_file is None:
-			sublime.status_message('Could not find TEX root. Please ensure that either you have configured a TEX root in your project settings or have a LaTeX document open.')
-			print('Could not find TEX root. Please ensure that either you have configured a TEX root in your project settings or have a LaTeX document open.')
+			msg = \
+				'Could not find TEX root. Please ensure that either you ' + \
+				'have configured a TEX root in your project settings or ' + \
+				'have a LaTeX document open.'
+			sublime.status_message(msg)
+			print(msg)
 			return
 
 		if not os.path.isfile(root_file):
@@ -56,16 +65,57 @@ class DeleteTempFilesCommand(sublime_plugin.WindowCommand):
 			print('Error while trying to delete local cache')
 			traceback.print_exc()
 
-		path = os.path.dirname(root_file)
+		aux_directory, aux_directory_setting = get_aux_directory(
+			root_file, return_setting=True
+		)
 
+		output_directory, output_directory_setting = get_output_directory(
+			root_file, return_setting=True
+		)
+
+		if aux_directory is not None:
+			# we cannot delete the output directory on Windows in case
+			# Sumatra is holding a reference to it
+			if (
+				sublime.platform() != 'windows' or
+				aux_directory != output_directory
+			):
+				if aux_directory_setting.startswith('<<'):
+					self._rmtree(aux_directory)
+				else:
+					self.delete_temp_files(aux_directory)
+
+		if output_directory is not None:
+			if output_directory_setting.startswith('<<'):
+				# we cannot delete the output directory on Windows in case
+				# Sumatra is holding a reference to it
+				if sublime.platform() == 'windows':
+					self._clear_dir(output_directory)
+				else:
+					self._rmtree(output_directory)
+			else:
+				self.delete_temp_files(output_directory)
+		else:
+			# if there is no output directory, we may need to clean files
+			# in the main directory, even if aux_directory is used
+			self.delete_temp_files(os.path.dirname(root_file))
+
+		sublime.status_message("Deleted temp files")
+
+	def delete_temp_files(self, path):
 		# Load the files to delete from the settings
-		temp_files_exts = get_setting('temp_files_exts',
+		temp_files_exts = get_setting(
+			'temp_files_exts',
 			['.blg', '.bbl', '.aux', '.log', '.brf', '.nlo', '.out', '.dvi',
-			 '.ps', '.lof', '.toc', '.fls', '.fdb_latexmk', '.pdfsync',
-			 '.synctex.gz', '.ind', '.ilg', '.idx'])
+				'.ps', '.lof', '.toc', '.fls', '.fdb_latexmk', '.pdfsync',
+				'.synctex.gz', '.ind', '.ilg', '.idx']
+		)
 
-		ignored_folders = get_setting('temp_files_ignored_folders',
-			['.git', '.svn', '.hg'])
+		ignored_folders = get_setting(
+			'temp_files_ignored_folders',
+			['.git', '.svn', '.hg']
+		)
+
 		ignored_folders = set(ignored_folders)
 
 		for dir_path, dir_names, file_names in os.walk(path):
@@ -73,16 +123,33 @@ class DeleteTempFilesCommand(sublime_plugin.WindowCommand):
 			for file_name in file_names:
 				for ext in temp_files_exts:
 					if file_name.endswith(ext):
-						file_name_to_del = os.path.join(dir_path, file_name)
-						if os.path.exists(file_name_to_del):
-							try:
-								os.remove(file_name_to_del)
-							except OSError:
-								# basically here for locked files in Windows,
-								# but who knows what we might find?
-								print('Error while trying to delete {0}'.format(file_name_to_del))
-								traceback.print_exc()
+						self._rmfile(os.path.join(dir_path, file_name))
 						# exit extension
 						break
 
-		sublime.status_message("Deleted temp files")
+	def _rmtree(self, path):
+		if os.path.exists(path):
+			try:
+				shutil.rmtree(path)
+			except OSError:
+				if os.path.exists(path):
+					# report the exception if the folder didn't end up deleted
+					traceback.print_exc()
+
+	def _rmfile(self, path):
+		if os.path.exists(path):
+			try:
+				os.remove(path)
+			except OSError:
+				if os.path.exists(path):
+					# basically here for locked files in Windows,
+					# but who knows what we might find?
+					print('Error while trying to delete {0}'.format(path))
+					traceback.print_exc()
+
+	def _clear_dir(self, path):
+		for root, directories, file_names in os.walk(path):
+			for directory in directories:
+				self._rmtree(os.path.join(root, directory))
+			for file_name in file_names:
+				self._rmfile(os.path.join(root, file_name))

--- a/getTeXRoot.py
+++ b/getTeXRoot.py
@@ -1,66 +1,7 @@
 # ST2/ST3 compat
 from __future__ import print_function
 
-import os
-import sublime
-if sublime.version() < '3000':
-	# we are on ST2 and Python 2.X
-	_ST3 = False
-	from latextools_utils.is_tex_file import is_tex_file
-	from latextools_utils.sublime_utils import get_project_file_name
-	from latextools_utils import parse_tex_directives
-else:
-	_ST3 = True
-	from .latextools_utils.is_tex_file import is_tex_file
-	from .latextools_utils.sublime_utils import get_project_file_name
-	from .latextools_utils import parse_tex_directives
-
-
-# Parse magic comments to retrieve TEX root
-# Stops searching for magic comments at first non-comment line of file
-# Returns root file or current file or None (if there is no root file,
-# and the current buffer is an unnamed unsaved file)
-
-# Contributed by Sam Finn
-def get_tex_root(view):
-	view_file = view.file_name()
-	root = view_file
-	directives = parse_tex_directives(view, only_for=['root'])
-	try:
-		root = directives['root']
-	except KeyError:
-		pass
-	else:
-		if not is_tex_file(root):
-			root = view_file
-
-		if not os.path.isabs(root) and view_file is not None:
-			file_path, _ = os.path.split(view_file)
-			root = os.path.normpath(os.path.join(file_path, root))
-
-	if root == view_file:
-		root = get_tex_root_from_settings(view)
-		if root is not None:
-			return root
-		return view_file
-
-	return root
-
-
-def get_tex_root_from_settings(view):
-	root = view.settings().get('TEXroot', None)
-
-	if root is not None:
-		if os.path.isabs(root):
-			if os.path.isfile(root):
-				return root
-		else:
-			proj_file = get_project_file_name(view)
-
-			if proj_file:
-				project_dir = os.path.dirname(proj_file)
-				root_path = os.path.normpath(os.path.join(project_dir, root))
-				if os.path.isfile(root_path):
-					return root_path
-
-	return root
+try:
+	from latextools_utils.tex_directives import get_tex_root
+except ImportError:
+	from .latextools_utils.tex_directives import get_tex_root

--- a/latexDocumentationViewer.py
+++ b/latexDocumentationViewer.py
@@ -5,12 +5,14 @@ import sublime_plugin
 
 import os
 import subprocess
-from subprocess import Popen, PIPE
+from subprocess import Popen
 
 try:
     from latextools_utils import get_setting
+    from latextools_utils.distro_utils import using_miktex
 except ImportError:
     from .latextools_utils import get_setting
+    from .latextools_utils.distro_utils import using_miktex
 
 if sublime.version() < '3000':
     _ST3 = False
@@ -28,18 +30,6 @@ def get_texpath():
         return os.path.expandvars(texpath).encode(sys.getfilesystemencoding())
     else:
         return os.path.expandvars(texpath)
-
-def using_miktex():
-    if sublime.platform() != 'windows':
-        return False
-
-    platform_settings = get_setting(sublime.platform(), {})
-
-    try:
-        distro = platform_settings.get('distro', 'miktex')
-        return distro in ['miktex', '']
-    except KeyError:
-        return True  # assumed
 
 def _view_texdoc(file):
     if file is None:

--- a/latex_input_completions.py
+++ b/latex_input_completions.py
@@ -10,8 +10,14 @@ import json
 
 try:
     from latextools_utils.is_tex_file import get_tex_extensions
+    from latextools_utils.output_directory import (
+        get_aux_directory, get_output_directory
+    )
 except ImportError:
     from .latextools_utils.is_tex_file import get_tex_extensions
+    from .latextools_utils.output_directory import (
+        get_aux_directory, get_output_directory
+    )
 
 if sublime.version() < '3000':
     # we are on ST2 and Python 2.X
@@ -38,7 +44,8 @@ TEX_INPUT_FILE_REGEX = re.compile(
 )
 
 # Get all file by types
-def get_file_list(root, types, filter_exts=[]):
+def get_file_list(root, types, filter_exts=[], output_directory=None,
+                  aux_directory=None):
     path = os.path.dirname(root)
 
     def file_match(f):
@@ -52,7 +59,9 @@ def get_file_list(root, types, filter_exts=[]):
     completions = []
     for dir_name, dirs, files in os.walk(path):
         files = [f for f in files if f[0] != '.' and file_match(f)]
-        dirs[:] = [d for d in dirs if d[0] != '.']
+        dirs[:] = [d for d in dirs if d[0] != '.' and
+                   os.path.join(dir_name, d) != output_directory and
+                   os.path.join(dir_name, d) != aux_directory]
         for f in files:
             full_path = os.path.join(dir_name, f)
             # Exclude image file have the same name of root file,
@@ -192,7 +201,12 @@ def parse_completions(view, line):
     elif input_file_types is not None:
         root = getTeXRoot.get_tex_root(view)
         if root:
-            completions = get_file_list(root, input_file_types, filter_exts)
+            output_directory = get_output_directory(root)
+            aux_directory = get_aux_directory(root)
+            completions = get_file_list(
+                root, input_file_types, filter_exts,
+                output_directory, aux_directory
+            )
         else:
             # file is unsaved
             completions = []

--- a/latextools_utils/__init__.py
+++ b/latextools_utils/__init__.py
@@ -1,16 +1,4 @@
-from __future__ import print_function
-
 try:
     from latextools_utils.settings import get_setting
-    from latextools_utils.tex_directives import parse_tex_directives
-    from latextools_utils import analysis
-    from latextools_utils import cache
-    from latextools_utils import sublime_utils
-    from latextools_utils import utils
 except ImportError:
     from .settings import get_setting
-    from .tex_directives import parse_tex_directives
-    from . import analysis
-    from . import cache
-    from . import sublime_utils
-    from . import utils

--- a/latextools_utils/distro_utils.py
+++ b/latextools_utils/distro_utils.py
@@ -1,0 +1,19 @@
+import sublime
+
+try:
+    from latextools_utils import get_setting
+except ImportError:
+    from . import get_setting
+
+
+def using_miktex():
+    if sublime.platform() != 'windows':
+        return False
+
+    platform_settings = get_setting(sublime.platform(), {})
+
+    try:
+        distro = platform_settings.get('distro', 'miktex')
+        return distro in ['miktex', '']
+    except KeyError:
+        return True

--- a/latextools_utils/output_directory.py
+++ b/latextools_utils/output_directory.py
@@ -1,0 +1,377 @@
+import hashlib
+import json
+import os
+import sublime
+import sys
+import tempfile
+
+try:
+    from latextools_utils import get_setting
+    from latextools_utils.distro_utils import using_miktex
+    from latextools_utils.tex_directives import (
+        get_tex_root, parse_tex_directives
+    )
+    from latextools_utils.sublime_utils import get_project_file_name
+except ImportError:
+    from . import get_setting
+    from .distro_utils import using_miktex
+    from .tex_directives import get_tex_root, parse_tex_directives
+    from .sublime_utils import get_project_file_name
+
+
+__all__ = [
+    'get_aux_directory', 'get_output_directory', 'get_jobname',
+    'UnsavedFileException'
+]
+
+
+# raised whenever the root cannot be determined, which indicates an unsaved
+# file
+class UnsavedFileException(Exception):
+    pass
+
+
+# finds the aux-directory
+# general algorithm:
+#   1. check for an explicit aux_directory directory
+#   2. check for an --aux-directory flag
+#   3. check for a project setting
+#   4. check for a global setting
+#   5. assume aux_directory is the same as output_directory
+# return_setting indicates that the raw setting should be returned
+# as well as the auxiliary directory
+def get_aux_directory(view_or_root, return_setting=False):
+    # not supported using texify or the simple builder
+    if using_texify_or_simple():
+        if return_setting:
+            return (None, None)
+        else:
+            return None
+
+    root = get_root(view_or_root)
+
+    aux_directory = None
+    if root is not None:
+        aux_directory = get_directive(root, 'aux_directory')
+
+    if aux_directory is not None and aux_directory != '':
+        aux_dir = resolve_to_absolute_path(
+            root, aux_directory, _get_root_directory(root)
+        )
+
+        if return_setting:
+            return (aux_dir, aux_directory)
+        else:
+            return aux_dir
+
+    view = sublime.active_window().active_view()
+    aux_directory = view.settings().get('aux_directory')
+
+    if aux_directory is not None and aux_directory != '':
+        aux_dir = resolve_to_absolute_path(
+            root,
+            aux_directory,
+            _get_root_directory(get_project_file_name(view))
+        )
+
+        if return_setting:
+            return (aux_dir, aux_directory)
+        else:
+            return aux_dir
+
+    settings = sublime.load_settings('LaTeXTools.sublime-settings')
+    aux_directory = settings.get('aux_directory')
+
+    if aux_directory is not None and aux_directory != '':
+        aux_dir = resolve_to_absolute_path(
+            root, aux_directory, _get_root_directory(root)
+        )
+
+        if return_setting:
+            return (aux_dir, aux_directory)
+        else:
+            return aux_dir
+
+    return get_output_directory(root, return_setting)
+
+
+# finds the output-directory
+# general algorithm:
+#   1. check for an explicit output_directory directive
+#   2. check for an --output-directory flag
+#   3. check for a project setting
+#   4. check for a global setting
+#   5. assume output_directory is None
+# return_setting indicates that the raw setting should be returned
+# as well as the output directory
+def get_output_directory(view_or_root, return_setting=False):
+    # not supported using texify or the simple builder
+    if using_texify_or_simple():
+        if return_setting:
+            return (None, None)
+        else:
+            return None
+
+    root = get_root(view_or_root)
+
+    output_directory = None
+    if root is not None:
+        output_directory = get_directive(root, 'output_directory')
+
+    if output_directory is not None and output_directory != '':
+        out_dir = resolve_to_absolute_path(
+            root, output_directory, _get_root_directory(root)
+        )
+
+        if return_setting:
+            return (out_dir, output_directory)
+        else:
+            return out_dir
+
+    view = sublime.active_window().active_view()
+    output_directory = view.settings().get('output_directory')
+
+    if output_directory is not None and output_directory != '':
+        out_dir = resolve_to_absolute_path(
+            root,
+            output_directory,
+            _get_root_directory(get_project_file_name(view))
+        )
+
+        if return_setting:
+            return (out_dir, output_directory)
+        else:
+            return out_dir
+
+    settings = sublime.load_settings('LaTeXTools.sublime-settings')
+    output_directory = settings.get('output_directory')
+
+    if output_directory is not None and output_directory != '':
+        out_dir = resolve_to_absolute_path(
+            root, output_directory, _get_root_directory(root)
+        )
+
+        if return_setting:
+            return (out_dir, output_directory)
+        else:
+            return out_dir
+
+    if return_setting:
+        return (None, None)
+    else:
+        return None
+
+
+# finds the jobname
+# general algorithm:
+#   1. check for an explict jobname setting
+#   2. check for a --jobname flag
+#   3. check for a project setting
+#   4. check for a global setting
+#   5. assume jobname is basename of tex_root
+# Note: returns None if root is unsaved
+def get_jobname(view_or_root):
+    root = get_root(view_or_root)
+
+    if root is None:
+        return None
+
+    if using_texify_or_simple():
+        return os.path.splitext(
+            os.path.basename(root)
+        )[0]
+
+    jobname = get_directive(root, 'jobname')
+
+    if jobname is None or jobname == '':
+        jobname = get_setting('jobname')
+
+    if jobname is None or jobname == '':
+        return os.path.splitext(
+            os.path.basename(root)
+        )[0]
+
+    return jobname
+
+
+def using_texify_or_simple():
+    if using_miktex():
+        builder = get_setting('builder', 'traditional')
+        if builder in ['', 'default', 'traditional', 'simple']:
+            return True
+    return False
+
+
+def get_root(view_or_root):
+    if isinstance(view_or_root, sublime.View):
+        # here we can still handle root being None if the output_directory
+        # setting is an aboslute path
+        return get_tex_root(view_or_root)
+    else:
+        return view_or_root
+
+
+def get_directive(root, key):
+    directives = parse_tex_directives(
+        root, multi_values=['options'], only_for=['options', key]
+    )
+
+    try:
+        return directives[key]
+    except KeyError:
+        option = key.replace('_', '-')
+        for opt in directives.get('options', []):
+            if opt.lstrip('-').startswith(option):
+                try:
+                    return opt.split('=')[1].strip()
+                except:
+                    # invalid option parameter
+                    return None
+        return None
+
+
+def resolve_to_absolute_path(root, value, root_path):
+    # special values
+    if (
+        len(value) > 4 and
+        value[0] == '<' and
+        value[1] == '<' and
+        value[-2] == '>' and
+        value[-1] == '>'
+    ):
+        root_hash = _get_root_hash(root)
+        if root_hash is None:
+            raise UnsavedFileException()
+
+        if value == '<<temp>>':
+            result = os.path.join(
+                _get_tmp_dir(), root_hash
+            )
+        elif value == '<<project>>':
+            result = os.path.join(
+                root_path, root_hash
+            )
+        elif value == '<<cache>>':
+            result = os.path.join(
+                get_cache_directory(),
+                root_hash
+            )
+        else:
+            print(u'unrecognized special value: {0}'.format(value))
+
+            # NOTE this assumes that the value provided is a typo, etc.
+            # and tries not to do anything harmful. This may not be the
+            # best assumption
+            return None
+
+        # create the directory
+        make_dirs(result)
+
+        return result
+
+    result = os.path.expandvars(
+        os.path.expanduser(
+            value
+        )
+    )
+
+    if os.path.isabs(result):
+        return os.path.normpath(result)
+    else:
+        return os.path.normpath(
+            os.path.join(
+                root_path,
+                result
+            )
+        )
+
+
+# wrapper for os.makedirs which will not raise an error is path already
+# exists
+def make_dirs(path):
+    try:
+        os.makedirs(path)
+    except OSError:
+        if not os.path.exists(path):
+            reraise(*sys.exc_info())
+
+
+if sys.version_info < (3,):
+    # reraise implementation from 6
+    exec("""def reraise(tp, value, tb=None):
+    raise tp, value, tb
+""")
+
+else:
+    # reraise implementation from 6
+    def reraise(tp, value, tb=None):
+        if value is None:
+            value = tp()
+        if value.__traceback__ is not tb:
+            raise value.with_traceback(tb)
+        raise value
+
+
+if sublime.version() < '3000':
+    def get_cache_directory():
+        return os.path.join(
+            sublime.packages_path(),
+            'User',
+            '.lt_cache'
+        )
+else:
+    def get_cache_directory():
+        return os.path.join(
+            sublime.cache_path(),
+            'LaTeXTools'
+        )
+
+
+# uses a process-wide temp directory which should be cleaned-up on exit
+def _get_tmp_dir():
+    if hasattr(_get_tmp_dir, 'directory'):
+        return _get_tmp_dir.directory
+    else:
+        _get_tmp_dir.directory = tempfile.mkdtemp()
+
+        # register directory to be deleted on next start-up
+        # unfortunately, there is no reliable way to do clean-up on exit
+        # see https://github.com/SublimeTextIssues/Core/issues/10
+        cache_dir = get_cache_directory()
+        make_dirs(cache_dir)
+
+        temporary_output_dirs = os.path.join(
+            cache_dir,
+            'temporary_output_dirs'
+        )
+
+        if os.path.exists(temporary_output_dirs):
+            with open(temporary_output_dirs, 'r') as f:
+                data = json.load(f)
+        else:
+            data = {'directories': []}
+
+        data['directories'].append(_get_tmp_dir.directory)
+
+        with open(temporary_output_dirs, 'w') as f:
+            json.dump(data, f)
+
+        return _get_tmp_dir.directory
+
+
+def _get_root_directory(root):
+    if root is None:
+        # best guess
+        return os.getcwd()
+    else:
+        if not os.path.isabs(root):
+            # again, best guess
+            return os.path.join(os.getcwd(), os.path.dirname(root))
+        return os.path.dirname(root)
+
+
+def _get_root_hash(root):
+    if root is None:
+        return None
+
+    return hashlib.md5(root.encode('utf-8')).hexdigest()

--- a/latextools_utils/tex_directives.py
+++ b/latextools_utils/tex_directives.py
@@ -1,10 +1,18 @@
 from __future__ import print_function
 
 import codecs
+import os
 import re
 import sublime
 import sys
 import traceback
+
+try:
+    from latextools_utils.is_tex_file import is_tex_file
+    from latextools_utils.sublime_utils import get_project_file_name
+except ImportError:
+    from .is_tex_file import is_tex_file
+    from .sublime_utils import get_project_file_name
 
 if sys.version_info < (3, 0):
     strbase = basestring
@@ -113,3 +121,53 @@ def parse_tex_directives(view_or_path, multi_values=[], key_maps={},
     finally:
         if is_file:
             lines.close()
+
+
+# Parse magic comments to retrieve TEX root
+# Stops searching for magic comments at first latex command in file
+# Returns root file or current file or None (if there is no root file,
+# and the current buffer is an unnamed unsaved file)
+
+# Contributed by Sam Finn
+def get_tex_root(view):
+    view_file = view.file_name()
+    root = view_file
+    directives = parse_tex_directives(view, only_for=['root'])
+    try:
+        root = directives['root']
+    except KeyError:
+        pass
+    else:
+        if not is_tex_file(root):
+            root = view_file
+
+        if not os.path.isabs(root) and view_file is not None:
+            file_path, _ = os.path.split(view_file)
+            root = os.path.normpath(os.path.join(file_path, root))
+
+    if root == view_file:
+        root = get_tex_root_from_settings(view)
+        if root is not None:
+            return root
+        return view_file
+
+    return root
+
+
+def get_tex_root_from_settings(view):
+    root = view.settings().get('TEXroot', None)
+
+    if root is not None:
+        if os.path.isabs(root):
+            if os.path.isfile(root):
+                return root
+        else:
+            proj_file = get_project_file_name(view)
+
+            if proj_file:
+                project_dir = os.path.dirname(proj_file)
+                root_path = os.path.normpath(os.path.join(project_dir, root))
+                if os.path.isfile(root_path):
+                    return root_path
+
+    return root

--- a/makePDF.py
+++ b/makePDF.py
@@ -12,7 +12,11 @@ if sublime.version() < '3000':
 		_classname_to_internal_name
 	)
 	from latextools_utils.is_tex_file import is_tex_file
-	from latextools_utils import get_setting, parse_tex_directives
+	from latextools_utils import get_setting
+	from latextools_utils.tex_directives import parse_tex_directives
+	from latextools_utils.output_directory import (
+		get_aux_directory, get_output_directory, get_jobname
+	)
 
 	strbase = basestring
 else:
@@ -24,7 +28,11 @@ else:
 		_classname_to_internal_name
 	)
 	from .latextools_utils.is_tex_file import is_tex_file
-	from .latextools_utils import get_setting, parse_tex_directives
+	from .latextools_utils import get_setting
+	from .latextools_utils.tex_directives import parse_tex_directives
+	from .latextools_utils.output_directory import (
+		get_aux_directory, get_output_directory, get_jobname
+	)
 
 	strbase = str
 
@@ -37,6 +45,7 @@ import functools
 import subprocess
 import types
 import traceback
+import shutil
 
 DEBUG = False
 
@@ -204,7 +213,30 @@ class CmdThread ( threading.Thread ):
 		# Note to self: need to think whether we don't want to codecs.open this, too...
 		# Also, we may want to move part of this logic to the builder...
 		try:
-			data = open(self.caller.tex_base + ".log", 'rb').read()		
+			log_file_base = self.caller.tex_base + ".log"
+			# NB aux_directory is never None if output_directory is set
+			if self.caller.aux_directory is None:
+				log_file = log_file_base
+			else:
+				log_file = os.path.join(
+					self.caller.aux_directory,
+					log_file_base
+				)
+
+				if not os.path.exists(log_file):
+					if self.caller.output_directory != self.caller.aux_directory:
+						log_file = os.path.join(
+							self.caller.aux_directory,
+							log_file_base
+						)
+
+						if not os.path.exists(log_file):
+							log_file = log_file_base
+					else:
+						log_file = log_file_base
+
+			with open(log_file, 'rb') as f:
+				data = f.read()
 		except IOError:
 			self.handle_std_outputs(out, err)
 		else:
@@ -348,7 +380,7 @@ class make_pdfCommand(sublime_plugin.WindowCommand):
 			sublime.error_message(self.file_name + ": file not found.")
 			return
 
-		self.tex_base, self.tex_ext = os.path.splitext(self.file_name)
+		self.tex_base = get_jobname(view)
 		tex_dir = os.path.dirname(self.file_name)
 
 		if not is_tex_file(self.file_name):
@@ -429,6 +461,17 @@ class make_pdfCommand(sublime_plugin.WindowCommand):
 		if 'options' in tex_directives:
 			options.extend(tex_directives['options'])
 
+		# filter out --aux-directory and --output-directory options which are
+		# handled separately
+		options = [opt for opt in options if (
+			not opt.startswith('--aux-directory') and
+			not opt.startswith('--output-directory') and
+			not opt.startswith('--jobname')
+		)]
+
+		self.aux_directory = get_aux_directory(self.file_name)
+		self.output_directory = get_output_directory(self.file_name)
+
 		# Read the env option (platform specific)
 		builder_platform_settings = builder_settings.get(self.plat)
 		if builder_platform_settings:
@@ -441,7 +484,7 @@ class make_pdfCommand(sublime_plugin.WindowCommand):
 
 		# Safety check: if we are using a built-in builder, disregard
 		# builder_path, even if it was specified in the pref file
-		if builder_name in ['simple', 'traditional', 'script']:
+		if builder_name in ['simple', 'traditional', 'script', 'basic']:
 			builder_path = None
 
 		if builder_path:
@@ -462,6 +505,9 @@ class make_pdfCommand(sublime_plugin.WindowCommand):
 			self.output,
 			engine,
 			options,
+			self.aux_directory,
+			self.output_directory,
+			self.tex_base,
 			tex_directives,
 			builder_settings,
 			platform_settings
@@ -529,15 +575,31 @@ class make_pdfCommand(sublime_plugin.WindowCommand):
 		sublime.set_timeout(functools.partial(self.do_finish, can_switch_to_pdf), 0)
 
 	def do_finish(self, can_switch_to_pdf):
-		# Move to TextCommand for compatibility with ST3
-		# edit = self.output_view.begin_edit()
-		# self.output_view.sel().clear()
-		# reg = sublime.Region(0)
-		# self.output_view.sel().add(reg)
-		# self.output_view.show(reg) # scroll to top
-		# self.output_view.end_edit(edit)
 		self.output_view.run_command("do_finish_edit")
+		# can_switch_to_pdf indicates a pdf should've been created
 		if can_switch_to_pdf:
+			# if using output_directory, follow the copy_output_on_build setting
+			# files are copied to the same directory as the main tex file
+			if self.output_directory is not None:
+				copy_on_build = get_setting('copy_output_on_build', True) or True
+				if copy_on_build is True:
+					shutil.copy2(
+						os.path.join(
+							self.output_directory,
+							self.tex_base + u'.pdf'
+						),
+						os.path.dirname(self.file_name)
+					)
+				elif isinstance(copy_on_build, list):
+					for ext in copy_on_build:
+						shutil.copy2(
+							os.path.join(
+								self.output_directory,
+								self.tex_base + ext
+							),
+							os.path.dirname(self.file_name)
+						)
+
 			self.view.run_command("jump_to_pdf", {"from_keybinding": False})
 
 


### PR DESCRIPTION
This adds the much-requested ability to use `--output-directory` and `--aux-directory` (cf. #559, #98, #161, #163, #383, #169). I've also added support for `--jobname`, as it pretty much has the same requirements and touches the same parts of the code.

All are controlled through either a setting or (yet another) `%!TEX` directive. The setting and directive name are `output_directory`, `aux_directory`, and `jobname` respectively. In addition, these changes will pick up any `--aux-directory=...`, `--output-directory=...`, or `--jobname=...` flags set via the TeX options support.

`output_directory` and `aux_directory` can be set to any of the following values:

* a path (relative to the main tex file, absolute, or, if specified in a project file, relative to the project file)
* `<<temp>>` a value which specifies to use a unique directory in the system temp path
* `<<cache>>` which specifies to use a unique directory in the ST cache directory or a subfolder of the User directory on ST2 (which doesn't have a cache folder)
* `<<project>>` which uses the same directory name as the other two but as a subfolder of the main file (I don't imagine this last option to be very useful to anyone; it was useful to build and test the feature).

`jobname` is just a string with no special interpolation.

In addition, I've added a setting `copy_output_on_build` which indicates whether to copy the PDF or any other files to the same folder as the main tex file. It can be set to:

* `true` (default) indicating to copy the PDF (only)
* `false` indicating that it should do nothing
* a list of extensions (e.g. `[".synctex.gz", ".pdf"]`, indicating that those files with the same basename as the main tex file and the given extensions should be copied.

When an auxiliary directory or output directory is used, it will be searched first for the log file. The output directory will be searched for the pdf file. If these files cannot be found it will fallback to the usual behaviour, i.e., a log or pdf file in the main directory. In addition, the behaviour of the `delete_temp_files` command is changed to delete the entire directory tree of the output directory and the auxiliary directory(+).

The hard part about adding this feature turned out not to be updating the various bits of code to be aware of the auxiliary directory, output directory or jobname. Rather, it was ensuring that the builders work properly. `latexmk`, whether on MiKTeX or TeXLive supports everything beautifully and simply. If you are intending to use the output directory feature, I'd highly recommend using `latexmk`. It turns out to be *impossible* to support this feature using `texify` because `texify` will fail with a fatal error if you attempt to pass `--output-directory`, `--aux-directory`, or `--jobname`, understandably(++). Thus, if you are using `texify`, none of these settings will not work (sorry; there's nothing I can do).

Since I figured it was better to *something* capable of supporting MiKTeX out of the box, I've added a new builder called `basic`(+++). In essence, it does the same thing as the `simple` builder with a few extra features:

1. It supports most of the same options / directives as the `traditional` builder, namely the `options` setting, the `program` setting, and (obviously) the `aux_directory`, `output_directory` and `jobname` settings as well as the corresponding directives.
1. It supports biblatex, including using biber, bibtex, or bibtex8 as engines (again, a commonly requested feature).
1. It supports running bibtex using `aux_directory` or `output_directory`, using a trick I borrowed from `latexmk`.

I've tried it out on some simple test cases and it works well enough though note that unlike `texify` it has no support for `makeindex` (patches are welcome).

I also modified the `script` builder to support the output directory via new `$aux_directory`, `$output_directory` and `$jobname` variables. However, in order to make it viable to use the script builder to run `bibtex`, I had to change the script builder so that it uses the shell (or cmd.exe) in order to allow basic shell commands. It should continue to function as it did before, but the added shell interpolation may affect some script commands people were using. In addition, `cmd.exe` doesn't work with a UNC path as the current working directory. If you're using the script builder for a project opened via a UNC path (not a mapped drive), you'll have to ensure all your paths are specified as absolute paths. Sorry about that.

(+) Strictly speaking, on Windows it does not remove the entire directory tree; it removes all the contents of the tree. The reason is that Sumatra has a directory change notifier attached to the directory of the file containing the PDF its viewing. The notifier does not receive messages when the directory it is watching is deleted (or if it does, it ignores them), which means that the directory becomes unusable until the PDF is closed in Sumatra. This seemed to be the path of least resistance.

(++) I say "understandably" because TeXify faces much the same problems LaTeXTools does: how to you read a log file when its name and location can be changed?

(+++) I didn't just try to add this to the `simple` builder as I agree with @msiniscalchi's reasons for keeping *that* builder as simple as possible. Note that, for this reason, the `output_directory` and `aux_directory` settings will be ignored if you are using the `simple` builder.