### PR TITLE
Multiple-cursor support for FillAll helper

### DIFF
--- a/latex_env_completions.py
+++ b/latex_env_completions.py
@@ -27,14 +27,18 @@ class LatexFillEnvCommand(sublime_plugin.TextCommand):
 
         if not is_cwl_available():
             if insert_char:
-                view.insert(edit, point, insert_char)
+                for sel in view.sel():
+                    view.insert(edit, sel.b, insert_char)
                 add_closing_bracket(view, edit)
             return
 
         if insert_char:
             # append the insert_char to the end of the current line if it
             # is given so this works when being triggered by pressing "{"
-            point += view.insert(edit, point, insert_char)
+            point += len(insert_char)
+            # insert the char to every selection
+            for sel in view.sel():
+                view.insert(edit, sel.b, insert_char)
 
             do_completion = get_setting("env_auto_trigger", False)
 

--- a/latex_ref_cite_completions.py
+++ b/latex_ref_cite_completions.py
@@ -40,13 +40,11 @@ class LatexRefCiteCommand(sublime_plugin.TextCommand):
                 "text.tex.latex"):
             return
 
-
         if insert_char:
-#            ed = view.begin_edit()
-#            point += view.insert(ed, point, insert_char)
-#            view.end_edit(ed)
-            # The above was roundabout and did not work on ST3!
-            point += view.insert(edit, point, insert_char)
+            point += len(insert_char)
+            # insert the char to every selection
+            for sel in view.sel():
+                view.insert(edit, sel.b, insert_char)
             # Get prefs and toggles to see if we are auto-triggering
             # This is only the case if we also must insert , or {, so we don't need a separate arg
             do_ref = get_setting('ref_auto_trigger', True)


### PR DESCRIPTION
This fixes https://github.com/SublimeText/LaTeXTools/issues/691

The same behavior occurs for "environment", "input", "ref " and "cite" completions. This fixes env and input completions and partially ref and cite (not complete because I was worried breaking something with the `pre_snippet` stuff).