### PR TITLE
Self-defined commands completions

### DIFF
--- a/latex_cwl_completions.py
+++ b/latex_cwl_completions.py
@@ -10,14 +10,14 @@ if sublime.version() < '3000':
     _ST3 = False
     from latex_cite_completions import OLD_STYLE_CITE_REGEX, NEW_STYLE_CITE_REGEX, match
     from latex_ref_completions import OLD_STYLE_REF_REGEX, NEW_STYLE_REF_REGEX
-    from latex_own_command_completions import get_own_command_completion
+    from latex_own_command_completions import get_own_command_completion, get_own_env_completion
     from getRegion import get_Region
     from latextools_utils import get_setting
 else:
     _ST3 = True
     from .latex_cite_completions import OLD_STYLE_CITE_REGEX, NEW_STYLE_CITE_REGEX, match
     from .latex_ref_completions import OLD_STYLE_REF_REGEX, NEW_STYLE_REF_REGEX
-    from .latex_own_command_completions import get_own_command_completion
+    from .latex_own_command_completions import get_own_command_completion, get_own_env_completion
     from .getRegion import get_Region
     from .latextools_utils import get_setting
 
@@ -98,7 +98,8 @@ class LatexCwlCompletion(sublime_plugin.EventListener):
         # if it is inside the begin oder end of an env,
         # create and return the available environments
         if is_env:
-            completions = parse_cwl_file(parse_line_as_environment)
+            completions = (parse_cwl_file(parse_line_as_environment) +
+                           get_own_env_completion(view))
             return completions
 
         # do not autocomplete if the leading backslash is escaped

--- a/latex_cwl_completions.py
+++ b/latex_cwl_completions.py
@@ -10,12 +10,14 @@ if sublime.version() < '3000':
     _ST3 = False
     from latex_cite_completions import OLD_STYLE_CITE_REGEX, NEW_STYLE_CITE_REGEX, match
     from latex_ref_completions import OLD_STYLE_REF_REGEX, NEW_STYLE_REF_REGEX
+    from latex_own_command_completions import get_own_command_completion
     from getRegion import get_Region
     from latextools_utils import get_setting
 else:
     _ST3 = True
     from .latex_cite_completions import OLD_STYLE_CITE_REGEX, NEW_STYLE_CITE_REGEX, match
     from .latex_ref_completions import OLD_STYLE_REF_REGEX, NEW_STYLE_REF_REGEX
+    from .latex_own_command_completions import get_own_command_completion
     from .getRegion import get_Region
     from .latextools_utils import get_setting
 
@@ -58,7 +60,7 @@ def _is_snippet(completion_entry):
     is a sublime snippet
     """
     completion_result = completion_entry[1]
-    return completion_result[0] == '\\' and '${1:' in completion_result
+    return completion_result[0] == '\\' and '{' in completion_result
 
 
 class LatexCwlCompletion(sublime_plugin.EventListener):
@@ -114,7 +116,8 @@ class LatexCwlCompletion(sublime_plugin.EventListener):
             if match(rex, line) != None:
                 return []
 
-        completions = parse_cwl_file(parse_line_as_command)
+        completions = (parse_cwl_file(parse_line_as_command) +
+                       get_own_command_completion(view))
         # autocompleting with slash already on line
         # this is necessary to work around a short-coming in ST where having a keyed entry
         # appears to interfere with it recognising that there is a \ already on the line

--- a/latex_env_completions.py
+++ b/latex_env_completions.py
@@ -7,12 +7,14 @@ try:
     from .latextools_utils import get_setting
     from .latex_input_completions import add_closing_bracket
     from .latex_cwl_completions import parse_cwl_file, parse_line_as_environment, is_cwl_available
+    from .latex_own_command_completions import get_own_env_completion
     from .latexFillAll import get_current_word
 except:
     _ST3 = False
     from latextools_utils import get_setting
     from latex_input_completions import add_closing_bracket
     from latex_cwl_completions import parse_cwl_file, parse_line_as_environment, is_cwl_available
+    from latex_own_command_completions import get_own_env_completion
     from latexFillAll import get_current_word
 
 
@@ -53,7 +55,8 @@ class LatexFillEnvCommand(sublime_plugin.TextCommand):
         else:
             prefix = ""
 
-        completions = parse_cwl_file(parse_line_as_environment)
+        completions = (parse_cwl_file(parse_line_as_environment) +
+                       get_own_env_completion(view))
         if prefix:
             completions = [c for c in completions if c[1].startswith(prefix)]
 

--- a/latex_own_command_completions.py
+++ b/latex_own_command_completions.py
@@ -1,0 +1,93 @@
+import sublime
+import re
+
+_ST3 = sublime.version() >= '3000'
+
+if _ST3:
+    from .latextools_utils import analysis, cache
+    from .getTeXRoot import get_tex_root
+else:
+    from latextools_utils import analysis, cache
+    from getTeXRoot import get_tex_root
+
+__all__ = ["get_own_env_completion", "get_own_command_completion"]
+
+
+def get_own_env_completion(view):
+    tex_root = get_tex_root(view)
+    if not tex_root:
+        return []
+
+    def make_completions():
+        ana = analysis.get_analysis(tex_root)
+        return _make_own_env_completion(ana)
+
+    return cache.cache(tex_root, "own_env_completion", make_completions)
+
+
+def get_own_command_completion(view):
+    tex_root = get_tex_root(view)
+    if not tex_root:
+        return []
+
+    def make_completions():
+        ana = analysis.get_analysis(tex_root)
+        return _make_own_command_completion(ana)
+
+    return cache.cache(tex_root, "own_command_completion", make_completions)
+
+
+def _make_own_env_completion(ana):
+    commands = ana.filter_commands(["newenvironment", "renewenvironment"])
+    return [(c.args + "\tself-defined", c.args) for c in commands]
+
+
+def _make_own_command_completion(ana):
+    com = ana.filter_commands(["newcommand", "renewcommand"])
+    res = [_parse_command(c) for c in com]
+    return res
+
+
+def _parse_command(c):
+    class NoArgs(Exception):
+        pass
+    try:
+        if not c.optargs2:
+            raise NoArgs()
+        arg_count = int(c.optargs2)
+        has_opt = bool(c.optargs2a)
+        s = c.args
+        if has_opt:
+            s += "[{0}]".format(c.optargs2a)
+            arg_count -= 1
+        elif arg_count == 0:
+            raise NoArgs()
+        s += "{arg}" * arg_count
+        comp = parse_keyword(s)
+    except:  # no args
+        s = c.args + "{}"
+        comp = s
+    return (s + "\tself-defined", comp)
+
+
+# TODO duplicate to avoid cyclic imports
+def parse_keyword(keyword):
+    # Replace strings in [] and {} with snippet syntax
+    def replace_braces(matchobj):
+        replace_braces.index += 1
+        if matchobj.group(1) is not None:
+            word = matchobj.group(1)
+            return u'{${%d:%s}}' % (replace_braces.index, word)
+        else:
+            word = matchobj.group(2)
+            return u'[${%d:%s}]' % (replace_braces.index, word)
+    replace_braces.index = 0
+
+    replace, n = re.subn(r'\{([^\{\}\[\]]*)\}|\[([^\{\}\[\]]*)\]', replace_braces, keyword)
+
+    # I do not understand why some of the input will eat the '\' charactor before it!
+    # This code is to avoid these things.
+    if n == 0 and re.search(r'^[a-zA-Z]+$', keyword[1:].strip()) != None:
+        return keyword
+    else:
+        return replace


### PR DESCRIPTION
This PR adds completions for self-defined commands and environments.

The completions are added into the cwl completions and are only available if cwl completions are available.

Supported completions:

- environment in `\(re)newenvironment`
- commands in `\(re)newcommand`
- math operators from `\DeclareMathOperator` (only inside math)

Feel free to suggest more.

![demo](https://cloud.githubusercontent.com/assets/12573621/11513807/7aecc68c-9875-11e5-89ce-7c002103dba0.gif)