### PR TITLE
Made LaTeXTools compatible with LaTeX-Plus syntax definition

### DIFF
--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -223,6 +223,7 @@ LaTeX Package keymap for Linux
 			{"key": "selector", "operator": "not_equal", "operand": "string.other.math.tex"},
 			{"key": "selector", "operator": "not_equal", "operand": "string.other.math.latex"},
 			{"key": "selector", "operator": "not_equal", "operand": "string.other.math.block.tex"},
+			{"key": "selector", "operator": "not_equal", "operand": "meta.function.environment.math.latex"},
 			{ "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
 			{ "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
 			{ "key": "preceding_text", "operator": "regex_contains", "operand": "\\\\(?:item|only|textbf|color|onslide|only|uncover|visible|invisible|alt|temporal)$", "match_all": true }

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -223,6 +223,7 @@ LaTeX Package keymap for OS X
 			{"key": "selector", "operator": "not_equal", "operand": "string.other.math.tex"},
 			{"key": "selector", "operator": "not_equal", "operand": "string.other.math.latex"},
 			{"key": "selector", "operator": "not_equal", "operand": "string.other.math.block.tex"},
+			{"key": "selector", "operator": "not_equal", "operand": "meta.function.environment.math.latex"},
 			{ "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
 			{ "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
 			{ "key": "preceding_text", "operator": "regex_contains", "operand": "\\\\(?:item|only|textbf|color|onslide|only|uncover|visible|invisible|alt|temporal)$", "match_all": true }

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -224,6 +224,7 @@ LaTeX Package keymap for Windows
 			{"key": "selector", "operator": "not_equal", "operand": "string.other.math.tex"},
 			{"key": "selector", "operator": "not_equal", "operand": "string.other.math.latex"},
 			{"key": "selector", "operator": "not_equal", "operand": "string.other.math.block.tex"},
+			{"key": "selector", "operator": "not_equal", "operand": "meta.function.environment.math.latex"},
 			{ "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
 			{ "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
 			{ "key": "preceding_text", "operator": "regex_contains", "operand": "\\\\(?:item|only|textbf|color|onslide|only|uncover|visible|invisible|alt|temporal)$", "match_all": true }

--- a/LaTeX math.sublime-completions
+++ b/LaTeX math.sublime-completions
@@ -1,5 +1,5 @@
 {
-        "scope": "string.other.math.tex, string.other.math.latex, string.other.math.block.environment.latex",
+        "scope": "string.other.math.tex, string.other.math.latex, string.other.math.block.environment.latex, meta.function.environment.math.latex",
 
         "completions":
         [


### PR DESCRIPTION
Specifically, followed the advice from [this proposal](https://github.com/sublimehq/Packages/issues/340)
about adding `meta.function.environment.math.latex` to the maths completions scope.