### PR TITLE
Fix jumping cursor on Linux

### DIFF
--- a/jumpToPDF.py
+++ b/jumpToPDF.py
@@ -81,7 +81,7 @@ def focus_st():
 		platform = sublime.platform()
 		# TODO: this does not work on OSX
 		# and I don't know why...
-		if platform == 'osx':
+		if platform == 'osx' or platform == 'linux':
 			return
 
 		plat_settings = get_setting(platform, {})


### PR DESCRIPTION
On  Arch Linux with i3 (X11) and dual monitor the mouse cursor is jumping
after compiling - today I fixed that with this patch. 

This probably fixes also #369?