### PR TITLE
Ensure Okular is always launched in a unique instance

### DIFF
--- a/LaTeXTools.sublime-settings
+++ b/LaTeXTools.sublime-settings
@@ -132,7 +132,7 @@
 		// The name of the ST2 or ST3 executable. On Ubuntu, both subl and sublime-text are
 		// available for ST2; adjust as needed for other platforms, and for ST3
 		"sublime": "sublime-text",
-		// How long to wait after evince has launched before sending a sync message
+		// How long to wait after evince or okular has launched before sending a sync message
 		// in seconds, floating point; choose 2.0 or 3.0 on a slower machine, 0.5 on a fast one
 		// Note: only tweak this if sync after launching the PDF viewer does not seem to work,
 		// or if the PDF viewer opens instantly and you don't want to wait.

--- a/viewers/okular_viewer.py
+++ b/viewers/okular_viewer.py
@@ -1,27 +1,52 @@
 from base_viewer import BaseViewer
 
+from latextools_utils import get_setting
+
 import subprocess
+import sys
+import time
 
 
 class OkularViewer(BaseViewer):
 
-    def _run_with_locator(self, locator, **kwargs):
+    def _run_okular(self, locator=None, **kwargs):
         keep_focus = kwargs.pop('keep_focus', True)
         command = ['okular', '--unique']
         if keep_focus:
             command.append('--noraise')
-        command.append(locator)
+        if locator is not None:
+            command.append(locator)
 
         subprocess.Popen(command)
 
+    def _is_okular_running(self):
+        stdout = subprocess.Popen(
+            ['ps', 'xw'], stdout=subprocess.PIPE
+        ).communicate()[0]
+
+        running_apps = stdout.decode(sys.getdefaultencoding(), 'ignore')
+        for app in running_apps.splitlines():
+            if 'okular' not in app:
+                continue
+            if '--unique' in app:
+                return True
+        return False
+
+    def _ensure_okular(self, **kwargs):
+        if not self._is_okular_running():
+            self._run_okular(**kwargs)
+            time.sleep(get_setting('linux', {}).get('sync_wait') or 1.0)
+
     def forward_sync(self, pdf_file, tex_file, line, col, **kwargs):
-        self._run_with_locator(
+        self._ensure_okular()
+        self._run_okular(
             '{pdf_file}#src:{line}{tex_file}'.format(**locals()),
             **kwargs
         )
 
     def view_file(self, pdf_file, **kwargs):
-        self._run_with_locator(
+        self._ensure_okular()
+        self._run_okular(
             pdf_file,
             **kwargs
         )


### PR DESCRIPTION
Partial solution to #730. See [here](https://github.com/SublimeText/LaTeXTools/issues/730#issuecomment-219309706) for limitations.

Essentially, to launch Okular, we first check if an instance with `--unique` is already running. If it is, we proceed as normal. If it isn't, we run `okular --unique` and then proceed with the normal sequence. This ensures that the document is *always* opened by the "unique" instance of Okular.

