### PR TITLE
Less Obtrusive Build Panel

### DIFF
--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -223,9 +223,12 @@ LaTeX Package keymap for Linux
 			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"}],
 		"command": "insert_snippet", "args": {"name":"Packages/LaTeXTools/Text monospace.sublime-snippet"}},
 
-
-
-
+	// Show panel
+	{ "keys": ["shift+escape"],
+		"context": [
+			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"},
+			{"key": "panel_visible", "operator": "equal", "operand": false }],
+		"command": "show_panel", "args": {"panel": "output.latextools"}},
 
 		// Auto-pair ``$''
 		// Lifted from default file

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -223,9 +223,12 @@ LaTeX Package keymap for OS X
 			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"}],
 		"command": "insert_snippet", "args": {"name":"Packages/LaTeXTools/Text monospace.sublime-snippet"}},
 
-
-
-
+	// Show panel
+	{ "keys": ["shift+escape"],
+		"context": [
+			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"},
+			{"key": "panel_visible", "operator": "equal", "operand": false }],
+		"command": "show_panel", "args": {"panel": "output.latextools"}},
 
 		// Auto-pair ``$''
 		// Lifted from default file

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -223,10 +223,12 @@ LaTeX Package keymap for Windows
 			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"}],
 		"command": "insert_snippet", "args": {"name":"Packages/LaTeXTools/Text monospace.sublime-snippet"}},
 
-
-
-
-
+	// Show panel
+	{ "keys": ["shift+escape"],
+		"context": [
+			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"},
+			{"key": "panel_visible", "operator": "equal", "operand": false }],
+		"command": "show_panel", "args": {"panel": "output.latextools"}},
 
 		// Auto-pair ``$''
 		// Lifted from default file

--- a/LaTeXTools.sublime-settings
+++ b/LaTeXTools.sublime-settings
@@ -330,13 +330,17 @@
 	// "no_warnings" (only hide the panel if no warnings occur)
 	// "no_badboxes" (only hide the panel if no badbox messages occur when badboxes are enabled) and
 	// "never" (default, never hide the build panel)
-	"hide_build_panel": "never",
+	"hide_build_panel": "no_badboxes",
 
 	// OPTION: "display_bad_boxes"
 	// controls whether or not to display any bad boxes in the build output
 	// if this is not set to true, the setting "no_badboxes" for
 	// "hide_build_panel" is equivalent to "no_warnings"
 	"display_bad_boxes": false,
+
+	// number of seconds to display the "build succeeded" or "build failed"
+	// message
+	"build_finished_message_length": 2.0,
 
 // ------------------------------------------------------------------
 // Viewer settings

--- a/README.markdown
+++ b/README.markdown
@@ -325,6 +325,12 @@ Two settings allow you to fine-tune the behavior of this command. `temp_files_ex
 
 This clears the [LaTeXTools cache](#latextools-cache). It is useful if the LaTeXTools cache information gets too out of date, but you want to maintain the LaTeX build files, such as `.aux`.
 
+### Show the build panel
+
+**Keybinding:** `shift+escape`
+
+This will show the LaTeXTools build panel, including any messages from the previous build.
+
 ### Forward and Inverse Search
 
 **Keybinding:** `C-l,j` (for forward search; inverse search depends on the previewer)
@@ -599,7 +605,7 @@ NOTE: for the time being, you will need to refer to the `LaTeXTools.sublime-sett
 
 ### Build Panel Settings
 - `highlight_build_panel` (`true`): if `true` the build panel will have a syntax applied to highlight any errors and warnings. Otherwise, the standard output panel configuration will be used.
-- `hide_build_panel` (`"never"`): controls whether or not to hide the build panel after a build is finished. Possible values:
+- `hide_build_panel` (`"no_badboxes"`): controls whether or not the build panel is show after a build. Possible values:
 	* `"always"` - hide the panel even if the build failed
 	* `"no_errors"` - only hide the panel if the build was successful even with warnings
 	* `"no_warnings"` - only hide the panel if no warnings occur
@@ -607,6 +613,7 @@ NOTE: for the time being, you will need to refer to the `LaTeXTools.sublime-sett
 	* `"never"` - never hide the build panel
 Any other value will be interpretted as the default.
 - `display_bad_boxes` (`false`): if `true` LaTeXTools will display any bad boxes encountered after a build. Note that this is disabled by default.
+- `build_finished_message_length` (`2.0`): the number of seconds to display the notification about the completion of the build in the status bar.
 
 ### Viewer settings
 

--- a/latextools_utils/progress_indicator.py
+++ b/latextools_utils/progress_indicator.py
@@ -1,0 +1,106 @@
+# Note modified from code licensed as follows:
+
+# Copyright (c) 2011-2015 Will Bond <will@wbond.net>
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+import sublime
+import threading
+
+
+class ProgressIndicator():
+
+    """
+    Animates an indicator, [=   ], in the status area while a thread runs
+
+    :param thread:
+        The thread to track for activity
+
+    :param message:
+        The message to display next to the activity indicator
+
+    :param success_message:
+        The message to display once the thread is complete
+    """
+
+    def __init__(self, thread, message, success_message, **kwargs):
+        self.thread = thread
+        self.message = message
+        self._success_message = success_message
+        self._success_message_lock = threading.RLock()
+        self.display_message_length = kwargs.get(
+            'display_message_length', 1000
+        )
+
+        if self.display_message_length < 0:
+            self.display_message_length = 1000
+
+        self.addend = 1
+        self.size = 8
+        self.last_view = None
+        self.window = None
+        sublime.set_timeout(lambda: self.run(0), 100)
+
+    def run(self, i):
+        if self.window is None:
+            self.window = sublime.active_window()
+        active_view = self.window.active_view()
+
+        if self.last_view is not None and active_view != self.last_view:
+            self.last_view.erase_status('_latextools')
+            self.last_view = None
+
+        if not self.thread.is_alive():
+            def cleanup():
+                active_view.erase_status('_latextools')
+            if hasattr(self.thread, 'result') and not self.thread.result:
+                cleanup()
+                return
+            with self._success_message_lock:
+                active_view.set_status('_latextools', self.success_message)
+
+            sublime.set_timeout(cleanup, self.display_message_length)
+            return
+
+        before = i % self.size
+        after = (self.size - 1) - before
+
+        active_view.set_status(
+            '_latextools',
+            '{0} [{1}={2}]'.format(self.message, ' ' * before, ' ' * after)
+        )
+        if self.last_view is None:
+            self.last_view = active_view
+
+        if not after:
+            self.addend = -1
+        if not before:
+            self.addend = 1
+        i += self.addend
+
+        sublime.set_timeout(lambda: self.run(i), 100)
+
+    @property
+    def success_message(self):
+        with self._success_message_lock:
+            return self._success_message
+
+    @success_message.setter
+    def success_message(self, success_message):
+        with self._success_message_lock:
+            self._success_message = success_message

--- a/makePDF.py
+++ b/makePDF.py
@@ -17,6 +17,7 @@ if sublime.version() < '3000':
 	from latextools_utils.output_directory import (
 		get_aux_directory, get_output_directory, get_jobname
 	)
+	from latextools_utils.progress_indicator import ProgressIndicator
 
 	strbase = basestring
 else:
@@ -33,8 +34,10 @@ else:
 	from .latextools_utils.output_directory import (
 		get_aux_directory, get_output_directory, get_jobname
 	)
+	from .latextools_utils.progress_indicator import ProgressIndicator
 
 	strbase = str
+	long = int
 
 import sublime_plugin
 import sys
@@ -153,12 +156,16 @@ class CmdThread ( threading.Thread ):
 								cwd=self.caller.tex_dir
 							)
 					except:
+						if self.caller.hide_panel_level != 'always':
+							self.caller.window.run_command(
+								"show_panel", {"panel": "output.latextools"}
+							)
 						self.caller.output("\n\nCOULD NOT COMPILE!\n\n")
 						self.caller.output("Attempted command:")
 						self.caller.output(" ".join(cmd))
 						self.caller.output("\nBuild engine: " + self.caller.builder.name)
 						self.caller.proc = None
-						print(traceback.format_exc())
+						traceback.print_exc()
 						return
 				# Abundance of caution / for possible future extensions:
 				elif isinstance(cmd, subprocess.Popen):
@@ -192,10 +199,14 @@ class CmdThread ( threading.Thread ):
 				# At this point, out contains the output from the current command;
 				# we pass it to the cmd_iterator and get the next command, until completion
 		except:
+			if self.caller.hide_panel_level != 'always':
+				self.caller.window.run_command(
+					"show_panel", {"panel": "output.latextools"}
+				)
 			self.caller.output("\n\nCOULD NOT COMPILE!\n\n")
 			self.caller.output("\nBuild engine: " + self.caller.builder.name)
 			self.caller.proc = None
-			print(traceback.format_exc())
+			traceback.print_exc()
 			return
 		finally:
 			# restore environment
@@ -270,15 +281,22 @@ class CmdThread ( threading.Thread ):
 			with open(log_file, 'rb') as f:
 				data = f.read()
 		except IOError:
-			self.caller.output([
-				"", ""
-				"Could not find log file {0}!".format(log_file_base),
-			])
-			try:
-				self.handle_std_outputs(out, err)
-			except:
-				# if out or err don't yet exist
-				self.caller.finish(False)
+			traceback.print_exc()
+
+			if self.caller.hide_panel_level != 'always':
+				self.caller.window.run_command(
+					"show_panel", {"panel": "output.latextools"}
+				)
+			content = ['', 'Could not read log file {0}.log'.format(
+				self.caller.tex_base
+			), '']
+			if out is not None:
+				content.extend(['Output from compilation:', '', out.decode('utf-8')])
+			if err is not None:
+				content.extend(['Errors from compilation:', '', err.decode('utf-8')])
+			self.caller.output(content)
+			# if we got here, there shouldn't be a PDF at all
+			self.caller.finish(False)
 		else:
 			errors = []
 			warnings = []
@@ -303,7 +321,9 @@ class CmdThread ( threading.Thread ):
 				else:
 					if errors:
 						content.append("")
-					content.append("No warnings.")
+						content.append("No warnings.")
+					else:
+						content[-1] = content[-1] + " No warnings."
 
 				if badboxes and self.caller.display_bad_boxes:
 					if warnings or errors:
@@ -318,21 +338,30 @@ class CmdThread ( threading.Thread ):
 							content.append("")
 						content.append("No bad boxes.")
 
-				hide_panel = {
-					"always": True,
-					"no_errors": not errors,
-					"no_warnings": not errors and not warnings,
-					"no_badboxes": not errors and not warnings and \
-						(not self.caller.display_bad_boxes or not badboxes),
-					"never": False
-				}.get(self.caller.hide_panel_level, False)
+				show_panel = {
+					"always": False,
+					"no_errors": bool(errors),
+					"no_warnings": bool(errors or warnings),
+					"no_badboxes": bool(
+						errors or warnings or
+						(self.caller.display_bad_boxes and badboxes)),
+					"never": True
+				}.get(self.caller.hide_panel_level, bool(errors or warnings))
 
-				if hide_panel:
-					# hide the build panel (ST2 api is not thread save)
+				if show_panel:
+					self.caller.progress_indicator.success_message = "build completed"
+					# show the build panel (ST2 api is not thread save)
 					if _ST3:
-						self.caller.window.run_command("hide_panel", {"panel": "output.latextools"})
+						self.caller.window.run_command(
+							"show_panel", {"panel": "output.latextools"}
+						)
 					else:
-						sublime.set_timeout(lambda: self.caller.window.run_command("hide_panel", {"panel": "output.latextools"}), 10)
+						sublime.set_timeout(
+							lambda: self.caller.window.run_command(
+								"show_panel",
+								{"panel": "output.latextools"}
+							), 0)
+				else:
 					message = "build completed"
 					if errors:
 						message += " with errors"
@@ -352,13 +381,12 @@ class CmdThread ( threading.Thread ):
 							message += " with"
 						message += " bad boxes"
 
-					if _ST3:
-						sublime.status_message(message)
-					else:
-						sublime.set_timeout(lambda: sublime.status_message(message), 10)
+					self.caller.progress_indicator.success_message = message
 			except Exception as e:
-				# dumpt exception to console
-				traceback.print_exc()
+				if self.caller.hide_panel_level != 'always':
+					self.caller.window.run_command(
+						"show_panel", {"panel": "output.latextools"}
+					)
 
 				content = ["", ""]
 				content.append(
@@ -375,19 +403,11 @@ class CmdThread ( threading.Thread ):
 				)
 				content.append("Please let us know on GitHub. Thanks!")
 
+				traceback.print_exc()
+
 			self.caller.output(content)
 			self.caller.output("\n\n[Done!]\n")
 			self.caller.finish(len(errors) == 0)
-
-	def handle_std_outputs(self, out, err):
-		content = ['']
-		if out is not None:
-			content.extend(['Output from compilation:', '', out.decode('utf-8')])
-		if err is not None:
-			content.extend(['Errors from compilation:', '', err.decode('utf-8')])
-		self.caller.output(content)
-		# if we got here, there shouldn't be a PDF at all
-		self.caller.finish(False)
 
 # Actual Command
 
@@ -465,11 +485,11 @@ class make_pdfCommand(sublime_plugin.WindowCommand):
 		self.output_view.set_read_only(True)
 
 		# Dumb, but required for the moment for the output panel to be picked
-        # up as the result buffer
+		# up as the result buffer
 		self.window.get_output_panel("latextools")
 
-		self.hide_panel_level = get_setting("hide_build_panel", "never")
-		if self.hide_panel_level != "always":
+		self.hide_panel_level = get_setting("hide_build_panel", "no_warnings")
+		if self.hide_panel_level == "never":
 			self.window.run_command("show_panel", {"panel": "output.latextools"})
 
 		self.plat = sublime.platform()
@@ -489,8 +509,12 @@ class make_pdfCommand(sublime_plugin.WindowCommand):
 		self.display_bad_boxes = get_setting("display_bad_boxes", False)
 		# This *must* exist, so if it doesn't, the user didn't migrate
 		if builder_name is None:
-			sublime.error_message("LaTeXTools: you need to migrate your preferences. See the README file for instructions.")
-			self.window.run_command('hide_panel', {"panel": "output.latextools"})
+			sublime.error_message(
+				"LaTeXTools: you need to migrate your preferences. See the README file for instructions."
+			)
+			self.window.run_command(
+				'hide_panel', {"panel": "output.latextools"}
+			)
 			return
 
 		# Default to 'traditional' builder
@@ -584,8 +608,19 @@ class make_pdfCommand(sublime_plugin.WindowCommand):
 		# Now get the tex binary path from prefs, change directory to
 		# that of the tex root file, and run!
 		self.path = platform_settings['texpath']
-		CmdThread(self).start()
+		thread = CmdThread(self)
+		thread.start()
 		print(threading.active_count())
+
+		# setup the progress indicator
+		display_message_length = long(
+			get_setting('build_finished_message_length', 2.0) * 1000
+		)
+		# NB CmdThread will change the success message
+		self.progress_indicator = ProgressIndicator(
+			thread, 'building', 'build failed',
+			display_message_length=display_message_length
+		)
 
 
 	# Threading headaches :-)

--- a/makePDF.py
+++ b/makePDF.py
@@ -349,7 +349,7 @@ class CmdThread ( threading.Thread ):
 				}.get(self.caller.hide_panel_level, bool(errors or warnings))
 
 				if show_panel:
-					self.caller.progress_indicator.success_message = "build completed"
+					self.caller.progress_indicator.success_message = "Build completed"
 					# show the build panel (ST2 api is not thread save)
 					if _ST3:
 						self.caller.window.run_command(
@@ -362,7 +362,7 @@ class CmdThread ( threading.Thread ):
 								{"panel": "output.latextools"}
 							), 0)
 				else:
-					message = "build completed"
+					message = "Build completed"
 					if errors:
 						message += " with errors"
 					if warnings:
@@ -618,7 +618,7 @@ class make_pdfCommand(sublime_plugin.WindowCommand):
 		)
 		# NB CmdThread will change the success message
 		self.progress_indicator = ProgressIndicator(
-			thread, 'building', 'build failed',
+			thread, 'Building', 'Build failed',
 			display_message_length=display_message_length
 		)
 


### PR DESCRIPTION
This builds on #712 and is intended to run builds in a less obtrusive way. Among other things, it implements #638 while addressing [my concerns here](https://github.com/SublimeText/LaTeXTools/pull/638#issuecomment-169167969).

This (if it is merged) is a rather major change, so I'm attempting to solicit some feedback.

1. By default, the output panel is not displayed initially unless `hide_build_panel` is set to `never`. Instead, an indicator (borrowed from [PackageControl](https://packagecontrol.io/)) is used to indicate the build is in progress.
1. By default, the output panel appears if any errors or warnings occur including (and this is the crucial bit) any exceptions thrown at the various points we already have "COULD NOT COMPILE" messages. If `hide_build_panel` is set to `always`, of course, the panel will never be shown.
1. I've added a key-binding, `shift+escape` to bring up the LaTeXTools output panel (this is the reason this change is based off #712 which, for other reasons, uses a uniquely named output panel). I realise a key-binding outside of the `C-l` namespace is risky, but it doesn't seem to be used frequently (if at all) and it corresponds well to the `escape` default binding which will already close the build panel.

The defaults may not be to everyone's tastes, but hopefully its a reasonable compromise.