### PR TITLE
Improved insert environment behavior

### DIFF
--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -140,6 +140,11 @@ LaTeX Package keymap for Linux
 		"context":  [
 			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"}],
 		"command": "insert_snippet", "args": {"name":"Packages/LaTeXTools/Wrap in environment.sublime-snippet"}},
+	{ "keys": ["ctrl+l","ctrl+n"],  
+		"context":  [
+			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"},
+			{"key": "selection_empty", "operator": "equal", "operand": true, "match_all": true}],
+		"command": "insert_snippet", "args": {"name":"Packages/LaTeXTools/Insert environment.sublime-snippet"}},
 	// Change the surrounding environment
 	{ "keys": ["ctrl+l", "ctrl+shift+n"],
 		"context":  [

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -140,6 +140,11 @@ LaTeX Package keymap for OS X
 		"context":  [
 			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"}],
 		"command": "insert_snippet", "args": {"name":"Packages/LaTeXTools/Wrap in environment.sublime-snippet"}},
+	{ "keys": ["super+l","super+n"],  
+		"context":  [
+			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"},
+			{"key": "selection_empty", "operator": "equal", "operand": true, "match_all": true}],
+		"command": "insert_snippet", "args": {"name":"Packages/LaTeXTools/Insert environment.sublime-snippet"}},
 	// Change the surrounding environment
 	{ "keys": ["super+l", "shift+super+n"],
 		"context":  [

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -140,6 +140,11 @@ LaTeX Package keymap for Windows
 		"context":  [
 			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"}],
 		"command": "insert_snippet", "args": {"name":"Packages/LaTeXTools/Wrap in environment.sublime-snippet"}},
+	{ "keys": ["ctrl+l","ctrl+n"],  
+		"context":  [
+			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"},
+			{"key": "selection_empty", "operator": "equal", "operand": true, "match_all": true}],
+		"command": "insert_snippet", "args": {"name":"Packages/LaTeXTools/Insert environment.sublime-snippet"}},
 	// Change the surrounding environment
 	{ "keys": ["ctrl+l", "ctrl+shift+n"],
 		"context":  [

--- a/Insert environment.sublime-snippet
+++ b/Insert environment.sublime-snippet
@@ -1,0 +1,11 @@
+<snippet>
+	<description>Insert a LaTeX environment</description>
+	<content><![CDATA[
+\\begin{${1:env}}
+$0
+\\end{$1}
+]]></content>
+	<!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
+	<!-- <tabTrigger>env</tabTrigger> -->
+	<scope>text.tex.latex</scope>
+</snippet>

--- a/latexCommand.py
+++ b/latexCommand.py
@@ -30,11 +30,14 @@ class latexcmdCommand(sublime_plugin.TextCommand):
 		expr = re.match(rex, line)
 		if expr:
 			command = expr.group(1)[::-1]
-			command_region = sublime.Region(point-len(command),point)
-			view.erase(edit, command_region)
-			# Be forgiving and skip \ if the user provided one (by mistake...)
-			bslash = "" if command[0] == '\\' else "\\\\" 
-			snippet = bslash + command + "{$1} $0"
+			if command:
+				command_region = sublime.Region(point-len(command),point)
+				view.erase(edit, command_region)
+				# Be forgiving and skip \ if the user provided one (by mistake...)
+				bslash = "" if command[0] == '\\' else "\\\\"
+				snippet = bslash + command + "{$1} $0"
+			else:
+				snippet = "\\\\$1{$2} $0"
 			view.run_command("insert_snippet", {'contents': snippet})
 		else:
 			sublime.status_message("LATEXTOOLS INTERNAL ERROR: could not find command to expand")

--- a/latexEnvironment.py
+++ b/latexEnvironment.py
@@ -19,9 +19,12 @@ class latexenvCommand(sublime_plugin.TextCommand):
 		expr = re.match(rex, line)
 		if expr:
 			environment = expr.group(1)[::-1]
-			environment_region = sublime.Region(point-len(environment),point)
-			view.erase(edit, environment_region)
-			snippet = "\\\\begin{" + environment + "}\n$1\n\\\\end{" + environment + "}$0"
+			if environment:
+				environment_region = sublime.Region(point-len(environment),point)
+				view.erase(edit, environment_region)
+				snippet = "\\\\begin{" + environment + "}\n$1\n\\\\end{" + environment + "}$0"
+			else:
+				snippet = "\\\\begin{${1:env}}\n$0\n\end{$1}"
 			view.run_command("insert_snippet", {'contents' : snippet})
 		else:
 			sublime.status_message("LATEXTOOLS INTERNAL ERROR: could not find environment to expand")

--- a/latexEnvironment.py
+++ b/latexEnvironment.py
@@ -24,7 +24,7 @@ class latexenvCommand(sublime_plugin.TextCommand):
 				view.erase(edit, environment_region)
 				snippet = "\\\\begin{" + environment + "}\n$1\n\\\\end{" + environment + "}$0"
 			else:
-				snippet = "\\\\begin{${1:env}}\n$0\n\end{$1}"
+				snippet = "\\\\begin{${1:env}}\n$2\n\end{$1}$0"
 			view.run_command("insert_snippet", {'contents' : snippet})
 		else:
 			sublime.status_message("LATEXTOOLS INTERNAL ERROR: could not find environment to expand")


### PR DESCRIPTION
Using the keybinding `C-l,C-n` this PR inserts an environment snippet, which ends inside the environment. Before the "wrap environment" snippet has been inserted, which ended behind the environment. The old behavior remains if text is selected.

I also changed the behavior of `C-l, e` and `C-l, c` if they are not prefixed by a word to let the user input the environment/command.

| | before | after this PR |
|---|----|---|
| `C-l,C-n` | ![lt_insert_env_old](https://cloud.githubusercontent.com/assets/12573621/15349558/02ae1796-1cd4-11e6-8a3a-51d8648ee734.gif) | ![lt_insert_env_new](https://cloud.githubusercontent.com/assets/12573621/15349515/b8ea322a-1cd3-11e6-9ad3-956eee667fea.gif) |
| `C-l, e` | ![lt_env_old](https://cloud.githubusercontent.com/assets/12573621/15355969/3016d1f6-1cf6-11e6-9d0c-a44b9951065e.gif) | ![lt_env_new_optimized](https://cloud.githubusercontent.com/assets/12573621/15356010/6d0d248e-1cf6-11e6-9841-c8238e3cc79d.gif) |
| `C-l, c` | ![lt_cmd_old](https://cloud.githubusercontent.com/assets/12573621/15355994/56564658-1cf6-11e6-8367-d933b6cc7979.gif) | ![lt_cmd_new_optimized](https://cloud.githubusercontent.com/assets/12573621/15356004/60d84ebe-1cf6-11e6-868d-6d1059164c74.gif) |

