### PR TITLE
fix trigger toggle for \epsilon and \varepsilon

### DIFF
--- a/LaTeX math.sublime-completions
+++ b/LaTeX math.sublime-completions
@@ -7,12 +7,12 @@
                 { "trigger": "b", "contents": "\\beta" },
                 { "trigger": "g", "contents": "\\gamma" },
                 { "trigger": "d", "contents": "\\delta" },
-                { "trigger": "delta", "contents": "partial" },
+                { "trigger": "\\delta", "contents": "\\partial" },
                 //{ "trigger": "partial", "contents": "delta" },  # can't have trigger as it conflicts with p -> \pi
 		{ "trigger": "e", "contents": "\\epsilon" },
-		{ "trigger": "epsilon", "contents": "varepsilon" }, 
+		{ "trigger": "\\epsilon", "contents": "\\varepsilon" }, 
                 /* toggle the two! */
-		{ "trigger": "varepsilon", "contents": "epsilon" },
+		{ "trigger": "\\varepsilon", "contents": "\\epsilon" },
 		{ "trigger": "z", "contents": "\\zeta"},
 		{ "trigger": "h", "contents": "\\eta" },
                 { "trigger": "q", "contents": "\\theta" },


### PR DESCRIPTION
If use the original one, `\` shall disappear after toggling.