### PR TITLE
Update bibtex parser to support cryptobib

### DIFF
--- a/external/bibtex/lexer.py
+++ b/external/bibtex/lexer.py
@@ -199,6 +199,7 @@ class Lexer(object):
                     bracket_depth += 1
                     value.append(matched)
                 else:
+                    self.current_line += 1
                     # consume space after new line replacing with 1 space
                     match = SPACE.match(self.code, i - 1)
                     if match:
@@ -234,9 +235,15 @@ class Lexer(object):
 
                 if matched == '"':
                     break
-                elif matched == '\\"':
-                    value.append('"')
+                elif matched == '{':
+                    self.current_index = match.start()
+                    consumed = self.value_token()
+                    if consumed > 0:
+                        i += consumed - 1
+                        last_token = self.tokens.pop(-1)
+                        value.extend(['{', last_token[1], '}'])
                 else:
+                    self.current_line += 1
                     # consume space after new line replacing with 1 space
                     match = SPACE.match(self.code, i - 1)
                     if match:
@@ -334,6 +341,6 @@ NUMBER              = re.compile(r'\d+', re.UNICODE)
 KEY                 = re.compile(r'([^\W\d][^,\s=]*)\s*=\s*', re.UNICODE)
 
 # These are used internally by the more complex "tokens"
-NEXT_QUOTE_BREAK    = re.compile(r'(?:\\")|\n|"')
+NEXT_QUOTE_BREAK    = re.compile(r'\n|"|\{')
 NEXT_BRACKET_BREAK  = re.compile(r'\{|}|\n')
 SPACE               = re.compile(r'\s+', re.UNICODE)

--- a/external/bibtex/parser.py
+++ b/external/bibtex/parser.py
@@ -165,7 +165,7 @@ class Parser(object):
             self.unexpected_token('key')
 
         node.key = self.token_value
-        node.value = self.string_value()
+        node.value = self.field_value()
 
         try:
             self._advance()
@@ -213,23 +213,6 @@ class Parser(object):
             return node
         else:
             self.unexpected_token('identifier')
-
-    def string_value(self):
-        try:
-            self._advance()
-        except IndexError:
-            self.unexpected_token('quoted_string or value')
-
-        token_type = self.token_type
-        if token_type == 'QUOTED_STRING':
-            node = QuotedLiteralNode()
-        elif token_type == 'VALUE':
-            node = QuotedLiteralNode()
-        else:
-            self.unexpected_token('quoted_string or value')
-
-        node.value = self.token_value
-        return node
 
     def key_values(self):
         values = []

--- a/external/bibtex/tests/lexer_tests.py
+++ b/external/bibtex/tests/lexer_tests.py
@@ -999,19 +999,6 @@ class TestQuotedStringToken(LexerTest):
             )
         )
 
-    def test_quoted_string_token_with_escaped_quotes(self):
-        self.lexer.code = '"value \\\"other value\\\""'
-        self.lexer.code_len = len(self.lexer.code)
-        self.lexer.quoted_string_token()
-
-        self.assertEqual(
-            self.lexer.tokens[0][1],
-            'value "other value"',
-            'expected token value to be "value \"other value\"", was "{0}"'.format(
-                self.lexer.tokens[0][1]
-            )
-        )
-
     def test_quoted_string_token_with_newline(self):
         self.lexer.code = '"value\nother value"'
         self.lexer.code_len = len(self.lexer.code)
@@ -1071,6 +1058,27 @@ class TestQuotedStringToken(LexerTest):
             self.lexer.tokens[0][1],
             'value other value',
             'expected token value to be "value other value", was "{0}"'.format(
+                self.lexer.tokens[0][1]
+            )
+        )
+
+    def test_quoted_string_ends_with_slash(self):
+        self.lexer.code = '"value other value\\\\"'
+        self.lexer.code_len = len(self.lexer.code)
+        result = self.lexer.quoted_string_token()
+
+        self.assertEqual(
+            result,
+            21,
+            'expected 21 characters to be consumed, found {0}'.format(
+                result
+            )
+        )
+
+        self.assertEqual(
+            self.lexer.tokens[0][1],
+            'value other value\\\\',
+            'expected token value to be "value other value\\\\", was "{0}"'.format(
                 self.lexer.tokens[0][1]
             )
         )

--- a/external/bibtex/tests/lexer_tests.py
+++ b/external/bibtex/tests/lexer_tests.py
@@ -1083,6 +1083,69 @@ class TestQuotedStringToken(LexerTest):
             )
         )
 
+    def test_quoted_string_containing_brackets(self):
+        self.lexer.code = '"text {WITH} brackets"'
+        self.lexer.code_len = len(self.lexer.code)
+        result = self.lexer.quoted_string_token()
+
+        self.assertEqual(
+            result,
+            22,
+            'expected 22 characters to be consumed, found {0}'.format(
+                result
+            )
+        )
+
+        self.assertEqual(
+            self.lexer.tokens[0][1],
+            'text {WITH} brackets',
+            'expected token value to be "text {{WITH}} brackets", was "{0}"'.format(
+                self.lexer.tokens[0][1]
+            )
+        )
+
+    def test_quoted_string_containing_brackets_with_quotes(self):
+        self.lexer.code = '"test {"}bracket{ escaping"}"'
+        self.lexer.code_len = len(self.lexer.code)
+        result = self.lexer.quoted_string_token()
+
+        self.assertEqual(
+            result,
+            29,
+            'expected 29 characters to be consumed, found {0}'.format(
+                result
+            )
+        )
+
+        self.assertEqual(
+            self.lexer.tokens[0][1],
+            'test {"}bracket{ escaping"}',
+            'expected token value to be "test {{"}}bracket{{ escaping"}}", was "{0}"'.format(
+                self.lexer.tokens[0][1]
+            )
+        )
+
+    def test_quoted_string_with_unmatched_brackets(self):
+        self.lexer.code = '"test { unmatched"'
+        self.lexer.code_len = len(self.lexer.code)
+        result = self.lexer.quoted_string_token()
+
+        self.assertEqual(
+            result,
+            18,
+            'expected 18 characters to be consumed, found {0}'.format(
+                result
+            )
+        )
+
+        self.assertEqual(
+            self.lexer.tokens[0][1],
+            'test { unmatched',
+            'expected token value to be "test {{ unmatched", was "{0}"'.format(
+                self.lexer.tokens[0][1]
+            )
+        )
+
 
 class TestEntryEndToken(LexerTest):
 

--- a/external/bibtex/tests/parser_tests.py
+++ b/external/bibtex/tests/parser_tests.py
@@ -455,64 +455,6 @@ class TestKeyValue(ParserTest):
             []
         )
 
-
-class TestStringValue(ParserTest):
-
-    def test_string_value_with_value(self):
-        self.parser.tokens = [('VALUE', 'value', {})]
-        self.parser._current_token = 0
-        self.parser._tokens_len = 1
-
-        node = self.parser.string_value()
-
-        self.assertIsInstance(
-            node,
-            QuotedLiteralNode
-        )
-
-        self.assertEqual(
-            node.value,
-            'value'
-        )
-
-    def test_string_value_with_quoted_string(self):
-        self.parser.tokens = [('QUOTED_STRING', 'value', {})]
-        self.parser._current_token = 0
-        self.parser._tokens_len = 1
-
-        node = self.parser.string_value()
-
-        self.assertIsInstance(
-            node,
-            QuotedLiteralNode
-        )
-
-        self.assertEqual(
-            node.value,
-            'value'
-        )
-
-    def test_string_value_with_invalid_token(self):
-        self.parser.tokens = [('EOF', 'EOF', {})]
-        self.parser._current_token = 0
-        self.parser._tokens_len = 1
-
-        self.assertRaises(
-            SyntaxError,
-            self.parser.string_value
-        )
-
-    def test_string_value_with_no_tokens(self):
-        self.parser.tokens = []
-        self.parser._current_token = 0
-        self.parser._tokens_len = 0
-
-        self.assertRaises(
-            SyntaxError,
-            self.parser.string_value
-        )
-
-
 class TestEntryKey(ParserTest):
 
     def test_entry_key(self):


### PR DESCRIPTION
 * Eliminates wrong-headed support for \" escapes in quoted strings
 * Adds support for brackets in quoted strings
 * Removes special case for @string values

- [x] Test this in LaTeXTools