### PR TITLE
Caching for BibTeX cite completions

### DIFF
--- a/01_reload_submodules.py
+++ b/01_reload_submodules.py
@@ -21,6 +21,7 @@ LOAD_ORDER = [
     'latextools_utils',
 
     # no internal dependencies
+    'latextools_utils.bibformat',
     'latextools_utils.settings',
     'latextools_utils.utils',
     'latextools_utils.tex_directives',
@@ -34,6 +35,7 @@ LOAD_ORDER = [
 
     # depend on any previous
     'latextools_utils.analysis',
+    'latextools_utils.bibcache',
     'latextools_utils.output_directory',
 
     'latextools_plugin_internal',

--- a/bibliography_plugins/newBibliography.py
+++ b/bibliography_plugins/newBibliography.py
@@ -9,9 +9,7 @@ from latextools_utils import bibcache
 
 import codecs
 from collections import Mapping
-import hashlib
 import sublime
-import time
 import traceback
 
 # LaTeX -> Unicode decoder
@@ -114,7 +112,6 @@ class NewBibliographyPlugin(LaTeXToolsPlugin):
         entries = []
         parser = Parser()
         for bibfname in bib_files:
-            cache_name = "bib_" + hashlib.md5(bibfname.encode("utf8")).hexdigest()
             try:
                 cached_entries = bibcache.read("new", bibfname)
                 entries.extend(cached_entries)

--- a/bibliography_plugins/newBibliography.py
+++ b/bibliography_plugins/newBibliography.py
@@ -113,7 +113,7 @@ class NewBibliographyPlugin(LaTeXToolsPlugin):
         parser = Parser()
         for bibfname in bib_files:
             try:
-                cached_entries = bibcache.read("new", bibfname)
+                cached_entries = bibcache.read_fmt("new", bibfname)
                 entries.extend(cached_entries)
                 continue
             except:
@@ -138,7 +138,7 @@ class NewBibliographyPlugin(LaTeXToolsPlugin):
                     bib_entries.append(EntryWrapper(entry))
 
                 try:
-                    fmt_entries = bibcache.write("new", bibfname, bib_entries)
+                    fmt_entries = bibcache.write_fmt("new", bibfname, bib_entries)
                     entries.extend(fmt_entries)
                 except:
                     entries.extend(bib_entries)

--- a/bibliography_plugins/traditionalBibliography.py
+++ b/bibliography_plugins/traditionalBibliography.py
@@ -1,13 +1,10 @@
 from latextools_plugin import LaTeXToolsPlugin
 
-from latextools_utils import cache
+from latextools_utils import bibcache
 
 import codecs
-import hashlib
-import os
 import re
 import sublime
-import time
 import traceback
 
 kp = re.compile(r'@[^\{]+\{(.+),')
@@ -37,14 +34,10 @@ class TraditionalBibliographyPlugin(LaTeXToolsPlugin):
     def get_entries(self, *bib_files):
         entries = []
         for bibfname in bib_files:
-            cache_name = "tradbib_" + hashlib.md5(bibfname.encode("utf8")).hexdigest()
             try:
-                modified_time = os.path.getmtime(bibfname)
-
-                (cached_time, cached_entries) = cache.read_global(cache_name)
-                if modified_time <= cached_time:
-                    entries.extend(cached_entries)
-                    continue
+                cached_entries = bibcache.read("trad", bibfname)
+                entries.extend(cached_entries)
+                continue
             except:
                 pass
 
@@ -56,6 +49,7 @@ class TraditionalBibliographyPlugin(LaTeXToolsPlugin):
                 continue
             else:
                 bib_data = bibf.readlines()
+                bib_entries = []
 
                 entry = {}
                 for line in bib_data:
@@ -71,7 +65,7 @@ class TraditionalBibliographyPlugin(LaTeXToolsPlugin):
                         continue
                     if line[0] == "@":
                         if 'keyword' in entry:
-                            entries.append(entry)
+                            bib_entries.append(entry)
                             entry = {}
 
                         kp_match = kp.search(line)
@@ -101,18 +95,16 @@ class TraditionalBibliographyPlugin(LaTeXToolsPlugin):
 
                 # at the end, we have a single record
                 if 'keyword' in entry:
-                    entries.append(entry)
+                    bib_entries.append(entry)
 
-
-                print ('Loaded %d bibitems' % (len(entries)))
+                print ('Loaded %d bibitems' % (len(bib_entries)))
 
                 try:
-                    current_time = time.time()
-                    cache.write_global(cache_name, (current_time, entries))
+                    fmt_entries = bibcache.write("trad", bibfname, bib_entries)
+                    entries.extend(fmt_entries)
                 except:
-                    print('Error occurred while trying to write to cache {0}'.format(
-                        cache_name
-                    ))
+                    entries.extend(bib_entries)
+                    print('Error occurred while trying to write to cache')
                     traceback.print_exc()
             finally:
                 try:

--- a/bibliography_plugins/traditionalBibliography.py
+++ b/bibliography_plugins/traditionalBibliography.py
@@ -35,7 +35,7 @@ class TraditionalBibliographyPlugin(LaTeXToolsPlugin):
         entries = []
         for bibfname in bib_files:
             try:
-                cached_entries = bibcache.read("trad", bibfname)
+                cached_entries = bibcache.read_fmt("trad", bibfname)
                 entries.extend(cached_entries)
                 continue
             except:
@@ -100,7 +100,7 @@ class TraditionalBibliographyPlugin(LaTeXToolsPlugin):
                 print ('Loaded %d bibitems' % (len(bib_entries)))
 
                 try:
-                    fmt_entries = bibcache.write("trad", bibfname, bib_entries)
+                    fmt_entries = bibcache.write_fmt("trad", bibfname, bib_entries)
                     entries.extend(fmt_entries)
                 except:
                     entries.extend(bib_entries)

--- a/latex_cite_completions.py
+++ b/latex_cite_completions.py
@@ -672,7 +672,8 @@ class LatexCiteCommand(sublime_plugin.TextCommand):
                 try:
                     return entry["<panel_formatted>"]
                 except:
-                    return [formatted_entry(s, entry) for s in cite_panel_format]
+                    return [bibformat.format_entry(s, entry) 
+                            for s in cite_panel_format]
             panel_entries = [
                 formatted_entry(completion)
                 for completion in completions

--- a/latex_cite_completions.py
+++ b/latex_cite_completions.py
@@ -31,7 +31,7 @@ if sublime.version() < '3000':
     import getTeXRoot
     from kpsewhich import kpsewhich
     from latextools_utils.is_tex_file import is_tex_file, get_tex_extensions
-    from latextools_utils import get_setting
+    from latextools_utils import bibformat, get_setting
     import latextools_plugin
 
     # reraise implementation from 6
@@ -45,7 +45,7 @@ else:
     from . import getTeXRoot
     from .kpsewhich import kpsewhich
     from .latextools_utils.is_tex_file import is_tex_file, get_tex_extensions
-    from .latextools_utils import get_setting
+    from .latextools_utils import bibformat, get_setting
     from . import latextools_plugin
 
     # reraise implementation from 6
@@ -383,119 +383,6 @@ def run_plugin_command(command, *args, **kwargs):
 
     return result
 
-TITLE_SEP = re.compile(':|\.|\?')
-def get_title_short(title):
-    title = TITLE_SEP.split(title)[0]
-    if len(title) > 60:
-        title = title[:60] + '...'
-    return title
-
-
-# default implementation that convers the author field into a short version of itself
-# assumes we get a basically raw LaTeX string, e.g. "Lastname, Firstnamd and Otherlastname, Otherfirstname"
-def get_author_short(authors):
-    if authors == '':
-        return ''
-
-    # split authors using ' and ' and get last name for 'last, first' format
-    authors = [a.split(", ")[0].strip(' ') for a in authors.split(" and ")]
-    # get last name for 'first last' format (preserve {...} text)
-    authors = [a.split(" ")[-1] if not('{' in a and a.endswith('}'))
-               else re.sub(r'{|}', '', a[a.rindex('{') + 1:-1])
-               for a in authors if len(a) > 0]
-
-    # truncate and add 'et al.'
-    if len(authors) > 2:
-        authors = authors[0] + " et al."
-    else:
-        authors = ' & '.join(authors)
-
-    # return formated string
-    return authors
-
-class CompletionWrapper(collections.Mapping):
-    '''
-    Wraps the returned completions so that we can properly handle any KeyErrors that
-    occur
-    '''
-    def __init__(self, entry):
-        self._entry = entry
-
-    def __getitem__(self, key):
-        try:
-            # emulating previous behaviour of latex_cite_completions
-            if key not in ('author', 'journal'):
-                return self._entry[key]
-            else:
-                value = self._entry[key]
-                return value or u'????'
-        except KeyError:
-            if key == 'author':
-                try:
-                    return self._entry['editor']
-                except KeyError:
-                    pass
-            elif key == 'author_short':
-                try:
-                    return get_author_short(self._entry['author'])
-                except KeyError:
-                    pass
-
-                return self['editor_short']
-            elif key == 'editor_short':
-                try:
-                    return get_author_short(self._entry['editor'])
-                except KeyError:
-                    pass
-            elif key == 'title_short':
-                try:
-                    return self._entry['shorttitle']
-                except KeyError:
-                    pass
-
-                try:
-                    return get_title_short(self._entry['title'])
-                except KeyError:
-                    pass
-            elif key == 'journal':
-                try:
-                    return self._entry['journaltitle']
-                except KeyError:
-                    pass
-
-                try:
-                    return self._entry['eprint']
-                except KeyError:
-                    pass
-            elif key == 'keyword':
-                try:
-                    return self._entry['citekey']
-                except KeyError:
-                    pass
-            elif key == 'year':
-                try:
-                    date = self._entry['date']
-                    date_matcher = re.match(r'(\d{4})', date)
-                    if date_matcher:
-                        return date_matcher.group(1)
-                except KeyError:
-                    pass
-            elif key == 'month':
-                try:
-                    date = self._entry['date']
-                    date_matcher = re.match(r'\d{4}-(\d{2})', date)
-                    if date_matcher:
-                        return date_matcher.group(1)
-                except KeyError:
-                    pass
-
-            return u'????'
-
-    def __iter__(self):
-        return iter(self._entry)
-
-    def __len__(self):
-        return len(self._entry)
 
 def get_cite_completions(view, point, autocompleting=False):
     line = view.substr(sublime.Region(view.line(point).a, point))
@@ -620,7 +507,8 @@ def get_cite_completions(view, point, autocompleting=False):
 
     #### END COMPLETIONS HERE ####
 
-    completions = [CompletionWrapper(completion) for completion in completions]
+    completions = [bibformat.CompletionWrapper(completion)
+                   for completion in completions]
 
     return completions, prefix, post_brace, new_point_a, new_point_b
 
@@ -678,13 +566,19 @@ class LatexCiteCompletions(sublime_plugin.EventListener):
         cite_autocomplete_format = get_setting('cite_autocomplete_format',
             "{keyword}: {title}")
 
-        formatter = Formatter()
-        r = [(prefix + formatter.vformat(cite_autocomplete_format, (), completion),
-              completion['keyword'] + post_brace) for completion in completions]
+        def formatted_entry(entry):
+            if "<autocomplete_formatted>" in entry:
+                return entry["<autocomplete_formatted>"]
+            else:
+                return bibformat.format_entry(cite_autocomplete_format, entry)
 
-        # print "%d bib entries matching %s" % (len(r), prefix)
+        completion_entries = [
+            (prefix + formatted_entry(completion),
+             completion['keyword'] + post_brace)
+            for completion in completions
+        ]
 
-        return r
+        return completion_entries
 
 
 class LatexCiteCommand(sublime_plugin.TextCommand):
@@ -784,9 +678,16 @@ class LatexCiteCommand(sublime_plugin.TextCommand):
             view.sel().add(sublime.Region(caret, caret))
         else:
             # show quick
-            formatter = Formatter()
-            view.window().show_quick_panel([[formatter.vformat(s, (), completion) for s in cite_panel_format] \
-                                        for completion in completions], on_done)
+            def formatted_entry(entry):
+                if "<panel_formatted>" in entry:
+                    return entry["<panel_formatted>"]
+                else:
+                    return [formatted_entry(s, entry) for s in cite_panel_format]
+            panel_entries = [
+                formatted_entry(completion)
+                for completion in completions
+            ]
+            view.window().show_quick_panel(panel_entries, on_done)
 
 def plugin_loaded():
     # load plugins from the bibliography_plugins dir of LaTeXTools if it exists

--- a/latex_cite_completions.py
+++ b/latex_cite_completions.py
@@ -561,9 +561,9 @@ class LatexCiteCompletions(sublime_plugin.EventListener):
             "{keyword}: {title}")
 
         def formatted_entry(entry):
-            if "<autocomplete_formatted>" in entry:
+            try:
                 return entry["<autocomplete_formatted>"]
-            else:
+            except:
                 return bibformat.format_entry(cite_autocomplete_format, entry)
 
         completion_entries = [
@@ -585,8 +585,7 @@ class LatexCiteCommand(sublime_plugin.TextCommand):
         print (point)
         # Only trigger within LaTeX
         # Note using score_selector rather than match_selector
-        if not view.score_selector(point,
-                "text.tex.latex"):
+        if not view.score_selector(point, "text.tex.latex"):
             return
 
         try:
@@ -647,10 +646,6 @@ class LatexCiteCommand(sublime_plugin.TextCommand):
             view.sel().subtract(view.sel()[0])
             view.sel().add(sublime.Region(caret, caret))
 
-        # get preferences for formating of quick panel
-        cite_panel_format = get_setting('cite_panel_format',
-            ["{title} ({keyword})", "{author}"])
-
         completions_length = len(completions)
         if completions_length == 0:
             return
@@ -669,11 +664,14 @@ class LatexCiteCommand(sublime_plugin.TextCommand):
             view.sel().subtract(view.sel()[0])
             view.sel().add(sublime.Region(caret, caret))
         else:
+            # get preferences for formating of quick panel
+            cite_panel_format = get_setting('cite_panel_format',
+                ["{title} ({keyword})", "{author}"])
             # show quick
             def formatted_entry(entry):
-                if "<panel_formatted>" in entry:
+                try:
                     return entry["<panel_formatted>"]
-                else:
+                except:
                     return [formatted_entry(s, entry) for s in cite_panel_format]
             panel_entries = [
                 formatted_entry(completion)

--- a/latex_cite_completions.py
+++ b/latex_cite_completions.py
@@ -505,11 +505,6 @@ def get_cite_completions(view, point, autocompleting=False):
 
     completions = run_plugin_command('get_entries', *bib_files)
 
-    #### END COMPLETIONS HERE ####
-
-    completions = [bibformat.CompletionWrapper(completion)
-                   for completion in completions]
-
     return completions, prefix, post_brace, new_point_a, new_point_b
 
 
@@ -556,10 +551,9 @@ class LatexCiteCompletions(sublime_plugin.EventListener):
 
         # filter against keyword or title
         if prefix:
-            completions = [comp for comp in completions if prefix.lower() in "%s %s" %
-                                                    (
-                                                        comp['keyword'].lower(),
-                                                        comp['title'].lower())]
+            lprefix = prefix.lower()
+            completions = [comp for comp in completions
+                           if _is_prefix(lprefix, comp)]
             prefix += " "
 
         # get preferences for formating of autocomplete entries
@@ -612,11 +606,9 @@ class LatexCiteCommand(sublime_plugin.TextCommand):
 
         # filter against keyword, title, or author
         if prefix:
-            completions = [comp for comp in completions if prefix.lower() in "%s %s %s" % 
-                                                    (
-                                                        comp['keyword'].lower(),
-                                                        comp['title'].lower(),
-                                                        comp['author'].lower())]
+            lprefix = prefix.lower()
+            completions = [comp for comp in completions
+                           if _is_prefix(lprefix, comp)]
 
         # Note we now generate citation on the fly. Less copying of vectors! Win!
         def on_done(i):
@@ -688,6 +680,14 @@ class LatexCiteCommand(sublime_plugin.TextCommand):
                 for completion in completions
             ]
             view.window().show_quick_panel(panel_entries, on_done)
+
+
+def _is_prefix(lower_prefix, entry):
+    try:
+        return lower_prefix in entry["<prefix_match>"]
+    except:
+        return lower_prefix in bibformat.create_prefix_match_str(entry)
+
 
 def plugin_loaded():
     # load plugins from the bibliography_plugins dir of LaTeXTools if it exists

--- a/latextools_utils/bibcache.py
+++ b/latextools_utils/bibcache.py
@@ -75,6 +75,7 @@ def _create_formatted_entries(formatted_cache_name, bib_entries, cache_time):
     formatted_entries = [
         {
             "keyword": entry["keyword"],
+            "<prefix_match>": bibformat.create_prefix_match_str(entry),
             "<panel_formatted>": [
                 bibformat.format_entry(s, entry) for s in panel_format
             ],

--- a/latextools_utils/bibcache.py
+++ b/latextools_utils/bibcache.py
@@ -10,6 +10,8 @@ else:
     _ST3 = True
     from . import bibformat, cache, get_setting
 
+_VERSION = 1
+
 
 def write_fmt(bib_name, bib_file, bib_entries):
     cache_name, formatted_cache_name = _cache_name(bib_name, bib_file)
@@ -40,9 +42,10 @@ def read_fmt(bib_name, bib_file):
     if modified_time > meta_data["cache_time"]:
         raise cache.CacheMiss()
 
-    # validate the format string are still valid
-    if any(meta_data[s] != get_setting("cite_" + s)
-           for s in ["panel_format", "autocomplete_format"]):
+    # validate the version and format strings are still valid
+    if (meta_data["version"] != _VERSION or
+            any(meta_data[s] != get_setting("cite_" + s)
+                for s in ["panel_format", "autocomplete_format"])):
         print("Formatting string has changed, updating cache...")
         # read the base information from the unformatted cache
         current_time, bib_entries = cache.read_global(cache_name)
@@ -68,10 +71,10 @@ def _create_formatted_entries(formatted_cache_name, bib_entries, cache_time):
 
     meta_data = {
         "cache_time": cache_time,
+        "version": _VERSION,
         "autocomplete_format": autocomplete_format,
         "panel_format": panel_format
     }
-    # TODO we might need to keep keys like "author"
     formatted_entries = [
         {
             "keyword": entry["keyword"],

--- a/latextools_utils/bibcache.py
+++ b/latextools_utils/bibcache.py
@@ -56,8 +56,8 @@ def read(bib_name, bib_file):
 
 def _cache_name(bib_name, bib_file):
     file_hash = cache.hash_digest(bib_file)
-    cache_name = "{0}_{1}".format(bib_name, file_hash)
-    formatted_cache_name = "{0}_fmt_{1}".format(bib_name, file_hash)
+    cache_name = "bib_{0}_{1}".format(bib_name, file_hash)
+    formatted_cache_name = "bib_{0}_fmt_{1}".format(bib_name, file_hash)
     return cache_name, formatted_cache_name
 
 

--- a/latextools_utils/bibcache.py
+++ b/latextools_utils/bibcache.py
@@ -1,0 +1,88 @@
+import os
+import time
+
+import sublime
+
+if sublime.version() < '3000':
+    _ST3 = False
+    from latextools_utils import bibformat, cache, get_setting
+else:
+    _ST3 = True
+    from . import bibformat, cache, get_setting
+
+
+def write(bib_name, bib_file, bib_entries):
+    cache_name, formatted_cache_name = _cache_name(bib_name, bib_file)
+
+    current_time = time.time()
+
+    # write the full unformatted bib entries into the cache together
+    # with a time stamp
+    print("Writing bibliography into cache {0}".format(cache_name))
+    cache.write_global(cache_name, (current_time, bib_entries))
+
+    # create and cache the formatted entries
+    formatted_entries = _create_formatted_entries(formatted_cache_name,
+                                                  bib_entries, current_time)
+    return formatted_entries
+
+
+def read(bib_name, bib_file):
+    cache_name, formatted_cache_name = _cache_name(bib_name, bib_file)
+
+    try:
+        meta_data, formatted_entries = cache.read_global(formatted_cache_name)
+    except:
+        raise cache.CacheMiss()
+
+    # raise a cache miss if the modification took place after the caching
+    modified_time = os.path.getmtime(bib_file)
+    if modified_time > meta_data["cache_time"]:
+        raise cache.CacheMiss()
+
+    # validate the format string are still valid
+    if any(meta_data[s] != get_setting("cite_" + s)
+           for s in ["panel_format", "autocomplete_format"]):
+        print("Formatting string has changed, updating cache...")
+        # read the base information from the unformatted cache
+        current_time, bib_entries = cache.read_global(cache_name)
+        # format and cache the entries
+        formatted_entries = _create_formatted_entries(formatted_cache_name,
+                                                      bib_entries,
+                                                      current_time)
+
+    return formatted_entries
+
+
+def _cache_name(bib_name, bib_file):
+    file_hash = cache.hash_digest(bib_file)
+    cache_name = "{0}_{1}".format(bib_name, file_hash)
+    formatted_cache_name = "{0}_fmt_{1}".format(bib_name, file_hash)
+    return cache_name, formatted_cache_name
+
+
+def _create_formatted_entries(formatted_cache_name, bib_entries, cache_time):
+    # create the formatted entries
+    autocomplete_format = get_setting("cite_autocomplete_format")
+    panel_format = get_setting("cite_panel_format")
+
+    meta_data = {
+        "cache_time": cache_time,
+        "autocomplete_format": autocomplete_format,
+        "panel_format": panel_format
+    }
+    # TODO we might need to keep keys like "author"
+    formatted_entries = [
+        {
+            "keyword": entry["keyword"],
+            "<panel_formatted>": [
+                bibformat.format_entry(s, entry) for s in panel_format
+            ],
+            "<autocomplete_formatted>":
+                bibformat.format_entry(autocomplete_format, entry)
+        }
+        for entry in bib_entries
+    ]
+
+    cache.write_global(formatted_cache_name, (meta_data, formatted_entries))
+    return formatted_entries

--- a/latextools_utils/bibcache.py
+++ b/latextools_utils/bibcache.py
@@ -14,6 +14,22 @@ _VERSION = 1
 
 
 def write_fmt(bib_name, bib_file, bib_entries):
+    """
+    Writes the entries resulting from the bibliography into the cache.
+    The entries are pre-formatted to improve the time for the cite
+    completion command.
+    These pre-formatted entries are returned and should be used in the
+    to improve the time and be consistent with the return values.
+
+    Arguments:
+    bib_name -- the (unique) name of the bibliography
+    bib_file -- the bibliography file, which resulted in the entries
+    bib_entries -- the entries, which are parsed from the bibliography
+
+    Returns:
+    The pre-formatted entries, which should be passed to the cite
+    completions
+    """
     cache_name, formatted_cache_name = _cache_name(bib_name, bib_file)
 
     current_time = time.time()
@@ -30,6 +46,21 @@ def write_fmt(bib_name, bib_file, bib_entries):
 
 
 def read_fmt(bib_name, bib_file):
+    """
+    Reads the cache file of a bibliography file.
+    If the bibliography file has been changed after the caching, this
+    will result in a CacheMiss.
+    These entries are pre-formatted and compatible with cite
+    completions.
+
+    Arguments:
+    bib_name -- the (unique) name of the bibliography
+    bib_file -- the bibliography file, which resulted in the entries
+
+    Returns:
+    The cached pre-formatted entries, which should be passed to the
+    cite completions
+    """
     cache_name, formatted_cache_name = _cache_name(bib_name, bib_file)
 
     try:

--- a/latextools_utils/bibcache.py
+++ b/latextools_utils/bibcache.py
@@ -11,7 +11,7 @@ else:
     from . import bibformat, cache, get_setting
 
 
-def write(bib_name, bib_file, bib_entries):
+def write_fmt(bib_name, bib_file, bib_entries):
     cache_name, formatted_cache_name = _cache_name(bib_name, bib_file)
 
     current_time = time.time()
@@ -27,7 +27,7 @@ def write(bib_name, bib_file, bib_entries):
     return formatted_entries
 
 
-def read(bib_name, bib_file):
+def read_fmt(bib_name, bib_file):
     cache_name, formatted_cache_name = _cache_name(bib_name, bib_file)
 
     try:

--- a/latextools_utils/bibformat.py
+++ b/latextools_utils/bibformat.py
@@ -4,17 +4,30 @@ import re
 
 
 TITLE_SEP = re.compile(':|\.|\?')
+PREFIX_MATCH_KEYS = set(["keyword", "title", "author"])
 
 formatter = Formatter()
 
 
+def _wrap(entry):
+    if not isinstance(entry, CompletionWrapper):
+        entry = CompletionWrapper(entry)
+    return entry
+
+
 def format_entry(format_string, entry):
-    return formatter.vformat(format_string, (), CompletionWrapper(entry))
+    return formatter.vformat(format_string, (), _wrap(entry))
 
 
 def format_entries(format_string, entries):
-    return [formatter.vformat(format_string, (), CompletionWrapper(entry))
+    return [formatter.vformat(format_string, (), _wrap(entry))
             for entry in entries]
+
+
+def create_prefix_match_str(entry):
+    prefix_str = " ".join(entry.get(key, "") for key in PREFIX_MATCH_KEYS)
+    prefix_str = prefix_str.lower()
+    return prefix_str
 
 
 def get_title_short(title):

--- a/latextools_utils/bibformat.py
+++ b/latextools_utils/bibformat.py
@@ -1,0 +1,135 @@
+from string import Formatter
+import collections
+import re
+
+
+TITLE_SEP = re.compile(':|\.|\?')
+
+formatter = Formatter()
+
+
+def format_entry(format_string, entry):
+    return formatter.vformat(format_string, (), CompletionWrapper(entry))
+
+
+def format_entries(format_string, entries):
+    return [formatter.vformat(format_string, (), CompletionWrapper(entry))
+            for entry in entries]
+
+
+def get_title_short(title):
+    title = TITLE_SEP.split(title)[0]
+    if len(title) > 60:
+        title = title[:60] + '...'
+    return title
+
+
+# default implementation that convers the author field into a short
+# version of itself assumes we get a basically raw LaTeX string,
+# e.g. "Lastname, Firstname and Otherlastname, Otherfirstname"
+def get_author_short(authors):
+    if authors == '':
+        return ''
+
+    # split authors using ' and ' and get last name for 'last, first' format
+    authors = [a.split(", ")[0].strip(' ') for a in authors.split(" and ")]
+    # get last name for 'first last' format (preserve {...} text)
+    authors = [a.split(" ")[-1] if not('{' in a and a.endswith('}'))
+               else re.sub(r'{|}', '', a[a.rindex('{') + 1:-1])
+               for a in authors if len(a) > 0]
+
+    # truncate and add 'et al.'
+    if len(authors) > 2:
+        authors = authors[0] + " et al."
+    else:
+        authors = ' & '.join(authors)
+
+    # return formated string
+    return authors
+
+
+class CompletionWrapper(collections.Mapping):
+    '''
+    Wraps the returned completions so that we can properly handle any
+    KeyErrors that occur
+    '''
+    def __init__(self, entry):
+        self._entry = entry
+
+    def __getitem__(self, key):
+        try:
+            # emulating previous behaviour of latex_cite_completions
+            if key not in ('author', 'journal'):
+                return self._entry[key]
+            else:
+                value = self._entry[key]
+                return value or u'????'
+        except KeyError:
+            if key[0] == "<":
+                raise
+            elif key == 'keyword':
+                try:
+                    return self._entry['citekey']
+                except KeyError:
+                    pass
+            elif key == 'author':
+                try:
+                    return self._entry['editor']
+                except KeyError:
+                    pass
+            elif key == 'author_short':
+                try:
+                    return get_author_short(self._entry['author'])
+                except KeyError:
+                    pass
+
+                return self['editor_short']
+            elif key == 'editor_short':
+                try:
+                    return get_author_short(self._entry['editor'])
+                except KeyError:
+                    pass
+            elif key == 'title_short':
+                try:
+                    return self._entry['shorttitle']
+                except KeyError:
+                    pass
+
+                try:
+                    return get_title_short(self._entry['title'])
+                except KeyError:
+                    pass
+            elif key == 'journal':
+                try:
+                    return self._entry['journaltitle']
+                except KeyError:
+                    pass
+
+                try:
+                    return self._entry['eprint']
+                except KeyError:
+                    pass
+            elif key == 'year':
+                try:
+                    date = self._entry['date']
+                    date_matcher = re.match(r'(\d{4})', date)
+                    if date_matcher:
+                        return date_matcher.group(1)
+                except KeyError:
+                    pass
+            elif key == 'month':
+                try:
+                    date = self._entry['date']
+                    date_matcher = re.match(r'\d{4}-(\d{2})', date)
+                    if date_matcher:
+                        return date_matcher.group(1)
+                except KeyError:
+                    pass
+
+            return u'????'
+
+    def __iter__(self):
+        return iter(self._entry)
+
+    def __len__(self):
+        return len(self._entry)

--- a/latextools_utils/cache.py
+++ b/latextools_utils/cache.py
@@ -41,6 +41,20 @@ class CacheMiss(Exception):
     pass
 
 
+def hash_digest(text):
+    """
+    Create the hash digest for a text. These digest can be used to
+    create a unique filename from the path to the root file.
+    The used has function is md5.
+
+    Arguments:
+    text -- the text for which the digest should be created
+    """
+    text_encoded = text.encode("utf8")
+    hash_result = hashlib.md5(text_encoded)
+    return hash_result.hexdigest()
+
+
 def delete_local_cache(tex_root):
     """
     Removes the local cache folder and the local cache files
@@ -226,9 +240,7 @@ def _local_cache_path(tex_root):
     else:
         cache_path = _hidden_local_cache_path()
         # convert the root to plain string and hash it
-        tex_root = tex_root.encode("utf8")
-        root_hash = hashlib.md5(tex_root)
-        root_hash = root_hash.hexdigest()
+        root_hash = hash_digest(tex_root)
         return os.path.join(cache_path, root_hash)
 
 
@@ -261,7 +273,7 @@ def _write(cache_path, name, obj):
 
     file_path = os.path.join(cache_path, name)
     with open(file_path, "wb") as f:
-        pickle.dump(obj, f)
+        pickle.dump(obj, f, protocol=-1)
 
 
 def _read(cache_path, name):


### PR DESCRIPTION
This has been discussed in https://github.com/SublimeText/LaTeXTools/pull/759.

This PR adds a special caching behavior, which improves the performance of cite completions.

Two modules are added:

- `bibformat`: Utility module for formating cite completion strings
- `bibcache`: The core of this PR. A special cache for bib files.

Before caching the `bibcache` module calculates the formating strings for the cite panel and the cite autocompletion.
These results are stored in a new dict under the keys `<panel_formatted>` and `<autocomplete_formatted>`. In addition this dict keeps important keys and will be cached and given to the completion.

The completion will be check and use the preformatted entry, if a special key is present. Otherwise it will work as before. Hence it is fully backward compatible with all bibliographies.

PS:
For prefix match a match string is created and stored under the special key `<prefix_match>`.

TODO:

- [x] some small additional performance improvements
- [x] keep fields, which are needed in cite completion (for prefix match)
- [x] ST2 compatibility
- [x] doc strings for bibcache