### PR TITLE
Add a setting to control whether or not to launch PDF viewer on build

### DIFF
--- a/LaTeXTools.sublime-settings
+++ b/LaTeXTools.sublime-settings
@@ -368,6 +368,12 @@
 		}
 	},
 
+	// OPTION: "open_pdf_on_build"
+	// specifies whether LaTeXTools should open the PDF file on a
+	// successful build. If set to false, the PDF file won't be opened
+	// unless explicitly launched using C-l,v or C-l,j
+	"open_pdf_on_build": true,
+
 // ------------------------------------------------------------------
 // Opening files included into the tex source code
 // ------------------------------------------------------------------

--- a/README.markdown
+++ b/README.markdown
@@ -564,6 +564,7 @@ NOTE: for the time being, you will need to refer to the `LaTeXTools.sublime-sett
 
  * `viewer` (`""`): the viewer you want to use. Leave blank (`""`) or set to `"default"`for the platform-specific viewer. Can also be set to `"preview"` if you want to use Preview on OS X, `"okular"` if you want to use Okular on Linux, `"zathura"` is you want to use Zathura on Linux, or `"command"` to run arbitrary commands. For details on the `"command"` option, see the section on the [Command Viewer](#command-viewer).
  * `viewer_settings`: these are viewer-specific settings. Please see the section on [Viewers](#viewers) or the documentation on [Alternate Viewers](#alternate-viewers) for details of what should be set here.
+ * `open_pdf_on_build` (`true`): Controls whether LaTeXTools will automatically open the configured PDF viewer on a successful build. If set to `false`, the PDF viewer will only be launched if explicitly requested using `C-l,v` or `C-l,j`.
 
 ### Bibliographic references settings
 

--- a/makePDF.py
+++ b/makePDF.py
@@ -630,7 +630,8 @@ class make_pdfCommand(sublime_plugin.WindowCommand):
 							os.path.dirname(self.file_name)
 						)
 
-			self.view.run_command("jump_to_pdf", {"from_keybinding": False})
+			if get_setting('open_pdf_on_build', True):
+				self.view.run_command("jump_to_pdf", {"from_keybinding": False})
 
 
 class DoOutputEditCommand(sublime_plugin.TextCommand):


### PR DESCRIPTION
This feature is occasionally requested (e.g. #463, #668) and, more broadly, I can see the need for something like this in certain circumstances, e.g., if you don't care about moving to a particular position in the PDF and your viewer already supports automatic updates when the PDF file is changed. Plus, the implementation is very simple.