### PR TITLE
Improve `subfile` support

### DIFF
--- a/LaTeXTools (Advanced).sublime-settings
+++ b/LaTeXTools (Advanced).sublime-settings
@@ -75,6 +75,12 @@
 	//		after commas (,)
 	"fillall_helper_entries": [
 		{
+			// subfile
+			"regex": "elifbus\\\\",
+			"extensions": ["tex"],
+			"strip_extensions": [".tex"]
+		},
+		{
 			// includesvg
 			"regex": "(?:\\][^{}\\[\\]]*\\[)?gvsedulcni\\\\",
 			"extensions": ["svg"],

--- a/latex_cite_completions.py
+++ b/latex_cite_completions.py
@@ -266,7 +266,7 @@ def find_bib_files(rootdir, src, bibfiles):
             bibfiles.append(candidate_file)
 
     # search through input tex files recursively
-    for f in re.findall(r'\\(?:input|include)\{[^\}]+\}',src_content):
+    for f in re.findall(r'\\(?:input|include|subfile)\{[^\}]+\}',src_content):
         input_f = re.search(r'\{([^\}]+)', f).group(1)
         find_bib_files(rootdir, input_f, bibfiles)
 

--- a/latex_ref_completions.py
+++ b/latex_ref_completions.py
@@ -99,7 +99,7 @@ def find_labels_in_files(rootdir, src, labels):
     labels += re.findall(r'\\label\{([^{}]+)\}', src_content)
 
     # search through input tex files recursively
-    for f in re.findall(r'\\(?:input|include)\{([^\{\}]+)\}', src_content):
+    for f in re.findall(r'\\(?:input|include|subfile)\{([^\{\}]+)\}', src_content):
         find_labels_in_files(rootdir, f, labels)
 
 


### PR DESCRIPTION
This improves the support for package subfile as requested in https://github.com/SublimeText/LaTeXTools/issues/670

It does not add a full support for the package, but improves it. It does

- add fillall helper if you type `\subfile{`
- adds labels defined in subfiles
- adds bibfiles from subfiles
