### PR TITLE
Add variants for different build configurations

### DIFF
--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -7,12 +7,12 @@ LaTeX Package keymap for Linux
 	{	"keys": ["ctrl+b"],
 		"context": [
 			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"},
-			{"key": "ltt_st_build", "operator": "regex_match", "operand": "2|30[0-7]"}],
+			{"key": "ltt_st_build", "operator": "equal", "operand": "<3080"}],
 		"command": "latextools_build_selector"},
 	{	"keys": ["ctrl+shift+b"],
 		"context": [
 			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"},
-			{"key": "ltt_st_build", "operator": "regex_match", "operand": "2|30[0-7]"}],
+			{"key": "ltt_st_build", "operator": "equal", "operand": "<3080"}],
 		"command": "latextools_build_selector",
 			"args": {"select": true}},
 

--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -6,11 +6,13 @@ LaTeX Package keymap for Linux
 	// it is necessary so on ST2 we can implement our build selector
 	{	"keys": ["ctrl+b"],
 		"context": [
-			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"}],
+			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"},
+			{"key": "ltt_st_build", "operator": "regex_match", "operand": "2|30[1-7]"}],
 		"command": "latextools_build_selector"},
 	{	"keys": ["ctrl+shift+b"],
 		"context": [
-			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"}],
+			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"},
+			{"key": "ltt_st_build", "operator": "regex_match", "operand": "2|30[1-7]"}],
 		"command": "latextools_build_selector",
 			"args": {"select": true}},
 

--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -2,6 +2,17 @@
 LaTeX Package keymap for Linux
 */
 [
+	// these also override ST3 commands, but we simply run the same commands
+	// it is necessary so on ST2 we can implement our build selector
+	{	"keys": ["ctrl+b"],
+		"context": [
+			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"}],
+		"command": "latextools_build_selector"},
+	{	"keys": ["ctrl+shift+b"],
+		"context": [
+			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"}],
+		"command": "latextools_build_selector",
+			"args": {"select": true}},
 
 	// New-style keybindings use "ctrl+l" as a prefix
 	// This overrides "extend selection to line", which is remapped to

--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -7,12 +7,12 @@ LaTeX Package keymap for Linux
 	{	"keys": ["ctrl+b"],
 		"context": [
 			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"},
-			{"key": "ltt_st_build", "operator": "regex_match", "operand": "2|30[1-7]"}],
+			{"key": "ltt_st_build", "operator": "regex_match", "operand": "2|30[0-7]"}],
 		"command": "latextools_build_selector"},
 	{	"keys": ["ctrl+shift+b"],
 		"context": [
 			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"},
-			{"key": "ltt_st_build", "operator": "regex_match", "operand": "2|30[1-7]"}],
+			{"key": "ltt_st_build", "operator": "regex_match", "operand": "2|30[0-7]"}],
 		"command": "latextools_build_selector",
 			"args": {"select": true}},
 

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -7,12 +7,12 @@ LaTeX Package keymap for OS X
 	{	"keys": ["super+b"],
 		"context": [
 			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"},
-			{"key": "ltt_st_build", "operator": "regex_match", "operand": "2|30[0-7]"}],
+			{"key": "ltt_st_build", "operator": "equal", "operand": "<3080"}],
 		"command": "latextools_build_selector"},
 	{	"keys": ["super+shift+b"],
 		"context": [
 			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"},
-			{"key": "ltt_st_build", "operator": "regex_match", "operand": "2|30[0-7]"}],
+			{"key": "ltt_st_build", "operator": "equal", "operand": "<3080"}],
 		"command": "latextools_build_selector",
 			"args": {"select": true}},
 

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -2,6 +2,17 @@
 LaTeX Package keymap for OS X
 */
 [
+	// these also override ST3 commands, but we simply run the same commands
+	// it is necessary so on ST2 we can implement our build selector
+	{	"keys": ["super+b"],
+		"context": [
+			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"}],
+		"command": "latextools_build_selector"},
+	{	"keys": ["super+shift+b"],
+		"context": [
+			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"}],
+		"command": "latextools_build_selector",
+			"args": {"select": true}},
 
 	// New-style keybindings use "cmd+l" as a prefix
 	// This overrides "extend selection to line", which is remapped to

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -6,11 +6,13 @@ LaTeX Package keymap for OS X
 	// it is necessary so on ST2 we can implement our build selector
 	{	"keys": ["super+b"],
 		"context": [
-			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"}],
+			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"},
+			{"key": "ltt_st_build", "operator": "regex_match", "operand": "2|30[1-7]"}],
 		"command": "latextools_build_selector"},
 	{	"keys": ["super+shift+b"],
 		"context": [
-			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"}],
+			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"},
+			{"key": "ltt_st_build", "operator": "regex_match", "operand": "2|30[1-7]"}],
 		"command": "latextools_build_selector",
 			"args": {"select": true}},
 

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -7,12 +7,12 @@ LaTeX Package keymap for OS X
 	{	"keys": ["super+b"],
 		"context": [
 			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"},
-			{"key": "ltt_st_build", "operator": "regex_match", "operand": "2|30[1-7]"}],
+			{"key": "ltt_st_build", "operator": "regex_match", "operand": "2|30[0-7]"}],
 		"command": "latextools_build_selector"},
 	{	"keys": ["super+shift+b"],
 		"context": [
 			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"},
-			{"key": "ltt_st_build", "operator": "regex_match", "operand": "2|30[1-7]"}],
+			{"key": "ltt_st_build", "operator": "regex_match", "operand": "2|30[0-7]"}],
 		"command": "latextools_build_selector",
 			"args": {"select": true}},
 

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -7,12 +7,12 @@ LaTeX Package keymap for Windows
 	{	"keys": ["ctrl+b"],
 		"context": [
 			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"},
-			{"key": "ltt_st_build", "operator": "regex_match", "operand": "2|30[0-7]"}],
+			{"key": "ltt_st_build", "operator": "equal", "operand": "<3080"}],
 		"command": "latextools_build_selector"},
 	{	"keys": ["ctrl+shift+b"],
 		"context": [
 			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"},
-			{"key": "ltt_st_build", "operator": "regex_match", "operand": "2|30[0-7]"}],
+			{"key": "ltt_st_build", "operator": "equal", "operand": "<3080"}],
 		"command": "latextools_build_selector",
 			"args": {"select": true}},
 

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -6,11 +6,13 @@ LaTeX Package keymap for Windows
 	// it is necessary so on ST2 we can implement our build selector
 	{	"keys": ["ctrl+b"],
 		"context": [
-			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"}],
+			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"},
+			{"key": "ltt_st_build", "operator": "regex_match", "operand": "2|30[1-7]"}],
 		"command": "latextools_build_selector"},
 	{	"keys": ["ctrl+shift+b"],
 		"context": [
-			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"}],
+			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"},
+			{"key": "ltt_st_build", "operator": "regex_match", "operand": "2|30[1-7]"}],
 		"command": "latextools_build_selector",
 			"args": {"select": true}},
 

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -2,6 +2,17 @@
 LaTeX Package keymap for Windows
 */
 [
+	// these also override ST3 commands, but we simply run the same commands
+	// it is necessary so on ST2 we can implement our build selector
+	{	"keys": ["ctrl+b"],
+		"context": [
+			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"}],
+		"command": "latextools_build_selector"},
+	{	"keys": ["ctrl+shift+b"],
+		"context": [
+			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"}],
+		"command": "latextools_build_selector",
+			"args": {"select": true}},
 
 	// New-style keybindings use "ctrl+l" as a prefix
 	// This overrides "extend selection to line", which is remapped to

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -7,12 +7,12 @@ LaTeX Package keymap for Windows
 	{	"keys": ["ctrl+b"],
 		"context": [
 			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"},
-			{"key": "ltt_st_build", "operator": "regex_match", "operand": "2|30[1-7]"}],
+			{"key": "ltt_st_build", "operator": "regex_match", "operand": "2|30[0-7]"}],
 		"command": "latextools_build_selector"},
 	{	"keys": ["ctrl+shift+b"],
 		"context": [
 			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"},
-			{"key": "ltt_st_build", "operator": "regex_match", "operand": "2|30[1-7]"}],
+			{"key": "ltt_st_build", "operator": "regex_match", "operand": "2|30[0-7]"}],
 		"command": "latextools_build_selector",
 			"args": {"select": true}},
 

--- a/LaTeX.sublime-build
+++ b/LaTeX.sublime-build
@@ -25,5 +25,51 @@
 	"linux":
 		{
 			"file_regex": "^(...*?):([0-9]+): ([0-9]*)([^\\.]+)"
+		},
+
+	"variants":
+	[
+		{
+			"name": "Traditional",
+			"builder": "traditional"
+		},
+		{
+			"name": "PdfLaTeX",
+			"builder": "traditional",
+			"program": "pdflatex"
+		},
+		{
+			"name": "XeLaTeX",
+			"builder": "traditional",
+			"program": "xelatex"
+		},
+		{
+			"name": "LuaLaTeX",
+			"builder": "traditional",
+			"program": "lualatex"
+		},
+		{
+			"name": "Basic Builder",
+			"builder": "basic"
+		},
+		{
+			"name": "Basic Builder - PdfLaTeX",
+			"builder": "basic",
+			"program": "pdflatex"
+		},
+		{
+			"name": "Basic Builder - XeLaTeX",
+			"builder": "basic",
+			"program": "xelatex"
+		},
+		{
+			"name": "Basic Builder - LuaLaTeX",
+			"builder": "basic",
+			"program": "lualatex"
+		},
+		{
+			"name": "Script Builder",
+			"builder": "script"
 		}
+	]
 }

--- a/README.markdown
+++ b/README.markdown
@@ -868,6 +868,7 @@ Otherwise, other features may not work as expected. In addition, you can specify
 |`command`|Overrides the `command` setting, providing the command run by the builder. This is only useful if you use the `traditional` builder. For the format, see the relevant [builder setting](#builder-settings).|
 |`env`|Overrides the `env` setting. Should be a dictionary similar to `env`, but note that when specified in a `.sublime-build` file, it is not, by default, platform-specific.|
 |`path`|Overrides the `texpath` settings. Note that if you set this, you are responsible for ensuring that the appropriate LaTeX install can still be found.|
+|`script_commands`|Overrides the `script_commands` setting used by the `script` builder. This is only useful if the `builder` is also changed to `script`.|
 
 ### Custom Builders
 

--- a/README.markdown
+++ b/README.markdown
@@ -286,8 +286,17 @@ The default ST Build command takes care of the following:
 * It parses the tex log file and lists all errors, warnings and, if enabled, bad boxes in an output panel at the bottom of the ST window: click on any error/warning/bad boxes to jump to the corresponding line in the text, or use the ST-standard Next Error/Previous Error commands.
 * It invokes the PDF viewer for your platform and performs a forward search: that is, it displays the PDF page where the text corresponding to the current cursor position is located.
 
+### Selecting Build Variant
 
-### Toggling window focus following a build
+**Keybinding:** `C-shift-b` (standard ST3 keybinding)
+
+LaTeXTools offers a range of build variants to select standard build options. These variants can be used to customize the options passed to the LaTeXTools builder, so that you don't need a project file or to use any of the `%!TEX` directives to change, e.g., the build system used. Variants are provided for the supported builders and for the supported programs.
+
+In addition, custom Sublime build files can be created to add your own variants to standard LaTeXTools commands. For more on this, see the section on [Sublime Build Files](#sublime-build-files).
+
+**Note**: The settings provided by build variants *override* settings specified in the file itself or in your settings. This means, for example, if you select a build variant that changes the program, `%!TEX program` directives or `program` settings will be ignored. If you want to return LaTeXTools back to its default behavior, please select the **LaTeX** build variant.
+
+### Toggling window focus following a build ###
 
 **Keybinding:** `C-l,t,f` (yes, this means `C-l`, then `t`, then `f`)
 
@@ -822,7 +831,45 @@ In addition, to ensure that forward and backward sync work, you need to ensure t
 
 Finally, please remember that script commands on Windows are run using `cmd.exe` which means that if your script uses any UNC paths will have to use `pushd` and `popd` to properly map and unmap a network drive.
 
-### Customizing the Build System
+### Sublime Build Files
+
+LaTeXTools now has some support for custom `.sublime-build` files or builders specified in your project settings. For an overview of `.sublime-build` files in general, please see [the Unofficial Documentation](http://sublime-text-unofficial-documentation.readthedocs.io/en/latest/reference/build_systems.html) (which is generally a great resource about Sublime Text). For more on adding builders to project files, see [the relevant section of the Sublime documentation](https://www.sublimetext.com/docs/3/projects.html). This section will cover the basics of creating a `.sublime-build` file that works with LaTeXTools.
+
+At a minimum, your `.sublime-build` file must have the following elements:
+
+```json
+{
+	"target": "make_pdf",
+	"selector": "text.tex.latex",
+
+	"osx":
+		{
+			"file_regex": "^(...*?):([0-9]+): ([0-9]*)([^\\.]+)"
+		},
+
+	"windows":
+		{
+			"file_regex": "^((?:.:)?[^:\n\r]*):([0-9]+):?([0-9]+)?:? (.*)$"
+		},
+
+	"linux":
+		{
+			"file_regex": "^(...*?):([0-9]+): ([0-9]*)([^\\.]+)"
+		}
+}
+```
+
+Otherwise, other features may not work as expected. In addition, you can specify the following other parameters:
+
+|Parameter|Description|
+|-----------------|------------------------------------------------------------|
+|`builder`|Overrides the `builder` setting. May refer to any valid LaTeXTools builder.|
+|`program`|Overrides the `program` setting or `%!TEX program` macro. May be one of `pdflatex`, `xelatex`, or `lualatex`|
+|`command`|Overrides the `command` setting, providing the command run by the builder. This is only useful if you use the `traditional` builder. For the format, see the relevant [builder setting](#builder-settings).|
+|`env`|Overrides the `env` setting. Should be a dictionary similar to `env`, but note that when specified in a `.sublime-build` file, it is not, by default, platform-specific.|
+|`path`|Overrides the `texpath` settings. Note that if you set this, you are responsible for ensuring that the appropriate LaTeX install can still be found.|
+
+### Custom Builders
 
 Since the release on March 13, 2014 ([v3.1.0](https://github.com/SublimeText/LaTeXTools/tree/v3.1.0)), LaTeXTools has had support for custom build systems, in addition to the default build system, called the "traditional" builder. Details on how to customize the traditional builder are documented above. If neither the traditional builder nor the script builder meet your needs you can also create a completely custom builder which should be able to support just about anything you can imagine. Let me know if you are interested in writing a custom builder!
 

--- a/builders/traditionalBuilder.py
+++ b/builders/traditionalBuilder.py
@@ -4,10 +4,13 @@ import sublime
 if sublime.version() < '3000':
 	# we are on ST2 and Python 2.X
 	_ST3 = False
+	strbase = basestring
 else:
 	_ST3 = True
+	strbase = str
 
 from pdfBuilder import PdfBuilder
+import shlex
 
 DEBUG = False
 
@@ -29,25 +32,25 @@ class TraditionalBuilder(PdfBuilder):
 	def __init__(self, *args):
 		# Sets the file name parts, plus internal stuff
 		super(TraditionalBuilder, self).__init__(*args)
-		#Now do our own initialization: set our name
+		# Now do our own initialization: set our name
 		self.name = "Traditional Builder"
 		# Display output?
 		self.display_log = self.builder_settings.get("display_log", False)
 		# Build command, with reasonable defaults
 		plat = sublime.platform()
 		# Figure out which distro we are using
-		try:
-			distro = self.platform_settings["distro"]
-		except KeyError: # default to miktex on windows and texlive elsewhere
-			if plat == 'windows':
-				distro = "miktex"
-			else:
-				distro = "texlive"
+		distro = self.platform_settings.get(
+			"distro",
+			"miktex" if plat == "windows" else "texlive"
+		)
 		if distro in ["miktex", ""]:
 			default_command = DEFAULT_COMMAND_WINDOWS_MIKTEX
-		else: # osx, linux, windows/texlive, everything else really!
+		else:  # osx, linux, windows/texlive, everything else really!
 			default_command = DEFAULT_COMMAND_LATEXMK
+
 		self.cmd = self.builder_settings.get("command", default_command)
+		if isinstance(self.cmd, strbase):
+			self.cmd = shlex.split(self.cmd)
 
 	#
 	# Very simple here: we yield a single command
@@ -59,7 +62,7 @@ class TraditionalBuilder(PdfBuilder):
 
 		# See if the root file specifies a custom engine
 		engine = self.engine
-		cmd = self.cmd[:] # Warning! If I omit the [:], cmd points to self.cmd!
+		cmd = self.cmd[:]  # Warning! If I omit the [:], cmd points to self.cmd!
 
 		# check if the command even wants the engine selected
 		engine_used = False

--- a/latextools_sublime_version_listener.py
+++ b/latextools_sublime_version_listener.py
@@ -3,6 +3,7 @@ from __future__ import print_function
 import sublime
 import sublime_plugin
 
+import operator as opi
 import re
 
 VERSION = sublime.version()
@@ -35,10 +36,23 @@ class LatextoolsSublimeVersionEventListener(sublime_plugin.EventListener):
             return None
 
     def _equal(self, operand):
-        return VERSION == operand
+        # if the operand starts with <, >, <=, >=, (=, or ==)
+        # change the compare operator correspondingly and strip the operand
+        if operand[0:1] in "<>=":
+            i = 1 if operand[1:2] != "=" else 2
+            comp_str, operand = operand[:i], operand[i:]
+            compare = {
+                "<": opi.lt,
+                ">": opi.gt,
+                "<=": opi.le,
+                ">=": opi.ge
+            }.get(comp_str, opi.eq)
+        else:
+            compare = opi.eq
+        return compare(VERSION, operand.strip())
 
     def _not_equal(self, operand):
-        return VERSION != operand
+        return not self._equal(operand)
 
     def _regex_match(self, operand):
         return re.match(operand, VERSION, re.UNICODE) is not None

--- a/latextools_sublime_version_listener.py
+++ b/latextools_sublime_version_listener.py
@@ -1,0 +1,53 @@
+from __future__ import print_function
+
+import sublime
+import sublime_plugin
+
+import re
+
+VERSION = sublime.version()
+
+
+class LatextoolsSublimeVersionEventListener(sublime_plugin.EventListener):
+
+    def __init__(self, *args, **kwargs):
+        super(LatextoolsSublimeVersionEventListener, self).__init__(
+            *args, **kwargs
+        )
+
+        self.ops = {
+            sublime.OP_EQUAL: self._equal,
+            sublime.OP_NOT_EQUAL: self._not_equal,
+            sublime.OP_REGEX_MATCH: self._regex_match,
+            sublime.OP_NOT_REGEX_MATCH: self._not_regex_match,
+            sublime.OP_REGEX_CONTAINS: self._regex_contains,
+            sublime.OP_NOT_REGEX_CONTAINS: self._not_regex_contains
+        }
+
+    def on_query_context(self, view, key, operator, operand, match_all):
+        if not key == 'ltt_st_build':
+            return None
+
+        try:
+            return self.ops[operator](operand)
+        # caution
+        except KeyError:
+            return None
+
+    def _equal(self, operand):
+        return VERSION == operand
+
+    def _not_equal(self, operand):
+        return VERSION != operand
+
+    def _regex_match(self, operand):
+        return re.match(operand, VERSION, re.UNICODE) is not None
+
+    def _not_regex_match(self, operand):
+        return re.match(operand, VERSION, re.UNICODE) is None
+
+    def _regex_contains(self, operand):
+        return re.search(operand, VERSION, re.UNICODE) is not None
+
+    def _not_regex_contains(self, operand):
+        return re.search(operand, VERSION, re.UNICODE) is None

--- a/latextools_utils/sublime_utils.py
+++ b/latextools_utils/sublime_utils.py
@@ -18,6 +18,8 @@ except ImportError:
 
 __all__ = ['normalize_path', 'get_project_file_name']
 
+_ST3 = sublime.version() >= '3000'
+
 # used by get_sublime_exe()
 SUBLIME_VERSION = re.compile(r'Build (\d{4})', re.UNICODE)
 
@@ -309,7 +311,7 @@ QUOTE = re.compile(r'(?<![^\\]\\)"')
 NEWLINE = re.compile(r'\r?\n')
 
 
-def parse_json_with_comments(filename):
+def _parse_json_with_comments(filename):
     with codecs.open(filename, 'r', 'utf-8', 'ignore') as f:
         content = f.read()
 
@@ -365,3 +367,12 @@ def parse_json_with_comments(filename):
         new_content.append(content[index:])
 
     return json.loads(''.join(new_content))
+
+
+if _ST3:
+    def parse_json_with_comments(filename):
+        with codecs.open(filename, 'r', 'utf-8', 'ignore') as f:
+            content = f.read()
+        return sublime.decode_value(content)
+else:
+    parse_json_with_comments = _parse_json_with_comments

--- a/latextools_utils/sublime_utils.py
+++ b/latextools_utils/sublime_utils.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
 
+import codecs
 import json
 import os
 import re
@@ -8,11 +9,11 @@ import subprocess
 import sys
 
 try:
-	from latextools_utils.settings import get_setting
-	from latextools_utils.system import which
+    from latextools_utils.settings import get_setting
+    from latextools_utils.system import which
 except ImportError:
-	from .settings import get_setting
-	from .system import which
+    from .settings import get_setting
+    from .system import which
 
 
 __all__ = ['normalize_path', 'get_project_file_name']
@@ -20,18 +21,19 @@ __all__ = ['normalize_path', 'get_project_file_name']
 # used by get_sublime_exe()
 SUBLIME_VERSION = re.compile(r'Build (\d{4})', re.UNICODE)
 
+
 # normalizes the paths stored in sublime session files on Windows
 # from:
 #     /c/path/to/file.ext
 # to:
 #     c:\path\to\file.ext
 def normalize_path(path):
-	if sublime.platform() == 'windows':
-		return os.path.normpath(
-			path.lstrip('/').replace('/', ':/', 1)
-		)
-	else:
-		return path
+    if sublime.platform() == 'windows':
+        return os.path.normpath(
+            path.lstrip('/').replace('/', ':/', 1)
+        )
+    else:
+        return path
 
 
 # returns the path to the sublime executable
@@ -200,102 +202,166 @@ def get_sublime_exe():
 
 
 def get_project_file_name(view):
-	try:
-		return view.window().project_file_name()
-	except AttributeError:
-		return _get_project_file_name(view)
+    try:
+        return view.window().project_file_name()
+    except AttributeError:
+        return _get_project_file_name(view)
 
 
 # long, complex hack for ST2 to load the project file from the current session
 def _get_project_file_name(view):
-	try:
-		window_id = view.window().id()
-	except AttributeError:
-		print('Could not determine project file as view does not seem to have an associated window.')
-		return None
+    try:
+        window_id = view.window().id()
+    except AttributeError:
+        print('Could not determine project file as view does not seem to have an associated window.')
+        return None
 
-	if window_id is None:
-		return None
+    if window_id is None:
+        return None
 
-	session = os.path.normpath(
-		os.path.join(
-			sublime.packages_path(),
-			'..',
-			'Settings',
-			'Session.sublime_session'
-		)
-	)
+    session = os.path.normpath(
+        os.path.join(
+            sublime.packages_path(),
+            '..',
+            'Settings',
+            'Session.sublime_session'
+        )
+    )
 
-	auto_save_session = os.path.normpath(
-		os.path.join(
-			sublime.packages_path(),
-			'..',
-			'Settings',
-			'Auto Save Session.sublime_session'
-		)
-	)
+    auto_save_session = os.path.normpath(
+        os.path.join(
+            sublime.packages_path(),
+            '..',
+            'Settings',
+            'Auto Save Session.sublime_session'
+        )
+    )
 
-	session = auto_save_session if os.path.exists(auto_save_session) else session
+    session = auto_save_session if os.path.exists(auto_save_session) else session
 
-	if not os.path.exists(session):
-		return None
+    if not os.path.exists(session):
+        return None
 
-	project_file = None
+    project_file = None
 
-	# we tell that we have found the current project's project file by
-	# looking at the folders registered for that project and comparing it
-	# to the open directorys in the current window
-	found_all_folders = False
-	try:
-		with open(session, 'r') as f:
-			session_data = f.read().replace('\t', ' ')
-		j = json.loads(session_data, strict=False)
-		projects = j.get('workspaces', {}).get('recent_workspaces', [])
+    # we tell that we have found the current project's project file by
+    # looking at the folders registered for that project and comparing it
+    # to the open directorys in the current window
+    found_all_folders = False
+    try:
+        with open(session, 'r') as f:
+            session_data = f.read().replace('\t', ' ')
+        j = json.loads(session_data, strict=False)
+        projects = j.get('workspaces', {}).get('recent_workspaces', [])
 
-		for project_file in projects:
-			found_all_folders = True
+        for project_file in projects:
+            found_all_folders = True
 
-			project_file = normalize_path(project_file)
-			try:
-				with open(project_file, 'r') as fd:
-					project_json = json.loads(fd.read(), strict=False)
+            project_file = normalize_path(project_file)
+            try:
+                with open(project_file, 'r') as fd:
+                    project_json = json.loads(fd.read(), strict=False)
 
-				if 'folders' in project_json:
-					project_folders = project_json['folders']
-					for directory in view.window().folders():
-						found = False
-						for folder in project_folders:
-							folder_path = normalize_path(folder['path'])
-							# handle relative folder paths
-							if not os.path.isabs(folder_path):
-								folder_path = os.path.normpath(
-									os.path.join(os.path.dirname(project_file), folder_path)
-								)
+                if 'folders' in project_json:
+                    project_folders = project_json['folders']
+                    for directory in view.window().folders():
+                        found = False
+                        for folder in project_folders:
+                            folder_path = normalize_path(folder['path'])
+                            # handle relative folder paths
+                            if not os.path.isabs(folder_path):
+                                folder_path = os.path.normpath(
+                                    os.path.join(os.path.dirname(project_file), folder_path)
+                                )
 
-							if folder_path == directory:
-								found = True
-								break
+                            if folder_path == directory:
+                                found = True
+                                break
 
-						if not found:
-							found_all_folders = False
-							break
+                        if not found:
+                            found_all_folders = False
+                            break
 
-					if found_all_folders:
-						break
-			except:
-				found_all_folders = False
-	except:
-		pass
+                    if found_all_folders:
+                        break
+            except:
+                found_all_folders = False
+    except:
+        pass
 
-	if not found_all_folders:
-		project_file = None
+    if not found_all_folders:
+        project_file = None
 
-	if (
-		project_file is None or
-		not project_file.endswith('.sublime-project') or
-		not os.path.exists(project_file)
-	):
-		return None
+    if (
+        project_file is None or
+        not project_file.endswith('.sublime-project') or
+        not os.path.exists(project_file)
+    ):
+        return None
 
-	print('Using project file: %s' % project_file)
-	return project_file
+    print('Using project file: %s' % project_file)
+    return project_file
+
+
+# tokens used to clean-up JSON files
+TOKENIZER = re.compile(r'(?<![^\\]\\)"|(/\*)|(//)|(#)')
+QUOTE = re.compile(r'(?<![^\\]\\)"')
+NEWLINE = re.compile(r'\r?\n')
+
+
+def parse_json_with_comments(filename):
+    with codecs.open(filename, 'r', 'utf-8', 'ignore') as f:
+        content = f.read()
+
+    try:
+        return json.loads(content)
+    except:
+        pass
+
+    # pre-process to strip comments
+    new_content = []
+    index = 0
+
+    content_length = len(content) - 1
+
+    match = TOKENIZER.search(content, index)
+    while match:
+        new_content.append(content[index:match.start()])
+
+        index = match.end()
+        value = match.group()
+
+        if value == '/*':
+            comment_end = content.find('*/', index)
+            if comment_end == -1:
+                # unbalanced comment
+                break
+            else:
+                new_lines = len(content[index:comment_end].split('\n')) - 1
+                new_content.extend(['\n'] * new_lines)
+                index = comment_end + 2
+        elif value == '//' or value == '#':
+            comment_end = NEWLINE.search(content, index)
+            if comment_end:
+                index = comment_end.end()
+            else:
+                break
+        elif value == '"':
+            new_content.append('"')
+            next_quote = QUOTE.search(content, index)
+            if next_quote:
+                new_content.append(content[index:next_quote.end()])
+                index = next_quote.end()
+            else:
+                # unclosed quote; return to generate json error
+                break
+
+        if index < content_length:
+            match = TOKENIZER.search(content, index)
+        else:
+            break
+
+    if index < content_length:
+        new_content.append(content[index:])
+
+    return json.loads(''.join(new_content))

--- a/makePDF.py
+++ b/makePDF.py
@@ -586,7 +586,7 @@ class make_pdfCommand(sublime_plugin.WindowCommand):
 	# parameters
 	def run(
 		self, file_regex="", program=None, builder=None, command=None,
-		env=None, path=None, update_phantoms_only=False,
+		env=None, path=None, script_commands=None, update_phantoms_only=False,
 		hide_phantoms_only=False, **kwargs
 	):
 		if update_phantoms_only:
@@ -752,7 +752,7 @@ class make_pdfCommand(sublime_plugin.WindowCommand):
 		self.output_directory = get_output_directory(self.file_name)
 
 		# Read the env option (platform specific)
-		builder_platform_settings = builder_settings.get(self.plat)
+		builder_platform_settings = builder_settings.get(self.plat, {})
 
 		if env is not None:
 			self.env = env
@@ -782,6 +782,10 @@ class make_pdfCommand(sublime_plugin.WindowCommand):
 			)
 			self.window.run_command('hide_panel', {"panel": "output.latextools"})
 			return
+
+		if builder_name == 'script' and script_commands:
+			builder_platform_settings['script_commands'] = script_commands
+			builder_settings[self.plat] = builder_platform_settings
 
 		print(repr(builder))
 		self.builder = builder(

--- a/makePDF.py
+++ b/makePDF.py
@@ -789,7 +789,7 @@ class make_pdfCommand(sublime_plugin.WindowCommand):
 				"Cannot find builder {0}.\n"
 				"Check your LaTeXTools Preferences".format(builder_name)
 			)
-			self.window.run_command('hide_panel', {"panel": "output.exec"})
+			self.window.run_command('hide_panel', {"panel": "output.latextools"})
 			return
 
 		print(repr(builder))

--- a/makePDF.py
+++ b/makePDF.py
@@ -807,7 +807,9 @@ class make_pdfCommand(sublime_plugin.WindowCommand):
 			self.path = path
 		else:
 			self.path = platform_settings.get('texpath', None)
-		CmdThread(self).start()
+
+		thread = CmdThread(self)
+		thread.start()
 		print(threading.active_count())
 
 		# setup the progress indicator

--- a/makePDF.py
+++ b/makePDF.py
@@ -18,6 +18,9 @@ if sublime.version() < '3000':
 		get_aux_directory, get_output_directory, get_jobname
 	)
 	from latextools_utils.progress_indicator import ProgressIndicator
+	from latextools_utils.sublime_utils import (
+		get_project_file_name, parse_json_with_comments
+	)
 	from latextools_utils.utils import run_on_main_thread
 
 	strbase = basestring
@@ -36,6 +39,9 @@ else:
 		get_aux_directory, get_output_directory, get_jobname
 	)
 	from .latextools_utils.progress_indicator import ProgressIndicator
+	from .latextools_utils.sublime_utils import (
+		get_project_file_name, parse_json_with_comments
+	)
 	from .latextools_utils.utils import run_on_main_thread
 
 	strbase = str
@@ -51,7 +57,10 @@ import subprocess
 import types
 import traceback
 import shutil
+import glob
 import re
+import json
+import codecs
 
 DEBUG = False
 
@@ -75,7 +84,167 @@ def getOEMCP():
     return str(codepage)
 
 
+class LatextoolsBuildSelector(sublime_plugin.WindowCommand):
 
+	# on 3080+, the necessary features are built-in by default
+	if sublime.version() > '3079':
+		def run(self, select=False):
+			select = False if select not in (True, False) else select
+			self.window.run_command('build', {'select': select})
+	# ST2 or ST3 before 3080
+	else:
+		# stores last settings for build
+		WINDOWS = {}
+
+		if _ST3:
+			def load_build_system(self, build_system):
+				build_system = sublime.load_resource(build_system)
+		else:
+			def load_build_system(self, build_system):
+				build_system = os.path.normpath(
+					build_system.replace('Packages', sublime.packages_path())
+				)
+
+				return self.parse_json_with_comments(build_system)
+
+		def run(self, select=False):
+			select = False if select not in (True, False) else select
+			view = self.view = self.window.active_view()
+			if not select:
+				window_settings = self.WINDOWS.get(self.window.id(), {})
+				build_system = window_settings.get('build_system')
+
+				if build_system:
+					build_variant = window_settings.get('build_variant', '')
+					self.run_build(build_system, build_variant)
+					return
+
+			# no previously selected build system or select is True
+			# find all .sublime-build files
+			if _ST3:
+				sublime_build_files = sublime.find_resources('*.sublime-build')
+				project_settings = self.window.project_data()
+			else:
+				sublime_build_files = glob.glob(os.path.join(
+					sublime.packages_path(), '*', '*.sublime-build'
+				))
+				project_file_name = get_project_file_name(view)
+				if project_file_name is not None:
+					try:
+						project_settings = \
+							parse_json_with_comments(project_file_name)
+					except:
+						print('Error parsing project file')
+						traceback.print_exc()
+						project_settings = {}
+				else:
+					project_settings = {}
+
+			builders = []
+			for i, build_system in enumerate(
+				project_settings.get('build_systems', [])
+			):
+				if (
+					'selector' not in build_system or
+					view.score_selector(0, project_settings['selector']) > 0
+				):
+					try:
+						build_system['name']
+					except:
+						print('Could not determine name for build system {0}'.format(
+							build_system
+						))
+						continue
+
+					build_system['index'] = i
+					builders.append(build_system)
+
+			for filename in sublime_build_files:
+				try:
+					sublime_build = parse_json_with_comments(filename)
+				except:
+					print(u'Error parsing file {0}'.format(filename))
+					continue
+
+				if (
+					'selector' not in sublime_build or
+					view.score_selector(0, sublime_build['selector']) > 0
+				):
+					sublime_build['file'] = filename.replace(
+						sublime.packages_path(), 'Packages', 1
+					).replace(os.path.sep, '/')
+
+					sublime_build['name'] = os.path.splitext(
+						os.path.basename(sublime_build['file'])
+					)[0]
+
+					builders.append(sublime_build)
+
+			formatted_entries = []
+			build_system_variants = []
+			for builder in builders:
+				build_system_name = builder['name']
+				build_system_internal_name = builder.get(
+					'index', builder.get('file')
+				)
+
+				formatted_entries.append(build_system_name)
+				build_system_variants.append((build_system_internal_name, ''))
+
+				for variant in builder.get('variants', []):
+					try:
+						formatted_entries.append(
+							"{0} - {1}".format(
+								build_system_name,
+								variant['name']
+							)
+						)
+					except KeyError:
+						continue
+
+					build_system_variants.append(
+						(build_system_internal_name, variant['name'])
+					)
+
+			entries = len(formatted_entries)
+			if entries == 0:
+				self.window.run_command('build')
+			elif entries == 1:
+				build_system, build_variant = build_system_variants[0]
+				self.WINDOWS[self.window.id()] = {
+					'build_system': build_system,
+					'build_variant': build_variant
+				}
+				self.run_build(build_system, build_variant)
+			else:
+				def on_done(index):
+					# cancel
+					if index == -1:
+						return
+
+					build_system, build_variant = build_system_variants[index]
+					self.WINDOWS[self.window.id()] = {
+						'build_system': build_system,
+						'build_variant': build_variant
+					}
+					self.run_build(build_system, build_variant)
+
+				self.window.show_quick_panel(formatted_entries, on_done)
+
+	def run_build(self, build_system, build_variant):
+		if build_system.isdigit():
+			self.window.run_command(
+				'set_build_system', {'index': int(build_system)}
+			)
+		else:
+			self.window.run_command(
+				'set_build_system', {'file': build_system}
+			)
+
+		if build_variant:
+			self.window.run_command('build', {'variant': build_variant})
+		else:
+			self.window.run_command('build')
 
 
 # First, define thread class for async processing
@@ -422,13 +591,13 @@ class make_pdfCommand(sublime_plugin.WindowCommand):
 		self.proc = None
 		self.proc_lock = threading.Lock()
 
-	def run(self,
-			cmd="",
-			file_regex="",
-			path="",
-			update_phantoms_only=False,
-			hide_phantoms_only=False):
-
+	# **kwargs is unused but there so run can safely ignore any unknown
+	# parameters
+	def run(
+		self, file_regex="", program=None, builder=None, command=None,
+		env=None, path=None, update_phantoms_only=False,
+		hide_phantoms_only=False, **kwargs
+	):
 		if update_phantoms_only:
 			if self.show_errors_inline:
 				self.update_phantoms()
@@ -527,18 +696,13 @@ class make_pdfCommand(sublime_plugin.WindowCommand):
 			return
 
 		# Get platform settings, builder, and builder settings
-		platform_settings  = get_setting(self.plat, {})
-		builder_name = get_setting("builder", "traditional")
+		platform_settings = get_setting(self.plat, {})
 		self.display_bad_boxes = get_setting("display_bad_boxes", False)
-		# This *must* exist, so if it doesn't, the user didn't migrate
-		if builder_name is None:
-			sublime.error_message(
-				"LaTeXTools: you need to migrate your preferences. See the README file for instructions."
-			)
-			self.window.run_command(
-				'hide_panel', {"panel": "output.latextools"}
-			)
-			return
+
+		if builder is not None:
+			builder_name = builder
+		else:
+			builder_name = get_setting("builder", "traditional")
 
 		# Default to 'traditional' builder
 		if builder_name in ['', 'default']:
@@ -550,6 +714,10 @@ class make_pdfCommand(sublime_plugin.WindowCommand):
 
 		builder_settings = get_setting("builder_settings", {})
 
+		# override the command
+		if command is not None:
+			builder_settings.set("command", command)
+
 		# parse root for any %!TEX directives
 		tex_directives = parse_tex_directives(
 			self.file_name,
@@ -558,8 +726,13 @@ class make_pdfCommand(sublime_plugin.WindowCommand):
 		)
 
 		# determine the engine
-		engine = tex_directives.get('program',
-			builder_settings.get("program", "pdflatex"))
+		if program is not None:
+			engine = program
+		else:
+			engine = tex_directives.get(
+				'program',
+				builder_settings.get("program", "pdflatex")
+			)
 
 		engine = engine.lower()
 
@@ -589,18 +762,21 @@ class make_pdfCommand(sublime_plugin.WindowCommand):
 
 		# Read the env option (platform specific)
 		builder_platform_settings = builder_settings.get(self.plat)
-		if builder_platform_settings:
+
+		if env is not None:
+			self.env = env
+		elif builder_platform_settings:
 			self.env = builder_platform_settings.get("env", None)
 		else:
 			self.env = None
-
-		# Now actually get the builder
-		builder_path = get_setting("builder_path", "")  # relative to ST packages dir!
 
 		# Safety check: if we are using a built-in builder, disregard
 		# builder_path, even if it was specified in the pref file
 		if builder_name in ['simple', 'traditional', 'script', 'basic']:
 			builder_path = None
+		else:
+			# relative to ST packages dir!
+			builder_path = get_setting("builder_path", "")
 
 		if builder_path:
 			bld_path = os.path.join(sublime.packages_path(), builder_path)
@@ -609,9 +785,11 @@ class make_pdfCommand(sublime_plugin.WindowCommand):
 		try:
 			builder = get_plugin('{0}_builder'.format(builder_name))
 		except NoSuchPluginException:
-			sublime.error_message("Cannot find builder " + builder_name + ".\n" \
-							      "Check your LaTeXTools Preferences")
-			self.window.run_command('hide_panel', {"panel": "output.latextools"})
+			sublime.error_message(
+				"Cannot find builder {0}.\n"
+				"Check your LaTeXTools Preferences".format(builder_name)
+			)
+			self.window.run_command('hide_panel', {"panel": "output.exec"})
 			return
 
 		print(repr(builder))
@@ -630,9 +808,11 @@ class make_pdfCommand(sublime_plugin.WindowCommand):
 
 		# Now get the tex binary path from prefs, change directory to
 		# that of the tex root file, and run!
-		self.path = platform_settings['texpath']
-		thread = CmdThread(self)
-		thread.start()
+		if path is not None:
+			self.path = path
+		else:
+			self.path = platform_settings.get('texpath', None)
+		CmdThread(self).start()
 		print(threading.active_count())
 
 		# setup the progress indicator
@@ -865,6 +1045,7 @@ class DoOutputEditCommand(sublime_plugin.TextCommand):
         self.view.insert(edit, self.view.size(), data)
         if selection_was_at_end:
             self.view.show(self.view.size())
+
 
 class DoFinishEditCommand(sublime_plugin.TextCommand):
     def run(self, edit):


### PR DESCRIPTION
This adds a few build variants for some simple configurations and, more importantly, adds a way for custom `.sublime-build` files to override build settings.

Basically, this allows us to implement something not far off what was requested in #255:

<img width="395" alt="screen shot" src="https://cloud.githubusercontent.com/assets/212893/16897588/e856cdc6-4bad-11e6-86d3-38c514a95254.png">

This menu can be brought up by pressing `C-shift-b`. On ST3, after build 3080, this is, of course, simply the default behaviour. However, I've back-ported something similar for earlier versions of ST3 and for ST2. The chosen build variant will persist across builds, but can be reset by choosing the **LaTeX** variant, which is simply the default configuration. (The functionality isn't *exactly* the same, but it's quite close; the main difference is that the selected build is *not* saved across windows or persisted after the application closes).

The other thing this allows is for us to support the request in #743 (see [my comment in that thread](https://github.com/SublimeText/LaTeXTools/issues/743#issuecomment-225304102)). More specifically, the following options can be provided by a `.sublime-build` file:

* `program`
* `builder`
* `command`
* `env`
* `path`

These, if provided, will override the corresponding settings, including the `%!TEX program = ...` magic comment.

We can always add more options if requested, but I thought this was a good starting point.