### PR TITLE
Add ability to jump to the root from magic comment

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -414,6 +414,7 @@ This is an IDE-like mouse navigation, which executes a jump depending on the con
 - Jump to referenced labels (e.g. `\ref`)
 - Jump to citation entries in bibliography files (e.g. `\cite`)
 - Open included files (e.g. `\input` or `\include`)
+- Open root file from `%!TEX root =...` magic comment
 - Open bibliographies (e.g. `\bibliography` or `\addbibresource`)
 - Open included graphics with a specified program (e.g. `\includegraphics`)
 - Open the documentation of used packages (e.g. `\usepackage`)


### PR DESCRIPTION
Redux of #761, but using `jumpto_anywhere` and with no fancy processing. Obviously only workable if the file has been saved to disk.