### PR TITLE
Hide commands if not in LaTeX files

### DIFF
--- a/delete_temp_files.py
+++ b/delete_temp_files.py
@@ -38,6 +38,10 @@ class ClearLocalLatexCacheCommand(sublime_plugin.WindowCommand):
 
 
 class DeleteTempFilesCommand(sublime_plugin.WindowCommand):
+	def is_visible(self, *args):
+		view = self.window.active_view()
+		return bool(view.score_selector(0, "text.tex"))
+
 	def run(self):
 		# Retrieve root file and dirname.
 		view = self.window.active_view()

--- a/jumpToPDF.py
+++ b/jumpToPDF.py
@@ -117,6 +117,10 @@ def focus_st():
 # Jump to current line in PDF file
 # NOTE: must be called with {"from_keybinding": <boolean>} as arg
 class JumpToPdf(sublime_plugin.TextCommand):
+	def is_visible(self, *args):
+		view = sublime.active_window().active_view()
+		return bool(view.score_selector(0, "text.tex"))
+
 	def run(self, edit, **args):
 		# Check prefs for PDF focus and sync
 		keep_focus = args.get('keep_focus', get_setting('keep_focus', True))
@@ -209,6 +213,10 @@ class JumpToPdf(sublime_plugin.TextCommand):
 
 
 class ViewPdf(sublime_plugin.WindowCommand):
+	def is_visible(self, *args):
+		view = self.window.active_view()
+		return bool(view.score_selector(0, "text.tex"))
+
 	def run(self, **args):
 		pdffile = None
 		if 'file' in args:

--- a/toggle_show.py
+++ b/toggle_show.py
@@ -23,6 +23,9 @@ def _make_panel_entry(t):
 
 
 class ToggleShowCommand(sublime_plugin.TextCommand):
+    def is_visible(self, *args):
+        view = sublime.active_window().active_view()
+        return bool(view.score_selector(0, "text.tex"))
 
     def run(self, edit, **args):
         view = self.view


### PR DESCRIPTION
This change the visibility of the commands for the command panel `C-Shift-p`. The commands will be invisible if you are not in a LaTeX file.

Currently I just made the command invisible, which are not applicable outside LaTeX files. Remaining command visible should be discussed:

- Reset user settings to default
- Create mousemap in user folder
- Build cache of LaTeX packages
- View package documentation

~~I would at least make the documentation command invisible.~~
