### PR TITLE
ToC section quickpanel

### DIFF
--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -187,7 +187,17 @@ LaTeX Package keymap for Linux
 		"command": "insert_snippet", "args": {"name":"Packages/LaTeXTools/Text monospace.sublime-snippet"}},
 
 
-
+	// Replace the `ctrl+r` overlay with a whole document overlay as opt-out
+	// Also add this overlay to `C-l, C-r`
+	{ "keys": ["ctrl+r"],
+		"context":  [
+			{"key": "selector", "operator": "equal", "operand": "text.tex"},
+			{"key": "overwrite_goto_overlay"}],
+		"command": "latex_toc_quickpanel"},
+	{ "keys": ["ctrl+l","ctrl+r"],
+		"context":  [
+			{"key": "selector", "operator": "equal", "operand": "text.tex"}],
+		"command": "latex_toc_quickpanel"},
 
 
 		// Auto-pair ``$''

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -187,7 +187,17 @@ LaTeX Package keymap for OS X
 		"command": "insert_snippet", "args": {"name":"Packages/LaTeXTools/Text monospace.sublime-snippet"}},
 
 
-
+	// Replace the `ctrl+r` overlay with a whole document overlay as opt-out
+	// Also add this overlay to `C-l, C-r`
+	{ "keys": ["super+r"],
+		"context":  [
+			{"key": "selector", "operator": "equal", "operand": "text.tex"},
+			{"key": "overwrite_goto_overlay"}],
+		"command": "latex_toc_quickpanel"},
+	{ "keys": ["super+l","super+r"],
+		"context":  [
+			{"key": "selector", "operator": "equal", "operand": "text.tex"}],
+		"command": "latex_toc_quickpanel"},
 
 
 		// Auto-pair ``$''

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -187,8 +187,17 @@ LaTeX Package keymap for Windows
 		"command": "insert_snippet", "args": {"name":"Packages/LaTeXTools/Text monospace.sublime-snippet"}},
 
 
-
-
+	// Replace the `ctrl+r` overlay with a whole document overlay as opt-out
+	// Also add this overlay to `C-l, C-r`
+	{ "keys": ["ctrl+r"],
+		"context":  [
+			{"key": "selector", "operator": "equal", "operand": "text.tex"},
+			{"key": "overwrite_goto_overlay"}],
+		"command": "latex_toc_quickpanel"},
+	{ "keys": ["ctrl+l","ctrl+r"],
+		"context":  [
+			{"key": "selector", "operator": "equal", "operand": "text.tex"}],
+		"command": "latex_toc_quickpanel"},
 
 
 		// Auto-pair ``$''

--- a/LaTeXTools (Advanced).sublime-settings
+++ b/LaTeXTools (Advanced).sublime-settings
@@ -1,5 +1,44 @@
 {
 // ------------------------------------------------------------------
+// Configuring the table of content quickpanel (C-r)
+// ------------------------------------------------------------------
+
+	// the commands, which will be treated as sections,
+	// i.e. the commands, which will be inserted into the quickpanel
+	"toc_section_commands": [
+		"part",
+		"chapter",
+		"section",
+		"subsection",
+		"subsubsection",
+		"paragraph",
+		"addpart",
+		"addchap",
+		"addsec",
+		"minisec"
+	],
+	// a mapping from each section command to its indent
+	"toc_indentations": {
+		"part": 0,
+		"chapter": 1,
+		"section": 2,
+		"subsection": 3,
+		"subsubsection": 4,
+		"paragraph": 5,
+		"addpart": 0,
+		"addchap": 1,
+		"addsec": 2,
+		"minisec": 2,
+		"label": 0
+	},
+	// the label commands, i.e. the commands,
+	// which will be shown/hidden using "Show Label" and "Hide Label"
+	"toc_labels": [
+		"label"
+	],
+
+
+// ------------------------------------------------------------------
 // Opening files included into the tex source code
 // ------------------------------------------------------------------
 // the commands to open image files. The extensions will be matched from top to bottom.
@@ -37,7 +76,7 @@
 				"extension": ["pdf", "eps"],
 				"command": "SumatraPDF"
 			}
-			// uncomment these lines to open all other images with the default programm
+			// uncomment these lines to open all other images with the default program
 			// ,
 			// {
 			// 	"command": "start"

--- a/LaTeXTools.sublime-settings
+++ b/LaTeXTools.sublime-settings
@@ -41,6 +41,10 @@
 	// Sync PDF to current editor position after building (true) or not
 	"forward_sync": true,
 
+	// Set this to false to disable the overwriting of the goto overlay for the hotkey `C-r`
+	// You can still access the "table of content quickpanel" via `C-l, C-r`
+	"overwrite_goto_overlay": true,
+
 	// When to trigger cwl-command completion (requires the LaTeX-cwl package)
 	// possible values are:
 	// "always" (always show command completions)
@@ -73,7 +77,7 @@
 	// can also be set on a per-project basis
 	"use_biblatex": false,
 
-	// the mapping from the locales to the dictionaries for the 
+	// the mapping from the locales to the dictionaries for the
 	// `%!TEX spellcheck` directive, where the locales must be all lowercase
 	// and separated by a minus sign (-). The dictionaries must be valid path
 	// and compatible with the ST integrated spellcheck
@@ -252,15 +256,15 @@
 	// "default" or ""	the default built-in build engine; currently
 	//					this is the same as "traditional"
 	//
-	// "basic"			invokes pdflatex / xelatex / lualates as 
+	// "basic"			invokes pdflatex / xelatex / lualates as
 	//					needed, then biber / bibtex and pdflatex /
 	//					xelatex / lualatex again if needed. Unlike
 	//					the "simple" builder this supports most of
 	//					LaTeXTools builder features.
 	//
 	// "script"			external script: invokes the set of commands
-	//					specified in the "script_commands" setting 
-	//					in the platform-specific part of the 
+	//					specified in the "script_commands" setting
+	//					in the platform-specific part of the
 	//					"builder_settings"
 	//
 	// "simple"			invokes pdflatex 1x or 2x as needed, then
@@ -325,7 +329,7 @@
 	// Specifies which viewer to use
 	// Possible values:
 	//
-	// "default" or ""	the default viewer for your platform, which 
+	// "default" or ""	the default viewer for your platform, which
 	//					is sumatra on Windows, skim on OS X and
 	//					evince on linux
 	//
@@ -387,13 +391,13 @@
 // Bibliographic references
 // ------------------------------------------------------------------
 	// OPTION: "bibliography"
-	// Either a single  bibliography plugin to use or a list of plugins 
+	// Either a single  bibliography plugin to use or a list of plugins
 	// which will be executed in order, stopping after the first result
 	// found
 	//
 	// Possible values:
 	//
-	// "traditional" 		the default, regex-based bibliography 
+	// "traditional" 		the default, regex-based bibliography
 	//						parsing
 	//
 	// "new"				a newer parser which supports UTF-8 and

--- a/toc_quickpanel.py
+++ b/toc_quickpanel.py
@@ -11,8 +11,10 @@ else:
     from latextools_utils import analysis, get_setting, quickpanel
 
 
-def _make_caption(toc_indentations, com):
+def _make_caption(toc_indentations, com, indent_offset):
     indent = toc_indentations.get(com.command, 0)
+    # lower the indent with the offset
+    indent = max(0, indent - indent_offset)
     short = {
         "subsubsection": "sss",
         "minisec": "msec",
@@ -43,8 +45,14 @@ class show_toc_quickpanel(quickpanel.CancelEntriesQuickpanel):
         secs = [c for c in labels if c.command in toc_section_commands]
 
         # create the user readably captions
-        caption_secs = [_make_caption(toc_indentations, s) for s in secs]
-        caption_labels = [_make_caption(toc_indentations, l) for l in labels]
+        # get the minimal indent (to lower the minimal section indent to 0)
+        max_indent_value = max(toc_indentations.values())
+        indent_offset = min(toc_indentations.get(com.command, max_indent_value)
+                            for com in secs)
+        caption_secs = [_make_caption(toc_indentations, s, indent_offset)
+                        for s in secs]
+        caption_labels = [_make_caption(toc_indentations, l, indent_offset)
+                          for l in labels]
 
         self.__only_sec = True
         # init the superclass with a copy of the section elements

--- a/toc_quickpanel.py
+++ b/toc_quickpanel.py
@@ -11,35 +11,17 @@ else:
     from latextools_utils import analysis, get_setting, quickpanel
 
 
-_section_commands = [
-    "chapter",
-    "section",
-    "subsection",
-    "subsubsection",
-    "paragraph"
-]
-
-_label_commands = [
-    "label"
-]
-
-_indentations = {
-    "chapter": 0,
-    "section": 1,
-    "subsection": 2,
-    "subsubsection": 3,
-    "paragraph": 4,
-    "label": 0
-}
-
-
-def _make_caption(com):
-    indent = _indentations.get(com.command, 0)
+def _make_caption(toc_indentations, com):
+    indent = toc_indentations.get(com.command, 0)
     short = {
         "subsubsection": "sss",
+        "minisec": "msec",
         "label": "L"
     }.get(com.command, com.command[0:3])
     short = short.title()
+    # special handling for koma script
+    if short.lower() == "add":
+        short = "+" + com.command[3:6].title()
 
     return ("  " * indent) + short + com.star + " " + com.args
 
@@ -51,14 +33,18 @@ class show_toc_quickpanel(quickpanel.CancelEntriesQuickpanel):
 
     def __init__(self, ana):
         # retrieve the labels and the sections
-        labels = ana.filter_commands(_section_commands + _label_commands)
+        toc_section_commands = get_setting("toc_section_commands", [])
+        toc_indentations = get_setting("toc_indentations", {})
+        toc_labels = get_setting("toc_labels", [])
+
+        labels = ana.filter_commands(toc_section_commands + toc_labels)
         # filter the labels and sections to only get the labels
         # (faster than an additional query)
-        secs = [c for c in labels if c.command in _section_commands]
+        secs = [c for c in labels if c.command in toc_section_commands]
 
         # create the user readably captions
-        caption_secs = list(map(_make_caption, secs))
-        caption_labels = list(map(_make_caption, labels))
+        caption_secs = [_make_caption(toc_indentations, s) for s in secs]
+        caption_labels = [_make_caption(toc_indentations, l) for l in labels]
 
         self.__only_sec = True
         # init the superclass with a copy of the section elements

--- a/toc_quickpanel.py
+++ b/toc_quickpanel.py
@@ -1,0 +1,134 @@
+import sublime
+import sublime_plugin
+
+_ST3 = sublime.version() >= '3000'
+
+if _ST3:
+    from .getTeXRoot import get_tex_root
+    from .latextools_utils import analysis, get_setting, quickpanel
+else:
+    from getTeXRoot import get_tex_root
+    from latextools_utils import analysis, get_setting, quickpanel
+
+
+_section_commands = [
+    "chapter",
+    "section",
+    "subsection",
+    "subsubsection",
+    "paragraph"
+]
+
+_label_commands = [
+    "label"
+]
+
+_indentations = {
+    "chapter": 0,
+    "section": 1,
+    "subsection": 2,
+    "subsubsection": 3,
+    "paragraph": 4,
+    "label": 0
+}
+
+
+def _make_caption(com):
+    indent = _indentations.get(com.command, 0)
+    short = {
+        "subsubsection": "sss",
+        "label": "L"
+    }.get(com.command, com.command[0:3])
+    short = short.title()
+
+    return ("  " * indent) + short + com.star + " " + com.args
+
+
+class show_toc_quickpanel(quickpanel.CancelEntriesQuickpanel):
+    __show_string = "Show Labels"
+    __hide_string = "Hide Labels"
+    __toggles = [__show_string, __hide_string]
+
+    def __init__(self, ana):
+        # retrieve the labels and the sections
+        labels = ana.filter_commands(_section_commands + _label_commands)
+        # filter the labels and sections to only get the labels
+        # (faster than an additional query)
+        secs = [c for c in labels if c.command in _section_commands]
+
+        # create the user readably captions
+        caption_secs = list(map(_make_caption, secs))
+        caption_labels = list(map(_make_caption, labels))
+
+        self.__only_sec = True
+        # init the superclass with a copy of the section elements
+        super(show_toc_quickpanel, self).__init__(
+            list(caption_secs), list(secs))
+
+        # story necessary fields
+        self.__secs = secs
+        self.__labels = labels
+        self.__caption_secs = caption_secs
+        self.__caption_labels = caption_labels
+
+        # add a item to show the labels
+        self.add_item(quickpanel.AT_END, self.__show_string,
+                      done_handler=self.__show_labels)
+        # register a function to hide the labels
+        self.done_handler[self.__hide_string] = self.__hide_labels
+
+        # show the quickpanel
+        self.show_quickpanel()
+
+    def __hide_labels(self):
+        """Handles the toggle to hide the labels"""
+        # exchange the captions after the offset (with no navigation entries)
+        self.captions = self.captions[0:self._offset] + self.__caption_secs
+        # change the name of the toggle from "Hide" to "Show"
+        index = self.captions.index(self.__hide_string)
+        self.captions[index] = self.__show_string
+        # update the entries
+        self.entries = self.__secs
+
+        # show the quickpanel such that the changes take effect
+        self.show_quickpanel(index)
+
+    def __show_labels(self):
+        """Handles the toggle to show the labels"""
+        # exchange the captions after the offset (with no navigation entries)
+        self.captions = self.captions[0:self._offset] + self.__caption_labels
+        # change the name of the toggle from "Show" to "Hide"
+        index = self.captions.index(self.__show_string)
+        self.captions[index] = self.__hide_string
+        # update the entries
+        self.entries = self.__labels
+
+        # show the quickpanel such that the changes take effect
+        self.show_quickpanel(index)
+
+
+def show_commands(captions, entries, show_cancel=True):
+    if show_cancel:
+        Quickpanel = quickpanel.CancelEntriesQuickpanel
+    else:
+        Quickpanel = quickpanel.EntriesQuickpanel
+    Quickpanel(captions, entries).show_quickpanel()
+
+
+class LatexTocQuickpanelCommand(sublime_plugin.WindowCommand):
+    def run(self):
+        view = self.window.active_view()
+        tex_root = get_tex_root(view)
+        if not tex_root:
+            return
+        ana = analysis.analyze_document(tex_root)
+
+        show_toc_quickpanel(ana)
+
+
+class LatexTocQuickpanelContext(sublime_plugin.EventListener):
+    def on_query_context(self, view, key, *args):
+        if (key != "overwrite_goto_overlay" or
+                not view.score_selector(0, "text.tex.latex")):
+            return None
+        return get_setting("overwrite_goto_overlay")


### PR DESCRIPTION
This adds a whole document "table of content" overlay to replace the default `C-r` keybinding (opt-out). It is also accessible via `C-l, C-r`.

The entries are indented (chapter<section<subsection<...) to create a better overview and you can show and hide the labels.

TODO:
- [x] add more section commands

![demo](https://cloud.githubusercontent.com/assets/12573621/16896680/5794b6b2-4b9a-11e6-9189-9470f8648233.gif)