### PR TITLE
Unique jump-to-anywhere mouse bindings

### DIFF
--- a/Default (Linux).sublime-mousemap
+++ b/Default (Linux).sublime-mousemap
@@ -2,11 +2,16 @@
     {
         "button": "button1",
         "modifiers": ["super"],
-        "command": "jumpto_tex_anywhere_by_mouse",
         "press_command": "drag_select",
-        // change this to the command to the command,
-        // that will be executed
-        // if your mouse click is not inside a tex-file
-        "args": { "fallback_command": "" }
+        "command": "jumpto_tex_anywhere_by_mouse",
+        "args": {
+            // change this to the command to the command,
+            // that will be executed
+            // if your mouse click is not inside a tex-file
+            "fallback_command": "",
+            // If you set set_caret to true it will set the caret
+            // to the clicked position before calling the command
+            "set_caret": false
+        }
     }
 ]

--- a/Default (Linux).sublime-mousemap
+++ b/Default (Linux).sublime-mousemap
@@ -9,7 +9,7 @@
             // that will be executed
             // if your mouse click is not inside a tex-file
             "fallback_command": "",
-            // If you set set_caret to true it will set the caret
+            // (ST3 only) If you set set_caret to true it will set the caret
             // to the clicked position before calling the command
             "set_caret": false
         }

--- a/Default (OSX).sublime-mousemap
+++ b/Default (OSX).sublime-mousemap
@@ -1,12 +1,17 @@
 [
     {
         "button": "button1",
-        "modifiers": ["ctrl"],
-        "command": "jumpto_tex_anywhere_by_mouse",
+        "modifiers": ["ctrl", "super"],
         "press_command": "drag_select",
-        // change this to the command to the command,
-        // that will be executed
-        // if your mouse click is not inside a tex-file
-        "args": { "fallback_command": "" }
+        "command": "jumpto_tex_anywhere_by_mouse",
+        "args": {
+            // change this to the command to the command,
+            // that will be executed
+            // if your mouse click is not inside a tex-file
+            "fallback_command": "",
+            // If you set set_caret to true it will set the caret
+            // to the clicked position before calling the command
+            "set_caret": false
+        }
     }
 ]

--- a/Default (OSX).sublime-mousemap
+++ b/Default (OSX).sublime-mousemap
@@ -9,7 +9,7 @@
             // that will be executed
             // if your mouse click is not inside a tex-file
             "fallback_command": "",
-            // If you set set_caret to true it will set the caret
+            // (ST3 only) If you set set_caret to true it will set the caret
             // to the clicked position before calling the command
             "set_caret": false
         }

--- a/Default (Windows).sublime-mousemap
+++ b/Default (Windows).sublime-mousemap
@@ -1,12 +1,17 @@
 [
     {
         "button": "button1",
-        "modifiers": ["alt"],
-        "command": "jumpto_tex_anywhere_by_mouse",
+        "modifiers": ["ctrl", "alt"],
         "press_command": "drag_select",
-        // change this to the command to the command,
-        // that will be executed
-        // if your mouse click is not inside a tex-file
-        "args": { "fallback_command": "" }
+        "command": "jumpto_tex_anywhere_by_mouse",
+        "args": {
+            // change this to the command to the command,
+            // that will be executed
+            // if your mouse click is not inside a tex-file
+            "fallback_command": "",
+            // If you set set_caret to true it will set the caret
+            // to the clicked position before calling the command
+            "set_caret": false
+        }
     }
 ]

--- a/Default (Windows).sublime-mousemap
+++ b/Default (Windows).sublime-mousemap
@@ -9,7 +9,7 @@
             // that will be executed
             // if your mouse click is not inside a tex-file
             "fallback_command": "",
-            // If you set set_caret to true it will set the caret
+            // (ST3 only) If you set set_caret to true it will set the caret
             // to the clicked position before calling the command
             "set_caret": false
         }

--- a/README.markdown
+++ b/README.markdown
@@ -406,7 +406,10 @@ Selecting any entry in the list will take you to the corresponding place in the 
 ### Jump to Anywhere
 
 **Keybinding:** `C-l, C-j` or `C-l, C-o` (see [below](#jumping-to-included-files))
-**Mousebinding:** `alt-leftclick` (Windows) / `super-leftclick` Linux) / `ctrl-leftclick` (OSX)
+
+**Mousebinding:** `ctrl-alt-leftclick` (Windows) / `super-leftclick` Linux) / `ctrl-super-leftclick` (OSX)
+
+**Mousebinding (With SublimeCodeIntel):** `alt-leftclick` (Windows) / `super-leftclick` Linux) / `ctrl-leftclick` (OSX)
 
 This is an IDE-like mouse navigation, which executes a jump depending on the context around the cursor. It is easy to use and intuitive. Just click with the mouse on a command while pressing the modifier key. The corresponding jump will be executed. Supported jump types are:
 
@@ -420,7 +423,7 @@ This is an IDE-like mouse navigation, which executes a jump depending on the con
 - Jump to self-defined command definition, i.e. jump to the `\newcommand` in which the command was defined
 
 #### SublimeCodeIntel Integration
-If you use [SublimeCodeIntel](https://github.com/SublimeCodeIntel/SublimeCodeIntel) you recognize the mouse-binding and it does not work out of the box. Just open the command palette and run the command `LaTeXTools: Create Mousemap in User folder`. This will create a mouse-map in the user folder or modify the existing one to add the mouse-binding. This mouse-binding has a `fallback_command` command as argument. This command will be executed if the command in called outside a LaTeX document.
+If you use [SublimeCodeIntel](https://github.com/SublimeCodeIntel/SublimeCodeIntel) you recognize the alternative mouse-bindings and it does not work out of the box. Just open the command palette and run the command `LaTeXTools: Create Mousemap in User folder`. This will create a mouse-map in the user folder or modify the existing one to add the mouse-binding with the same modifiers as SublimeCodeIntel. This mouse-binding has a `fallback_command` command as argument. This command will be executed if the command in called outside a LaTeX document.
 
 #### Jumping to included files
 To open a file included using, e.g., `\input` or `\include` or a bibliography, simply click while holding down the modifier key or press `C-l, C-j`. Sublime will open the included file.

--- a/create_mousemap.py
+++ b/create_mousemap.py
@@ -67,15 +67,27 @@ class LatextoolsCreateMousemapCommand(sublime_plugin.WindowCommand):
             with open(ltt_mouse_file, "r") as f:
                 content = f.read()
             if sci_installed:
+                # add the fallback command
                 replace_from = '"fallback_command": ""'
                 replace_to = '"fallback_command": "goto_python_definition"'
                 content = content.replace(replace_from, replace_to)
+                # change the keybindings to the one used by SCI
+                if plat == "OSX":
+                    replace_from = '["ctrl", "super"]'
+                    replace_to = '["ctrl"]'
+                    content = content.replace(replace_from, replace_to)
+                elif plat == "Windows":
+                    replace_from = '["ctrl", "alt"]'
+                    replace_to = '["alt"]'
+                    content = content.replace(replace_from, replace_to)
             return content
 
         def replace_old_mousemap():
             content = read_ltt_content()
             with open(user_mouse_file, "w") as f:
                 f.write(content)
+            # open the mouse map, such that the user can change the modifier
+            self.window.open_file(user_mouse_file)
 
         def append_to_old_mousemap():
             with open(user_mouse_file, "r") as f:

--- a/jumpto_anywhere.py
+++ b/jumpto_anywhere.py
@@ -289,7 +289,7 @@ class JumptoTexAnywhereByMouseCommand(sublime_plugin.WindowCommand):
     def want_event(self):
         return True
 
-    def run(self, event, fallback_command="", set_caret=False):
+    def run(self, event=None, fallback_command="", set_caret=False):
         window = self.window
         view = window.active_view()
 
@@ -299,7 +299,10 @@ class JumptoTexAnywhereByMouseCommand(sublime_plugin.WindowCommand):
 
         if score_selector("text.tex.latex"):
             print("Jump in tex file.")
-            pos = view.window_to_text((event["x"], event["y"]))
+            if _ST3:
+                pos = view.window_to_text((event["x"], event["y"]))
+            else:
+                pos = view.sel()[0].b
             view.run_command("jumpto_tex_anywhere", {"position": pos})
         elif fallback_command:
             if set_caret:
@@ -308,6 +311,9 @@ class JumptoTexAnywhereByMouseCommand(sublime_plugin.WindowCommand):
             window.run_command(fallback_command)
 
     def _set_caret(self, view, event):
+        # this is not supported for ST2
+        if not _ST3:
+            return
         pos = view.window_to_text((event["x"], event["y"]))
         view.sel().clear()
         view.sel().add(sublime.Region(pos, pos))

--- a/jumpto_anywhere.py
+++ b/jumpto_anywhere.py
@@ -211,12 +211,15 @@ def _opt_jumpto_self_def_command(view, com_reg):
 
 
 class JumptoTexAnywhereCommand(sublime_plugin.TextCommand):
-    def run(self, edit):
+    def run(self, edit, position=None):
         view = self.view
-        if len(view.sel()) != 1:
-            print("Jump to anywhere does not work with multiple cursors")
-            return
-        sel = view.sel()[0]
+        if position is None:
+            if len(view.sel()) != 1:
+                print("Jump to anywhere does not work with multiple cursors")
+                return
+            sel = view.sel()[0]
+        else:
+            sel = sublime.Region(position, position)
         line_r = view.line(sel)
         line = view.substr(line_r)
 
@@ -251,7 +254,7 @@ class JumptoTexAnywhereCommand(sublime_plugin.TextCommand):
         args = com_reg.group("args")
         reversed_command = "{" + command[::-1] + "\\"
         # the cursor position inside the command
-        pos = view.sel()[0].b - line_r.begin() - com_reg.start()
+        pos = sel.b - line_r.begin() - com_reg.start()
         # check if its a ref
         if NEW_STYLE_REF_REGEX.match(reversed_command):
             sublime.status_message("Jump to reference '{0}'".format(args))
@@ -262,11 +265,13 @@ class JumptoTexAnywhereCommand(sublime_plugin.TextCommand):
             _jumpto_cite(view, com_reg, pos)
         # check if it is any kind of input command
         elif any(reg.match(com_reg.group(0)) for reg in INPUT_REG_EXPS):
-            args = {
+            kwargs = {
                 "auto_create_missing_folders": False,
                 "auto_insert_root": False
             }
-            view.run_command("jumpto_tex_file", args)
+            if pos is not None:
+                kwargs.update({"position": position})
+            view.run_command("jumpto_tex_file", kwargs)
         elif command in ["usepackage", "Requirepackage"]:
             _jumpto_pkg_doc(view, com_reg, pos)
         else:
@@ -281,8 +286,12 @@ class JumptoTexAnywhereCommand(sublime_plugin.TextCommand):
 
 
 class JumptoTexAnywhereByMouseCommand(sublime_plugin.WindowCommand):
-    def run(self, fallback_command=""):
-        view = self.window.active_view()
+    def want_event(self):
+        return True
+
+    def run(self, event, fallback_command="", set_caret=False):
+        window = self.window
+        view = window.active_view()
 
         def score_selector(selector):
             point = view.sel()[0].b if len(view.sel()) else 0
@@ -290,7 +299,15 @@ class JumptoTexAnywhereByMouseCommand(sublime_plugin.WindowCommand):
 
         if score_selector("text.tex.latex"):
             print("Jump in tex file.")
-            view.run_command("jumpto_tex_anywhere")
+            pos = view.window_to_text((event["x"], event["y"]))
+            view.run_command("jumpto_tex_anywhere", {"position": pos})
         elif fallback_command:
+            if set_caret:
+                self._set_caret(view, event)
             print("Run command '{0}'".format(fallback_command))
-            view.run_command(fallback_command)
+            window.run_command(fallback_command)
+
+    def _set_caret(self, view, event):
+        pos = view.window_to_text((event["x"], event["y"]))
+        view.sel().clear()
+        view.sel().add(sublime.Region(pos, pos))

--- a/jumpto_tex_file.py
+++ b/jumpto_tex_file.py
@@ -213,7 +213,7 @@ def _split_bib_args(bib_args):
 class JumptoTexFileCommand(sublime_plugin.TextCommand):
 
     def run(self, edit, auto_create_missing_folders=True,
-            auto_insert_root=True):
+            auto_insert_root=True, position=None):
         view = self.view
         window = view.window()
         tex_root = get_tex_root(view)
@@ -221,7 +221,12 @@ class JumptoTexFileCommand(sublime_plugin.TextCommand):
             sublime.status_message("Save your current file first")
             return
 
-        for sel in view.sel():
+        if position is None:
+            selections = list(view.sel())
+        else:
+            selections = [sublime.Region(position, position)]
+
+        for sel in selections:
             line_r = view.line(sel)
             line = view.substr(line_r)
 


### PR DESCRIPTION
This fixes #784 and #786.

It uses unique keybindings and adapts them if SublimeCodeIntel is installed to be compatible.