### PR TITLE
Improve support for symlinks

### DIFF
--- a/jumpToPDF.py
+++ b/jumpToPDF.py
@@ -144,24 +144,29 @@ class JumpToPdf(sublime_plugin.TextCommand):
 		root = getTeXRoot.get_tex_root(self.view)
 		file_name = get_jobname(root)
 
-
 		output_directory = get_output_directory(self.view)
 		if output_directory is None:
 			root = getTeXRoot.get_tex_root(self.view)
-			pdffile = os.path.join(
-				os.path.dirname(root),
-				file_name + u'.pdf'
+			pdffile = os.path.realpath(
+				os.path.join(
+					os.path.dirname(root),
+					file_name + u'.pdf'
+				)
 			)
 		else:
-			pdffile = os.path.join(
-				output_directory,
-				file_name + u'.pdf'
+			pdffile = os.path.realpath(
+				os.path.join(
+					output_directory,
+					file_name + u'.pdf'
+				)
 			)
 
 			if not os.path.exists(pdffile):
-				pdffile = os.path.join(
-					os.path.dirname(root),
-					file_name + u'.pdf'
+				pdffile = os.path.realpath(
+					os.path.join(
+						os.path.dirname(root),
+						file_name + u'.pdf'
+					)
 				)
 
 		(line, col) = self.view.rowcol(self.view.sel()[0].end())
@@ -220,7 +225,11 @@ class ViewPdf(sublime_plugin.WindowCommand):
 	def run(self, **args):
 		pdffile = None
 		if 'file' in args:
-			pdffile = args.pop('file', None)
+			pdffile = os.path.realpath(
+				os.path.normpath(
+					args.pop('file', None)
+				)
+			)
 		else:
 			view = self.window.active_view()
 
@@ -229,20 +238,26 @@ class ViewPdf(sublime_plugin.WindowCommand):
 
 			output_directory = get_output_directory(view)
 			if output_directory is None:
-				pdffile = os.path.join(
-					os.path.dirname(root),
-					file_name + u'.pdf'
+				pdffile = os.path.realpath(
+					os.path.join(
+						os.path.dirname(root),
+						file_name + u'.pdf'
+					)
 				)
 			else:
-				pdffile = os.path.join(
-					output_directory,
-					file_name + u'.pdf'
+				pdffile = os.path.realpath(
+					os.path.join(
+						output_directory,
+						file_name + u'.pdf'
+					)
 				)
 
 				if not os.path.exists(pdffile):
-					pdffile = os.path.join(
-						os.path.dirname(root),
-						file_name + u'.pdf'
+					pdffile = os.path.realpath(
+						os.path.join(
+							os.path.dirname(root),
+							file_name + u'.pdf'
+						)
 					)
 
 		# since we potentially accept an argument, add some extra

--- a/latex_input_completions.py
+++ b/latex_input_completions.py
@@ -151,12 +151,23 @@ def get_file_list(root, types, filter_exts=[], output_directory=None,
 
         return True
 
+    def dir_match(d):
+        _d = os.path.realpath(os.path.join(dir_name, d))
+        if (
+            _d in handled_directories or
+            _d == output_directory or
+            _d == aux_directory
+        ):
+            return False
+
+        return True
+
     completions = []
-    for dir_name, dirs, files in os.walk(path):
+    handled_directories = set([])
+    for dir_name, dirs, files in os.walk(path, followlinks=True):
+        handled_directories.add(os.path.realpath(dir_name))
         files = [f for f in files if f[0] != '.' and file_match(f)]
-        dirs[:] = [d for d in dirs if d[0] != '.' and
-                   os.path.join(dir_name, d) != output_directory and
-                   os.path.join(dir_name, d) != aux_directory]
+        dirs[:] = [d for d in dirs if d[0] != '.' and dir_match(d)]
         for f in files:
             full_path = os.path.join(dir_name, f)
             # Exclude image file have the same name of root file,

--- a/latextools_utils/output_directory.py
+++ b/latextools_utils/output_directory.py
@@ -276,12 +276,14 @@ def resolve_to_absolute_path(root, value, root_path):
     )
 
     if os.path.isabs(result):
-        return os.path.normpath(result)
+        return os.path.realpath(os.path.normpath(result))
     else:
-        return os.path.normpath(
-            os.path.join(
-                root_path,
-                result
+        return os.path.realpath(
+            os.path.normpath(
+                os.path.join(
+                    root_path,
+                    result
+                )
             )
         )
 
@@ -373,5 +375,7 @@ def _get_root_directory(root):
 def _get_root_hash(root):
     if root is None:
         return None
+
+    root = os.path.realpath(root)
 
     return hashlib.md5(root.encode('utf-8')).hexdigest()


### PR DESCRIPTION
This adds support for symlinks requested in #792 and #796, as well as some unreported issues with `output_directory`.

There are still likely still some cases where symlinks will cause possibly unexpected behaviour. Two I'm aware of:

1. Compiling from a document that uses a symlink to point to the root will have a different "Compiling..." message than compiling from the root directly. I don't think this really causes problems.

1. Using the `jump_to_anywhere` functions on a file opened via symlinks with a copy opened from the real path results in multiple tabs of the same file that don't share the same buffer. This is addressable, but doing so would unnecessarily slow things down in cases where the file is only ever opened via a symlink or where symlinks aren't involved at all, as we'd have to do an exhaustive search of every open file, determine if it is the same file we were attempting to open and then substituting the path of the opened file. In any case, the better option is to request that ST itself implements this behaviour, since the same issue affects any files opened in ST.