### PR TITLE
Dependency for `markdown-popups`

### DIFF
--- a/dependencies.json
+++ b/dependencies.json
@@ -1,0 +1,11 @@
+{
+    "*": {
+        ">=3080": [
+            "pygments",
+            "python-markdown",
+            "mdpopups",
+            "python-jinja2",
+            "markupsafe"
+        ]
+    }
+}

--- a/dependencies.json
+++ b/dependencies.json
@@ -1,6 +1,6 @@
 {
     "*": {
-        ">=3080": [
+        ">=3118": [
             "pygments",
             "python-markdown",
             "mdpopups",


### PR DESCRIPTION
This PR adds the [markdown-popups](http://facelessuser.github.io/sublime-markdown-popups/usage/#dependencies) as a [dependency](https://packagecontrol.io/docs/dependencies). This is a popular library to provide functions for popups and phantoms. Since these are used by upcoming PRs (https://github.com/SublimeText/LaTeXTools/pull/785), we should ensure that the dependency is installed.