### PR TITLE
Pass out and aux dir as relative paths to LaTeX if possible

### DIFF
--- a/builders/basicBuilder.py
+++ b/builders/basicBuilder.py
@@ -98,14 +98,23 @@ class BasicBuilder(PdfBuilder):
 
         latex.append(self.base_name)
 
+        # Check if any subfolders need to be created
+        # this adds a number of potential runs as LaTeX treats being unable
+        # to open output files as fatal errors
+        output_directory = (
+            self.aux_directory_full or self.output_directory_full
+        )
+
+        if (
+            output_directory is not None and
+            not os.path.exists(output_directory)
+        ):
+            self.make_directory(output_directory)
+
         yield (latex, "running {0}...".format(engine))
         self.display("done.\n")
         self.log_output()
 
-        # Check if any subfolders need to be created
-        # this adds a number of potential runs as LaTeX treats being unable
-        # to open output files as fatal errors
-        output_directory = self.aux_directory or self.output_directory
         if output_directory is not None:
             while True:
                 start = 0
@@ -202,7 +211,9 @@ class BasicBuilder(PdfBuilder):
         env = dict(os.environ)
         cwd = self.tex_dir
 
-        output_directory = self.aux_directory or self.output_directory
+        output_directory = (
+            self.aux_directory_full or self.output_directory_full
+        )
         if output_directory is not None:
             # cwd is, at the point, the path to the main tex file
             if _ST3:

--- a/builders/pdfBuilder.py
+++ b/builders/pdfBuilder.py
@@ -48,12 +48,32 @@ class PdfBuilder(latextools_plugin.LaTeXToolsPlugin):
 		self.out = ""
 		self.engine = engine
 		self.options = options
-		self.output_directory = output_directory
-		self.aux_directory = aux_directory
+		self.output_directory = self.output_directory_full = output_directory
+		self.aux_directory = self.aux_directory_full = aux_directory
 		self.job_name = job_name
 		self.tex_directives = tex_directives
 		self.builder_settings = builder_settings
 		self.platform_settings = platform_settings
+
+		# if output_directory and aux_directory can be specified as a path
+		# relative to self.tex_dir, we use that instead of the absolute path
+		# note that the full path for both is available as
+		# self.output_directory_full and self.aux_directory_full
+		if (
+			self.output_directory and
+			self.output_directory.startswith(self.tex_dir)
+		):
+			self.output_directory = os.path.relpath(
+				self.output_directory, self.tex_dir
+			)
+
+		if (
+			self.aux_directory and
+			self.aux_directory.startswith(self.tex_dir)
+		):
+			self.aux_directory = os.path.relpath(
+				self.output_directory, self.tex_dir
+			)
 
 	# Send to callable object
 	# Usually no need to override

--- a/builders/scriptBuilder.py
+++ b/builders/scriptBuilder.py
@@ -139,8 +139,8 @@ class ScriptBuilder(PdfBuilder):
 				file_name=self.tex_name,
 				file_ext=self.tex_ext,
 				file_base_name=self.base_name,
-				output_directory=self.output_directory or self.tex_dir,
-				aux_directory=self.aux_directory or self.tex_dir,
+				output_directory=self.output_directory_full or self.tex_dir,
+				aux_directory=self.aux_directory_full or self.tex_dir,
 				jobname=self.job_name
 			)
 


### PR DESCRIPTION
This implements option 2 outlined [in this comment on #813](https://github.com/SublimeText/LaTeXTools/issues/813#issuecomment-239665358). Essentially, if the `output_directory` and / or `aux_directory` point to a path that is a subfolder of the path containing the main file, we use a relative path for `output_directory` and `aux_directory` instead of an absolute path.

The underlying issue in #813 is a mismatch between the font encoding pdfLaTeX uses to represent в and в as its defined in UTF-8. This doesn't do anything to resolve that issue. However, as long as `output_directory` and `aux_directory` are specified relative to the main file and the file part only contains ASCII characters, the issue should be avoidable. Alternatively, using XeTeX or LuaTeX (which internally use UTF-8) also avoids the issue regardless of the path.