### PR TITLE
Add !TEX directives to the fill all helper

### DIFF
--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -127,7 +127,7 @@ LaTeX Package keymap for Linux
 	{	"keys": ["="],
 		"context":  [
 			{"key": "setting.disable_latex_ref_cite_auto_trigger", "operator": "not_equal", "operand": true},
-			{"key": "selector", "operator": "equal", "operand": "text.tex.latex comment.line.percentage.tex"},
+			{"key": "selector", "operator": "equal", "operand": "text.tex.latex comment.line.percentage"},
 			{"key": "selection_empty", "operator": "equal", "operand": true, "match_all": true},
 			{"key": "lt_fill_all_directive.equal_sign", "operator": "equal", "match_all": true, "operand": true}],
 		"command": "latex_fill_all", "args": {"completion_type": "directive", "insert_char": "="}},

--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -63,7 +63,7 @@ LaTeX Package keymap for Linux
 	{	"keys": ["{"],
 		"context":  [
 			{"key": "setting.disable_latex_ref_cite_auto_trigger", "operator": "not_equal", "operand": true},
-			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"},
+			{"key": "selector", "operator": "equal", "operand": "text.tex.latex - comment"},
 			{"key": "selection_empty", "operator": "equal", "operand": true, "match_all": true},
 			{"key": "lt_fill_all_ref.open_curly", "operator": "equal", "match_all": true, "operand": true}],
 		"command": "latex_fill_all", "args": {"completion_type": "ref", "insert_char": "{"}},
@@ -71,7 +71,7 @@ LaTeX Package keymap for Linux
 	{	"keys": ["{"],
 		"context":  [
 			{"key": "setting.disable_latex_ref_cite_auto_trigger", "operator": "not_equal", "operand": true},
-			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"},
+			{"key": "selector", "operator": "equal", "operand": "text.tex.latex - comment"},
 			{"key": "selection_empty", "operator": "equal", "operand": true, "match_all": true},
 			{"key": "lt_fill_all_cite.open_curly", "operator": "equal", "match_all": true, "operand": true}],
 		"command": "latex_fill_all", "args": {"completion_type": "cite", "insert_char": "{"}},
@@ -79,7 +79,7 @@ LaTeX Package keymap for Linux
 	{	"keys": [","],
 		"context":  [
 			{"key": "setting.disable_latex_ref_cite_auto_trigger", "operator": "not_equal", "operand": true},
-			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"},
+			{"key": "selector", "operator": "equal", "operand": "text.tex.latex - comment"},
 			{"key": "selection_empty", "operator": "equal", "operand": true, "match_all": true},
 			{"key": "lt_fill_all_cite.comma", "operator": "equal", "match_all": true, "operand": true}],
 		"command": "latex_fill_all", "args": {"completion_type": "cite", "insert_char": ","}},
@@ -87,7 +87,7 @@ LaTeX Package keymap for Linux
 	{	"keys": [","],
 		"context":  [
 			{"key": "setting.disable_latex_ref_cite_auto_trigger", "operator": "not_equal", "operand": true},
-			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"},
+			{"key": "selector", "operator": "equal", "operand": "text.tex.latex - comment"},
 			{"key": "selection_empty", "operator": "equal", "operand": true, "match_all": true},
 			{"key": "lt_fill_all_ref.comma", "operator": "equal", "match_all": true, "operand": true}],
 		"command": "latex_fill_all", "args": {"completion_type": "ref", "insert_char": ","}},
@@ -95,7 +95,7 @@ LaTeX Package keymap for Linux
 	{	"keys": ["["],
 		"context":  [
 			{"key": "setting.disable_latex_ref_cite_auto_trigger", "operator": "not_equal", "operand": true},
-			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"},
+			{"key": "selector", "operator": "equal", "operand": "text.tex.latex - comment"},
 			{"key": "selection_empty", "operator": "equal", "operand": true, "match_all": true},
 			{"key": "lt_fill_all_cite.open_square", "operator": "equal", "match_all": true, "operand": true}],
 		"command": "latex_fill_all", "args": {"completion_type": "cite", "insert_char": "["}},
@@ -103,7 +103,7 @@ LaTeX Package keymap for Linux
 	{	"keys": ["{"],
 		"context":  [
 			{"key": "setting.disable_latex_ref_cite_auto_trigger", "operator": "not_equal", "operand": true},
-			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"},
+			{"key": "selector", "operator": "equal", "operand": "text.tex.latex - comment"},
 			{"key": "selection_empty", "operator": "equal", "operand": true, "match_all": true},
 			{"key": "lt_fill_all_input.open_curly", "operator": "equal", "operand": true, "match_all": true}],
 		"command": "latex_fill_all", "args": {"completion_type": "input", "insert_char": "{"}},
@@ -111,7 +111,7 @@ LaTeX Package keymap for Linux
 	{	"keys": [","],
 		"context":  [
 			{"key": "setting.disable_latex_ref_cite_auto_trigger", "operator": "not_equal", "operand": true},
-			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"},
+			{"key": "selector", "operator": "equal", "operand": "text.tex.latex - comment"},
 			{"key": "selection_empty", "operator": "equal", "operand": true, "match_all": true},
 			{"key": "lt_fill_all_input.comma", "operator": "equal", "operand": true, "match_all": true}],
 		"command": "latex_fill_all", "args": {"completion_type": "input", "insert_char": ","}},
@@ -119,7 +119,7 @@ LaTeX Package keymap for Linux
 	{	"keys": ["{"],
 		"context":  [
 			{"key": "setting.disable_latex_ref_cite_auto_trigger", "operator": "not_equal", "operand": true},
-			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"},
+			{"key": "selector", "operator": "equal", "operand": "text.tex.latex - comment"},
 			{"key": "selection_empty", "operator": "equal", "operand": true, "match_all": true},
 			{"key": "lt_fill_all_env.open_curly", "operator": "equal", "operand": true, "match_all": true}],
 		"command": "latex_fill_all", "args": {"completion_type": "env", "insert_char": "{"}},

--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -141,6 +141,10 @@ LaTeX Package keymap for Linux
 		"context":  [
 			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"}],
 		"command": "toggle_auto", "args": {"which": "env"}},
+	{ 	"keys": ["ctrl+l","t","a", "d"],
+		"context":  [
+			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"}],
+		"command": "toggle_auto", "args": {"which": "tex_directive"}},
 	{ 	"keys": ["ctrl+l","t","a", "b"],
 		"context":  [
 			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"}],

--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -124,6 +124,14 @@ LaTeX Package keymap for Linux
 			{"key": "lt_fill_all_env.open_curly", "operator": "equal", "operand": true, "match_all": true}],
 		"command": "latex_fill_all", "args": {"completion_type": "env", "insert_char": "{"}},
 
+	{	"keys": ["="],
+		"context":  [
+			{"key": "setting.disable_latex_ref_cite_auto_trigger", "operator": "not_equal", "operand": true},
+			{"key": "selector", "operator": "equal", "operand": "text.tex.latex comment.line.percentage.tex"},
+			{"key": "selection_empty", "operator": "equal", "operand": true, "match_all": true},
+			{"key": "lt_fill_all_directive.equal_sign", "operator": "equal", "match_all": true, "operand": true}],
+		"command": "latex_fill_all", "args": {"completion_type": "directive", "insert_char": "="}},
+
 	// Toggle autocomplete
 	{ 	"keys": ["ctrl+l","t","a", "r"],
 		"context":  [

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -141,6 +141,10 @@ LaTeX Package keymap for OS X
 		"context":  [
 			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"}],
 		"command": "toggle_auto", "args": {"which": "env"}},
+	{ 	"keys": ["super+l","t","a", "d"],
+		"context":  [
+			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"}],
+		"command": "toggle_auto", "args": {"which": "tex_directive"}},
 	{ 	"keys": ["super+l","t","a", "b"],
 		"context":  [
 			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"}],

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -124,6 +124,14 @@ LaTeX Package keymap for OS X
 			{"key": "lt_fill_all_env.open_curly", "operator": "equal", "operand": true, "match_all": true}],
 		"command": "latex_fill_all", "args": {"completion_type": "env", "insert_char": "{"}},
 
+	{	"keys": ["="],
+		"context":  [
+			{"key": "setting.disable_latex_ref_cite_auto_trigger", "operator": "not_equal", "operand": true},
+			{"key": "selector", "operator": "equal", "operand": "text.tex.latex comment.line.percentage.tex"},
+			{"key": "selection_empty", "operator": "equal", "operand": true, "match_all": true},
+			{"key": "lt_fill_all_directive.equal_sign", "operator": "equal", "match_all": true, "operand": true}],
+		"command": "latex_fill_all", "args": {"completion_type": "directive", "insert_char": "="}},
+
 	// Toggle autocomplete
 	{ 	"keys": ["super+l","t","a", "r"],
 		"context":  [

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -127,7 +127,7 @@ LaTeX Package keymap for OS X
 	{	"keys": ["="],
 		"context":  [
 			{"key": "setting.disable_latex_ref_cite_auto_trigger", "operator": "not_equal", "operand": true},
-			{"key": "selector", "operator": "equal", "operand": "text.tex.latex comment.line.percentage.tex"},
+			{"key": "selector", "operator": "equal", "operand": "text.tex.latex comment.line.percentage"},
 			{"key": "selection_empty", "operator": "equal", "operand": true, "match_all": true},
 			{"key": "lt_fill_all_directive.equal_sign", "operator": "equal", "match_all": true, "operand": true}],
 		"command": "latex_fill_all", "args": {"completion_type": "directive", "insert_char": "="}},

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -63,7 +63,7 @@ LaTeX Package keymap for OS X
 	{	"keys": ["{"],
 		"context":  [
 			{"key": "setting.disable_latex_ref_cite_auto_trigger", "operator": "not_equal", "operand": true},
-			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"},
+			{"key": "selector", "operator": "equal", "operand": "text.tex.latex - comment"},
 			{"key": "selection_empty", "operator": "equal", "operand": true, "match_all": true},
 			{"key": "lt_fill_all_ref.open_curly", "operator": "equal", "match_all": true, "operand": true}],
 		"command": "latex_fill_all", "args": {"completion_type": "ref", "insert_char": "{"}},
@@ -71,7 +71,7 @@ LaTeX Package keymap for OS X
 	{	"keys": ["{"],
 		"context":  [
 			{"key": "setting.disable_latex_ref_cite_auto_trigger", "operator": "not_equal", "operand": true},
-			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"},
+			{"key": "selector", "operator": "equal", "operand": "text.tex.latex - comment"},
 			{"key": "selection_empty", "operator": "equal", "operand": true, "match_all": true},
 			{"key": "lt_fill_all_cite.open_curly", "operator": "equal", "match_all": true, "operand": true}],
 		"command": "latex_fill_all", "args": {"completion_type": "cite", "insert_char": "{"}},
@@ -79,7 +79,7 @@ LaTeX Package keymap for OS X
 	{	"keys": [","],
 		"context":  [
 			{"key": "setting.disable_latex_ref_cite_auto_trigger", "operator": "not_equal", "operand": true},
-			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"},
+			{"key": "selector", "operator": "equal", "operand": "text.tex.latex - comment"},
 			{"key": "selection_empty", "operator": "equal", "operand": true, "match_all": true},
 			{"key": "lt_fill_all_cite.comma", "operator": "equal", "match_all": true, "operand": true}],
 		"command": "latex_fill_all", "args": {"completion_type": "cite", "insert_char": ","}},
@@ -87,7 +87,7 @@ LaTeX Package keymap for OS X
 	{	"keys": [","],
 		"context":  [
 			{"key": "setting.disable_latex_ref_cite_auto_trigger", "operator": "not_equal", "operand": true},
-			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"},
+			{"key": "selector", "operator": "equal", "operand": "text.tex.latex - comment"},
 			{"key": "selection_empty", "operator": "equal", "operand": true, "match_all": true},
 			{"key": "lt_fill_all_ref.comma", "operator": "equal", "match_all": true, "operand": true}],
 		"command": "latex_fill_all", "args": {"completion_type": "ref", "insert_char": ","}},
@@ -95,7 +95,7 @@ LaTeX Package keymap for OS X
 	{	"keys": ["["],
 		"context":  [
 			{"key": "setting.disable_latex_ref_cite_auto_trigger", "operator": "not_equal", "operand": true},
-			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"},
+			{"key": "selector", "operator": "equal", "operand": "text.tex.latex - comment"},
 			{"key": "selection_empty", "operator": "equal", "operand": true, "match_all": true},
 			{"key": "lt_fill_all_cite.open_square", "operator": "equal", "match_all": true, "operand": true}],
 		"command": "latex_fill_all", "args": {"completion_type": "cite", "insert_char": "["}},
@@ -103,7 +103,7 @@ LaTeX Package keymap for OS X
 	{	"keys": ["{"],
 		"context":  [
 			{"key": "setting.disable_latex_ref_cite_auto_trigger", "operator": "not_equal", "operand": true},
-			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"},
+			{"key": "selector", "operator": "equal", "operand": "text.tex.latex - comment"},
 			{"key": "selection_empty", "operator": "equal", "operand": true, "match_all": true},
 			{"key": "lt_fill_all_input.open_curly", "operator": "equal", "operand": true, "match_all": true}],
 		"command": "latex_fill_all", "args": {"completion_type": "input", "insert_char": "{"}},
@@ -111,7 +111,7 @@ LaTeX Package keymap for OS X
 	{	"keys": [","],
 		"context":  [
 			{"key": "setting.disable_latex_ref_cite_auto_trigger", "operator": "not_equal", "operand": true},
-			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"},
+			{"key": "selector", "operator": "equal", "operand": "text.tex.latex - comment"},
 			{"key": "selection_empty", "operator": "equal", "operand": true, "match_all": true},
 			{"key": "lt_fill_all_input.comma", "operator": "equal", "operand": true, "match_all": true}],
 		"command": "latex_fill_all", "args": {"completion_type": "input", "insert_char": ","}},
@@ -119,7 +119,7 @@ LaTeX Package keymap for OS X
 	{	"keys": ["{"],
 		"context":  [
 			{"key": "setting.disable_latex_ref_cite_auto_trigger", "operator": "not_equal", "operand": true},
-			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"},
+			{"key": "selector", "operator": "equal", "operand": "text.tex.latex - comment"},
 			{"key": "selection_empty", "operator": "equal", "operand": true, "match_all": true},
 			{"key": "lt_fill_all_env.open_curly", "operator": "equal", "operand": true, "match_all": true}],
 		"command": "latex_fill_all", "args": {"completion_type": "env", "insert_char": "{"}},

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -63,7 +63,7 @@ LaTeX Package keymap for Windows
 	{	"keys": ["{"],
 		"context":  [
 			{"key": "setting.disable_latex_ref_cite_auto_trigger", "operator": "not_equal", "operand": true},
-			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"},
+			{"key": "selector", "operator": "equal", "operand": "text.tex.latex - comment"},
 			{"key": "selection_empty", "operator": "equal", "operand": true, "match_all": true},
 			{"key": "lt_fill_all_ref.open_curly", "operator": "equal", "match_all": true, "operand": true}],
 		"command": "latex_fill_all", "args": {"completion_type": "ref", "insert_char": "{"}},
@@ -71,7 +71,7 @@ LaTeX Package keymap for Windows
 	{	"keys": ["{"],
 		"context":  [
 			{"key": "setting.disable_latex_ref_cite_auto_trigger", "operator": "not_equal", "operand": true},
-			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"},
+			{"key": "selector", "operator": "equal", "operand": "text.tex.latex - comment"},
 			{"key": "selection_empty", "operator": "equal", "operand": true, "match_all": true},
 			{"key": "lt_fill_all_cite.open_curly", "operator": "equal", "match_all": true, "operand": true}],
 		"command": "latex_fill_all", "args": {"completion_type": "cite", "insert_char": "{"}},
@@ -79,7 +79,7 @@ LaTeX Package keymap for Windows
 	{	"keys": [","],
 		"context":  [
 			{"key": "setting.disable_latex_ref_cite_auto_trigger", "operator": "not_equal", "operand": true},
-			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"},
+			{"key": "selector", "operator": "equal", "operand": "text.tex.latex - comment"},
 			{"key": "selection_empty", "operator": "equal", "operand": true, "match_all": true},
 			{"key": "lt_fill_all_cite.comma", "operator": "equal", "match_all": true, "operand": true}],
 		"command": "latex_fill_all", "args": {"completion_type": "cite", "insert_char": ","}},
@@ -87,7 +87,7 @@ LaTeX Package keymap for Windows
 	{	"keys": [","],
 		"context":  [
 			{"key": "setting.disable_latex_ref_cite_auto_trigger", "operator": "not_equal", "operand": true},
-			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"},
+			{"key": "selector", "operator": "equal", "operand": "text.tex.latex - comment"},
 			{"key": "selection_empty", "operator": "equal", "operand": true, "match_all": true},
 			{"key": "lt_fill_all_ref.comma", "operator": "equal", "match_all": true, "operand": true}],
 		"command": "latex_fill_all", "args": {"completion_type": "ref", "insert_char": ","}},
@@ -95,7 +95,7 @@ LaTeX Package keymap for Windows
 	{	"keys": ["["],
 		"context":  [
 			{"key": "setting.disable_latex_ref_cite_auto_trigger", "operator": "not_equal", "operand": true},
-			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"},
+			{"key": "selector", "operator": "equal", "operand": "text.tex.latex - comment"},
 			{"key": "selection_empty", "operator": "equal", "operand": true, "match_all": true},
 			{"key": "lt_fill_all_cite.open_square", "operator": "equal", "match_all": true, "operand": true}],
 		"command": "latex_fill_all", "args": {"completion_type": "cite", "insert_char": "["}},
@@ -103,7 +103,7 @@ LaTeX Package keymap for Windows
 	{	"keys": ["{"],
 		"context":  [
 			{"key": "setting.disable_latex_ref_cite_auto_trigger", "operator": "not_equal", "operand": true},
-			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"},
+			{"key": "selector", "operator": "equal", "operand": "text.tex.latex - comment"},
 			{"key": "selection_empty", "operator": "equal", "operand": true, "match_all": true},
 			{"key": "lt_fill_all_input.open_curly", "operator": "equal", "operand": true, "match_all": true}],
 		"command": "latex_fill_all", "args": {"completion_type": "input", "insert_char": "{"}},
@@ -111,7 +111,7 @@ LaTeX Package keymap for Windows
 	{	"keys": [","],
 		"context":  [
 			{"key": "setting.disable_latex_ref_cite_auto_trigger", "operator": "not_equal", "operand": true},
-			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"},
+			{"key": "selector", "operator": "equal", "operand": "text.tex.latex - comment"},
 			{"key": "selection_empty", "operator": "equal", "operand": true, "match_all": true},
 			{"key": "lt_fill_all_input.comma", "operator": "equal", "operand": true, "match_all": true}],
 		"command": "latex_fill_all", "args": {"completion_type": "input", "insert_char": ","}},
@@ -119,7 +119,7 @@ LaTeX Package keymap for Windows
 	{	"keys": ["{"],
 		"context":  [
 			{"key": "setting.disable_latex_ref_cite_auto_trigger", "operator": "not_equal", "operand": true},
-			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"},
+			{"key": "selector", "operator": "equal", "operand": "text.tex.latex - comment"},
 			{"key": "selection_empty", "operator": "equal", "operand": true, "match_all": true},
 			{"key": "lt_fill_all_env.open_curly", "operator": "equal", "operand": true, "match_all": true}],
 		"command": "latex_fill_all", "args": {"completion_type": "env", "insert_char": "{"}},

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -124,6 +124,14 @@ LaTeX Package keymap for Windows
 			{"key": "lt_fill_all_env.open_curly", "operator": "equal", "operand": true, "match_all": true}],
 		"command": "latex_fill_all", "args": {"completion_type": "env", "insert_char": "{"}},
 
+	{	"keys": ["="],
+		"context":  [
+			{"key": "setting.disable_latex_ref_cite_auto_trigger", "operator": "not_equal", "operand": true},
+			{"key": "selector", "operator": "equal", "operand": "text.tex.latex comment.line.percentage.tex"},
+			{"key": "selection_empty", "operator": "equal", "operand": true, "match_all": true},
+			{"key": "lt_fill_all_directive.equal_sign", "operator": "equal", "match_all": true, "operand": true}],
+		"command": "latex_fill_all", "args": {"completion_type": "directive", "insert_char": "="}},
+
 	// Toggle autocomplete
 	{ 	"keys": ["ctrl+l","t","a", "r"],
 		"context":  [

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -149,6 +149,10 @@ LaTeX Package keymap for Windows
 		"context":  [
 			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"}],
 		"command": "toggle_auto", "args": {"which": "env"}},
+	{ 	"keys": ["ctrl+l","t","a", "d"],
+		"context":  [
+			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"}],
+		"command": "toggle_auto", "args": {"which": "tex_directive"}},
 	{ 	"keys": ["ctrl+l","t","a", "b"],
 		"context":  [
 			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"}],

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -127,7 +127,7 @@ LaTeX Package keymap for Windows
 	{	"keys": ["="],
 		"context":  [
 			{"key": "setting.disable_latex_ref_cite_auto_trigger", "operator": "not_equal", "operand": true},
-			{"key": "selector", "operator": "equal", "operand": "text.tex.latex comment.line.percentage.tex"},
+			{"key": "selector", "operator": "equal", "operand": "text.tex.latex comment.line.percentage"},
 			{"key": "selection_empty", "operator": "equal", "operand": true, "match_all": true},
 			{"key": "lt_fill_all_directive.equal_sign", "operator": "equal", "match_all": true, "operand": true}],
 		"command": "latex_fill_all", "args": {"completion_type": "directive", "insert_char": "="}},

--- a/LaTeXTools.sublime-settings
+++ b/LaTeXTools.sublime-settings
@@ -30,6 +30,10 @@
 	// You can also use toggle: C-l,t,a,e
 	"env_auto_trigger": false,
 
+	// Fill-helper autocompletion trigger for tex directive values after TEX directive=
+	// You can also use toggle: C-l,t,a,d
+	"tex_directive_auto_trigger": true,
+
 	// Controls whether the various fill-helpers should try to insert a
 	// completing }, ], or ) when inserted and either the C-l,C-f or C-l,x
 	// keybindings were used to trigger the completion. This attempts to be smart

--- a/latex_directive_completions.py
+++ b/latex_directive_completions.py
@@ -133,6 +133,49 @@ def _directive_program_completions(view, value, ac=True):
     return comp
 
 
+def _directive_output_directory_completions(view, value, ac=True):
+    if not ac:
+        # deal popup panel trigger
+        comp = [
+            (["Other", "Define your own path"], ""),
+            (["Cache", "Use LaTeXTools cache path"], "<<cache>>"),
+            (["Project", "Use a folder relative to project root"],
+             "<<project>>"),
+            (["Temporary", "Use a temporary directory"], "<<temp>>")
+        ]
+        comp = [
+            c for c in comp
+            if c[1].startswith(value) or c[1].startswith("<<" + value)
+        ]
+        return [c[0] for c in comp], [c[1] for c in comp]
+
+    if value.endswith(">>"):
+        return []
+
+    # special behavior to deal with << and  and >
+    if value.endswith(">"):
+        lstrip = len(value)
+    elif value.startswith("<<"):
+        lstrip = 2
+    elif value.startswith("<"):
+        lstrip = 1
+    else:
+        lstrip = 0
+    comp = [
+        ("cache\tLaTeXTools cache", "<<cache>>"),
+        ("project\tRelative to project", "<<project>>"),
+        ("temp\tTemporary directory", "<<temp>>"),
+    ]
+    comp = [
+        (c[0], c[1][lstrip:]) for c in comp
+        if c[0].startswith(value) or c[1].startswith(value)
+    ]
+    return comp
+
+
+_directive_aux_directory_completions = _directive_output_directory_completions
+
+
 _EXCLAMATION_MARK_RE = re.compile(
     r"%+\s*!"
     r"$",
@@ -222,7 +265,7 @@ class LatexDirectiveCompletion(sublime_plugin.EventListener):
         ]
         if _EXCLAMATION_MARK_RE.match(line_str):
             row, _ = view.rowcol(point)
-            # do this completion only in the first 10 lines
+            # do this completion only in the first 20 lines
             if row < 20:
                 comp = [
                     ("TEX {0}\tTEX directive".format(s), "TEX " + s)

--- a/latex_directive_completions.py
+++ b/latex_directive_completions.py
@@ -183,6 +183,9 @@ class DirectiveFillAllHelper(FillAllHelper):
     def matches_line(self, line):
         return bool(_REVERSE_LINE_MATCH_RE.match(line))
 
+    def get_supported_scope_selector(self):
+        return "comment"
+
     def is_enabled(self):
         return get_setting("tex_directive_auto_trigger", True)
 

--- a/latex_directive_completions.py
+++ b/latex_directive_completions.py
@@ -191,7 +191,7 @@ class DirectiveFillAllHelper(FillAllHelper):
         return bool(_REVERSE_LINE_MATCH_RE.match(line))
 
     def is_enabled(self):
-        return get_setting('cite_auto_trigger', True)
+        return get_setting("tex_directive_auto_trigger", True)
 
 
 class LatexDirectiveCompletion(sublime_plugin.EventListener):

--- a/latex_directive_completions.py
+++ b/latex_directive_completions.py
@@ -74,9 +74,7 @@ def _directive_root_completions(view, value, ac=True):
 
     len_prefix = len([v for v in value if v in [".", "/"]])
     tex_files = [
-        # (s, s[len_prefix:])
-        s
-        for s in tex_files
+        s for s in tex_files
         if s.startswith(value) or
         (not len_prefix and s.startswith("./" + value))
     ]

--- a/latex_directive_completions.py
+++ b/latex_directive_completions.py
@@ -173,18 +173,11 @@ class DirectiveFillAllHelper(FillAllHelper):
         return comp
 
     def get_auto_completions(self, view, prefix, line):
-        print("get_auto_completions")
         comp = self._get_completions(view, prefix, line, ac=True)
-
-        # print("comp:", comp)
         return comp
 
     def get_completions(self, view, prefix, line):
-        print("get_completions")
-        print("prefix: '%s'" % prefix)
-        print("line:", line)
         comp = self._get_completions(view, prefix, line, ac=False)
-        # print("comp:", comp)
         return comp
 
     def matches_line(self, line):

--- a/latex_directive_completions.py
+++ b/latex_directive_completions.py
@@ -1,0 +1,173 @@
+import os
+import re
+
+import sublime
+import sublime_plugin
+
+
+_ST3 = sublime.version() >= "3000"
+
+if _ST3:
+    from . import detect_spellcheck
+    from .latextools_utils import get_setting
+else:
+    import detect_spellcheck
+    from latextools_utils import get_setting
+
+try:
+    installed_locales = sorted(detect_spellcheck._dictionary_mappings.keys())
+except:
+    installed_locales = ["en", "en-en", "en-us"]
+
+
+def _prettify_locale(loc):
+    if "-" not in loc:
+        return loc
+    try:
+        lang, country = loc.split("-")
+    except ValueError:
+        return loc
+    return "{0}_{1}".format(lang, country.upper())
+
+
+def _directive_root_completions(view, value):
+    if not view.file_name():
+        return []
+
+    directory, base_name = os.path.split(view.file_name())
+    exts = get_setting("tex_file_exts", view=view)
+
+    def is_tex_file(file_name):
+        return any(file_name.endswith(e) for e in exts)
+
+    def list_tex_files(dir_path):
+        return (f for f in os.listdir(dir_path) if is_tex_file(f))
+
+    tex_files = [
+        "./" + f for f in list_tex_files(directory) if not base_name == f
+    ]
+
+    # search up to 3 empty folders for tex files
+    search_threshold = 3
+    search_miss = 0
+
+    path = "../"
+
+    while search_miss < search_threshold:
+        parent = os.path.abspath(os.path.join(directory, path))
+
+        parent_tex_files = list(path + s for s in list_tex_files(parent))
+        tex_files.extend(parent_tex_files)
+
+        if not parent_tex_files:
+            search_miss += 1
+        else:
+            search_miss = 0
+
+        path += "../"
+        # ensure we are not going into an infinite loop if someone
+        # is working on the root directory
+        if parent == os.path.abspath(os.path.join(directory, path)):
+            break
+
+    len_prefix = len([v for v in value if v in [".", "/"]])
+    tex_files = [
+        # (s, s[len_prefix:])
+        s
+        for s in tex_files
+        if s.startswith(value) or
+        (not len_prefix and s.startswith("./" + value))
+    ]
+
+    comp = [(s + "\ttex-file", s[len_prefix:]) for s in tex_files]
+    return comp
+
+
+def _directive_spellcheck_completions(view, value):
+
+    user_sc = get_setting("tex_spellcheck_paths", view=view, default={})
+    locales = sorted(user_sc.keys())
+
+    locales.extend(installed_locales)
+
+    def get_locale(loc):
+        try:
+            loc = detect_spellcheck.normalize_locale(loc)
+            dic = user_sc.get(loc) or detect_spellcheck.get_dict_path(loc)
+            _, dic = os.path.split(dic)
+        except:
+            dic = "locale"
+        return dic
+    locales = [
+        loc
+        for loc in map(_prettify_locale, locales)
+        if loc.startswith(value)
+    ]
+
+    comp = [
+        ("{0}\t{1}".format(loc, get_locale(loc)), loc)
+        for loc in locales
+    ]
+    return comp
+
+
+def _directive_program_completions(view, value):
+
+    engines = [
+        "pdflatex", "xelatex", "lualatex", "pdftex", "xetex", "luatex"
+    ]
+    engines = [e for e in engines if e.startswith(value)]
+    comp = [(e + "\ttex-program", e) for e in engines]
+    return comp
+
+
+class LatexDirectiveCompletion(sublime_plugin.EventListener):
+    def on_query_completions(self, view, prefix, locations):
+        if len(locations) > 1:
+            return
+        # return
+        point = locations[0]
+        if not view.score_selector(
+                point, "text.tex.latex comment.line.percentage.tex"):
+            return
+
+        line_str = view.substr(sublime.Region(view.line(point).a, point))
+        if prefix:
+            line_str = line_str[:-len(prefix)]
+
+        # circumvent completion if it cannot be possible
+        if "!" not in line_str:
+            return
+
+        comp = None
+
+        ts_directives = ["root", "spellcheck", "program"]
+        if re.match("\s*%\s*!$", line_str):
+            comp = [
+                ("TEX {0}\tTS-directive".format(s), "TEX " + s)
+                for s in ts_directives
+            ]
+        elif re.match("\s*%\s*!TEX\s+$", line_str):
+            comp = [(s + "\tTS-directive", s) for s in ts_directives]
+        else:
+            m = re.match("\s*%\s*!TEX\s+([\w-]+)\s*=\s*(.*)$", line_str)
+            if not m:
+                return
+            directive = m.group(1).lower()
+            # remove leading TS-
+            if directive.startswith("ts-"):
+                directive = directive[3:]
+            value = m.group(2) + prefix
+            function = "_directive_{0}_completions".format(directive)
+            # call the completion
+            try:
+                comp = globals().get(function)(view, value)
+            except:
+                pass
+
+        if comp is not None:
+            return (
+                comp,
+                sublime.INHIBIT_WORD_COMPLETIONS |
+                sublime.INHIBIT_EXPLICIT_COMPLETIONS
+            )

--- a/latex_fill_all.py
+++ b/latex_fill_all.py
@@ -650,6 +650,8 @@ class LatexFillAllEventListener(
         completion type, e.g. "lt_fill_all_cite", etc.
         '''
         # quick exit conditions
+        if not key.startswith("lt_fill_all_"):
+            return None
         for sel in view.sel():
             point = sel.b
             if not view.score_selector(point, "text.tex.latex"):

--- a/latex_fill_all.py
+++ b/latex_fill_all.py
@@ -577,6 +577,19 @@ class LatexFillHelper(object):
             for start, end in tuples
         ]
 
+    def score_selector(self, view, selector):
+        '''
+        Scores a selector on a view, returns True if the selectors is
+        scored for each selection.
+
+        :param view:
+            the current view
+
+        :param selector:
+            the selector, which should be scored
+        '''
+        return all(view.score_selector(sel.b, selector) for sel in view.sel())
+
 
 class LatexFillAllPluginConsumer(object):
     '''
@@ -675,6 +688,10 @@ class LatexFillAllEventListener(
         if not(completion_type and completion_type.is_enabled()):
             return False
 
+        selector = completion_type.get_supported_scope_selector()
+        if not self.score_selector(view, selector):
+            return False
+
         lines = [
             insert_char + view.substr(
                 getRegion(view.line(sel).begin(), sel.b)
@@ -743,6 +760,10 @@ class LatexFillAllEventListener(
                 break
 
         if completion_type is None:
+            self.clear_bracket_cache()
+            return []
+        elif not self.score_selector(
+                view, completion_type.get_supported_scope_selector()):
             self.clear_bracket_cache()
             return []
         # completions could be unpredictable if we've changed the prefix
@@ -996,6 +1017,10 @@ class LatexFillAllCommand(
         # inserting a comma or bracket; otherwise, it must've been a keypress
         if insert_char and not completion_type.is_enabled():
             self.complete_brackets(view, edit, insert_char)
+            return
+
+        selector = completion_type.get_supported_scope_selector()
+        if not self.score_selector(view, selector):
             return
 
         # we are not adding a bracket or comma, we do not have a fancy prefix

--- a/latex_fill_all.py
+++ b/latex_fill_all.py
@@ -652,9 +652,7 @@ class LatexFillAllEventListener(
         # quick exit conditions
         for sel in view.sel():
             point = sel.b
-            if (
-                view.score_selector(point, "text.tex.latex") == 0
-            ):
+            if not view.score_selector(point, "text.tex.latex"):
                 return None
 
         # load the plugins
@@ -709,9 +707,7 @@ class LatexFillAllEventListener(
 
     def on_query_completions(self, view, prefix, locations):
         for location in locations:
-            if (
-                view.score_selector(location, "text.tex.latex") == 0
-            ):
+            if not view.score_selector(location, "text.tex.latex"):
                 return
 
         completion_types = self.get_completion_types()
@@ -882,9 +878,7 @@ class LatexFillAllCommand(
 
         for sel in view.sel():
             point = sel.b
-            if (
-                view.score_selector(point, "text.tex.latex") == 0
-            ):
+            if not view.score_selector(point, "text.tex.latex"):
                 self.complete_brackets(view, edit, insert_char)
                 return
 
@@ -1017,10 +1011,6 @@ class LatexFillAllCommand(
         # inserting a comma or bracket; otherwise, it must've been a keypress
         if insert_char and not completion_type.is_enabled():
             self.complete_brackets(view, edit, insert_char)
-            return
-
-        selector = completion_type.get_supported_scope_selector()
-        if not self.score_selector(view, selector):
             return
 
         # we are not adding a bracket or comma, we do not have a fancy prefix

--- a/latex_fill_all.py
+++ b/latex_fill_all.py
@@ -54,7 +54,7 @@ class LatexFillHelper(object):
     #
     # defines non-word characters. See get_current_word
     WORD_SEPARATOR_RX = re.compile(
-        r'([^{}\[\],\\$&#^~%\s]*)',
+        r'([^{}\[\],\\$&#^~%\s=]*)',
         re.UNICODE
     )
 
@@ -626,7 +626,8 @@ class LatexFillAllEventListener(
     SUPPORTED_INSERT_CHARS = {
         'open_curly': '{',
         'open_square': '[',
-        'comma': ','
+        'comma': ',',
+        'equal_sign': '='
     }
 
     def on_query_context(self, view, key, operator, operand, match_all):
@@ -639,8 +640,7 @@ class LatexFillAllEventListener(
         for sel in view.sel():
             point = sel.b
             if (
-                view.score_selector(point, "text.tex.latex") == 0 or
-                view.score_selector(point, "comment") > 0
+                view.score_selector(point, "text.tex.latex") == 0
             ):
                 return None
 
@@ -693,8 +693,7 @@ class LatexFillAllEventListener(
     def on_query_completions(self, view, prefix, locations):
         for location in locations:
             if (
-                view.score_selector(location, "text.tex.latex") == 0 or
-                view.score_selector(location, "comment") > 0
+                view.score_selector(location, "text.tex.latex") == 0
             ):
                 return
 
@@ -863,8 +862,7 @@ class LatexFillAllCommand(
         for sel in view.sel():
             point = sel.b
             if (
-                view.score_selector(point, "text.tex.latex") == 0 or
-                view.score_selector(point, "comment") > 0
+                view.score_selector(point, "text.tex.latex") == 0
             ):
                 self.complete_brackets(view, edit, insert_char)
                 return

--- a/latextools_utils/internal_types.py
+++ b/latextools_utils/internal_types.py
@@ -59,6 +59,14 @@ class FillAllHelper(LaTeXToolsPlugin):
         '''
         return False
 
+    def get_supported_scope_selector(self):
+        '''
+        Returns the scope selector, in which the completion should be
+        enabled. Default value is outside comments (- comment).
+        Omit text.tex.latex, because it is always checked.
+        '''
+        return '- comment'
+
     # subclass may implement matches_fancy_prefix(self, line) to
     # support a fancy prefix, such as \cite_prefix, etc.
 

--- a/toggle_show.py
+++ b/toggle_show.py
@@ -16,6 +16,7 @@ _toggle_settings = [
     "cite_auto_trigger",
     "fill_auto_trigger",
     "env_auto_trigger",
+    "tex_directive_auto_trigger",
     "smart_bracket_auto_trigger"
 ]
 


### PR DESCRIPTION
This add the `!TEX` directives to the fill all helper, supported directives are:

- `program` show the programs `pdflatex`, `xelatex`, `lualatex` and also `pdftex`, `xetex`, `luatex`
- `root` seach current folder and parent folders for tex files
- `spellcheck` show the supported locales

Each entry is added in the auto completion menu, if you write `% !TEX`. In addition it adds a trigger on `=`.

@ig0774 This still requires minor changes in the fill all helper, because it blacklist comment scopes. It might be good to add a method `get_supported_scopes`, which returns the scopes and is `-comment` by default.