### PR TITLE
Improved keybinding for inserting $ pairs

### DIFF
--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -262,13 +262,30 @@ LaTeX Package keymap for Linux
 	"context":  
 		[
 			{ "key": "setting.command_mode", "operator": "equal", "operand": false },
-			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"},
+			{ "key": "selector", "operator": "equal", "operand": "text.tex.latex" },
 			{ "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
 			{ "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
-			/*{ "key": "following_text", "operator": "regex_contains", "operand": "^(?:\t| |\\)|])", "match_all": true },*/
-			{ "key": "preceding_text", "operator": "not_regex_contains", "operand": "[\"a-zA-Z0-9_]$", "match_all": true },
-			{ "key": "eol_selector", "operator": "not_equal", "operand": "string.quoted.double", "match_all": true }
+			// do not insert this if it is escaped
+			{ "key": "preceding_text", "operator": "not_regex_contains", "operand": "(?:\\\\\\\\)*(?:\\\\|\\$)$", "match_all": true },
+			// don't insert, it inside math environments
+			{ "key": "selector", "operator": "not_equal", "operand": "meta.environment.math, string.other.math", "match_all": true },
+			// don't insert, if there is an open dollar math environment at the end of the line
+			{ "key": "eol_selector", "operator": "not_equal", 
+			  "operand": "meta.environment.math.inline.dollar - punctuation.definition.string.end, string.other.math - punctuation.definition.string.end",
+			  "match_all": true }
 		] 
+	},
+	// fully close $$ environments
+	{ "keys": ["$"], "command": "insert", "args": {"characters": "$$"}, 
+	"context":
+		[
+			{ "key": "setting.command_mode", "operator": "equal", "operand": false },
+			{ "key": "selector", "operator": "equal", "operand": "text.tex.latex meta.environment.math.block.dollar" },
+			{ "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
+			{ "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
+			// do not insert this if it is escaped
+			{ "key": "preceding_text", "operator": "not_regex_contains", "operand": "(?:\\\\\\\\)*(?:\\\\|\\$)$", "match_all": true }
+		]
 	},
 	// wrap in $
 	{ "keys": ["$"], "command": "insert_snippet", "args": {"contents": "\\$${0:$SELECTION}\\$"}, "context":

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -262,13 +262,30 @@ LaTeX Package keymap for OS X
 	"context":  
 		[
 			{ "key": "setting.command_mode", "operator": "equal", "operand": false },
-			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"},
+			{ "key": "selector", "operator": "equal", "operand": "text.tex.latex" },
 			{ "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
 			{ "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
-			/*{ "key": "following_text", "operator": "regex_contains", "operand": "^(?:\t| |\\)|])", "match_all": true },*/
-			{ "key": "preceding_text", "operator": "not_regex_contains", "operand": "[\"a-zA-Z0-9_]$", "match_all": true },
-			{ "key": "eol_selector", "operator": "not_equal", "operand": "string.quoted.double", "match_all": true }
+			// do not insert this if it is escaped
+			{ "key": "preceding_text", "operator": "not_regex_contains", "operand": "(?:\\\\\\\\)*(?:\\\\|\\$)$", "match_all": true },
+			// don't insert, it inside math environments
+			{ "key": "selector", "operator": "not_equal", "operand": "meta.environment.math, string.other.math", "match_all": true },
+			// don't insert, if there is an open dollar math environment at the end of the line
+			{ "key": "eol_selector", "operator": "not_equal", 
+			  "operand": "meta.environment.math.inline.dollar - punctuation.definition.string.end, string.other.math - punctuation.definition.string.end",
+			  "match_all": true }
 		] 
+	},
+	// fully close $$ environments
+	{ "keys": ["$"], "command": "insert", "args": {"characters": "$$"}, 
+	"context":
+		[
+			{ "key": "setting.command_mode", "operator": "equal", "operand": false },
+			{ "key": "selector", "operator": "equal", "operand": "text.tex.latex meta.environment.math.block.dollar" },
+			{ "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
+			{ "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
+			// do not insert this if it is escaped
+			{ "key": "preceding_text", "operator": "not_regex_contains", "operand": "(?:\\\\\\\\)*(?:\\\\|\\$)$", "match_all": true }
+		]
 	},
 	// wrap in $
 	{ "keys": ["$"], "command": "insert_snippet", "args": {"contents": "\\$${0:$SELECTION}\\$"}, "context":

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -262,13 +262,30 @@ LaTeX Package keymap for Windows
 	"context":  
 		[
 			{ "key": "setting.command_mode", "operator": "equal", "operand": false },
-			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"},
+			{ "key": "selector", "operator": "equal", "operand": "text.tex.latex" },
 			{ "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
 			{ "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
-			/*{ "key": "following_text", "operator": "regex_contains", "operand": "^(?:\t| |\\)|])", "match_all": true },*/
-			{ "key": "preceding_text", "operator": "not_regex_contains", "operand": "[\"a-zA-Z0-9_]$", "match_all": true },
-			{ "key": "eol_selector", "operator": "not_equal", "operand": "string.quoted.double", "match_all": true }
+			// do not insert this if it is escaped
+			{ "key": "preceding_text", "operator": "not_regex_contains", "operand": "(?:\\\\\\\\)*(?:\\\\|\\$)$", "match_all": true },
+			// don't insert, it inside math environments
+			{ "key": "selector", "operator": "not_equal", "operand": "meta.environment.math, string.other.math", "match_all": true },
+			// don't insert, if there is an open dollar math environment at the end of the line
+			{ "key": "eol_selector", "operator": "not_equal", 
+			  "operand": "meta.environment.math.inline.dollar - punctuation.definition.string.end, string.other.math - punctuation.definition.string.end",
+			  "match_all": true }
 		] 
+	},
+	// fully close $$ environments
+	{ "keys": ["$"], "command": "insert", "args": {"characters": "$$"}, 
+	"context":
+		[
+			{ "key": "setting.command_mode", "operator": "equal", "operand": false },
+			{ "key": "selector", "operator": "equal", "operand": "text.tex.latex meta.environment.math.block.dollar" },
+			{ "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
+			{ "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
+			// do not insert this if it is escaped
+			{ "key": "preceding_text", "operator": "not_regex_contains", "operand": "(?:\\\\\\\\)*(?:\\\\|\\$)$", "match_all": true }
+		]
 	},
 	// wrap in $
 	{ "keys": ["$"], "command": "insert_snippet", "args": {"contents": "\\$${0:$SELECTION}\\$"}, "context":


### PR DESCRIPTION
This fixes https://github.com/SublimeText/LaTeXTools/issues/857 and does several improvements for inserting $ pairs including better compatibility for the new LaTeX Syntax.