### PR TITLE
CWL-completions for \begin{}...\end{}

### DIFF
--- a/latex_cwl_completions.py
+++ b/latex_cwl_completions.py
@@ -500,7 +500,7 @@ def parse_line_as_environment(line):
 
 
 def parse_line_as_command(line):
-    return line, command_to_snippet(line)
+    return command_to_snippet(line)
 
 
 # actually does the parsing of the cwl files
@@ -533,10 +533,14 @@ def parse_cwl_file(cwl, s, parse_line=parse_line_as_command):
         # tracking purposes, but we can ignore it
         line = line.split('#', 1)[0]
 
+        # trailing spaces aren't relevant (done here in case they precede)
+        # a # char
+        line = line.rstrip()
+
         result = parse_line(line)
         if result is None:
             continue
-        (keyword, insertion) = result
+        keyword, insertion = result
         item = (u'%s\t%s' % (keyword, method), insertion)
         completions.append(item)
 

--- a/latex_cwl_completions.py
+++ b/latex_cwl_completions.py
@@ -541,6 +541,11 @@ def parse_cwl_file(cwl, s, parse_line=parse_line_as_command):
         if result is None:
             continue
         keyword, insertion = result
+
+        # pad the keyword with spaces; this is to keep the size of the
+        # autocompletions consistent regardless of the returned results
+        keyword = keyword.ljust(50)
+
         item = (u'%s\t%s' % (keyword, method), insertion)
         completions.append(item)
 

--- a/latextools_utils/parser_utils.py
+++ b/latextools_utils/parser_utils.py
@@ -1,9 +1,14 @@
 import re
 
 # used to convert arguments and optional arguments into fields
-BRACES_MATCH_REGEX = re.compile(r'\{([^\{\}\[\]]*)\}|\[([^\{\}\[\]]*)\]')
+BRACES_MATCH_RX = re.compile(r'\{([^\}]*)\}|\[([^\]]*)\]')
 
-ALPHAS_REGEX = re.compile(r'^[a-zA-Z]+$')
+ALPHAS_RX = re.compile(r'^[a-zA-Z]+$')
+
+BEGIN_ENV_RX = re.compile(
+    r'\\begin{(?P<name>[^\}]*)\}'
+    r'(?:(?P<remainder1>.*)(?P<item>\\item)|(?P<remainder2>.*))'
+)
 
 
 def command_to_snippet(keyword):
@@ -11,7 +16,8 @@ def command_to_snippet(keyword):
     converts a LaTeX command, like \dosomething{arg1}{arg2} into a ST snippet
     like \dosomething{$1:arg1}{$2:arg2}
     '''
-    # Replace strings in [] and {} with snippet syntax
+
+    # replace strings in [] and {} with snippet syntax
     def replace_braces(matchobj):
         replace_braces.index += 1
         if matchobj.group(1) is not None:
@@ -23,13 +29,45 @@ def command_to_snippet(keyword):
 
     replace_braces.index = 0
 
-    replace, n = BRACES_MATCH_REGEX.subn(
-        replace_braces, keyword
-    )
+    # \begin{}...\end{} pairs should be inserted together
+    m = BEGIN_ENV_RX.match(keyword)
+    if m:
+        item = bool(m.group('item'))
+        name = m.group('name')
 
-    # I do not understand why sometimes the input will eat the '\' charactor
-    # before it! This code is to avoid these things.
-    if n == 0 and ALPHAS_REGEX.search(keyword[1:].strip()) is not None:
-        return keyword
+        # \begin{}, no environment
+        if not name:
+            replace, n = BRACES_MATCH_RX.subn(replace_braces, keyword)
+            final = replace + u'\n${0}\n\\end{{$1}}$0'.format(
+                replace_braces.index + 1
+            )
+
+            return keyword, final
+        # \begin{} with environment
+        # only create fields for any other items
+        else:
+            remainder = m.group('remainder1') or m.group('remainder2') or ''
+            replace, n = BRACES_MATCH_RX.subn(replace_braces, remainder)
+
+            final = u'\\begin{{{0}}}{1}\n'.format(name, replace or '')
+            if item:
+                final += u'\\item ${0}\n'.format(replace_braces.index + 1)
+            else:
+                final += u'${0}\n'.format(replace_braces.index + 1)
+            final += u'\\end{{{0}}}$0'.format(name)
+
+            # having \item at the end of the display value messes with
+            # completions thus, we cut the \item off the end
+            if item:
+                return keyword[:-5], final
+            else:
+                return keyword, final
     else:
-        return replace
+        replace, n = BRACES_MATCH_RX.subn(replace_braces, keyword)
+
+        # I do not understand why sometimes the input will eat the '\'
+        # character before it! This code is to avoid these things.
+        if n == 0 and ALPHAS_RX.search(keyword[1:].strip()) is not None:
+            return keyword, keyword
+        else:
+            return keyword, replace


### PR DESCRIPTION
This PR extends CWL-completions to insert the matching `\end{}` tag when a `\begin{}` tag is inserted. In addition, where in the CWL files it indicates that a completion uses `\item`, this will automatically insert a blank `\item`. E.g.,

`\begin{}` expands to:

```latex
\begin{|}

\end{|}
```

(where `|` indicates the cursor)

`\begin{align}` expands to:

```latex
\begin{align}
|
\end{align}
```

`\begin{enumerate}` expands to:

```latex
\begin{enumerate}
\item |
\end{enumerate}
```

Additionally, I've forced the CWL-autocompletion box to be more or less the same size regardless of the completions shown, which hopefully helps with the visibility of some completions.