### PR TITLE
encode tex_dir for Popen, to handle non ANSI characters in it

### DIFF
--- a/makePDF.py
+++ b/makePDF.py
@@ -139,12 +139,13 @@ class CmdThread ( threading.Thread ):
 					# Now create a Popen object
 					try:
 						if self.caller.plat == "windows":
+							encodedTexDir = self.caller.tex_dir.encode(sys.getfilesystemencoding())
 							proc = subprocess.Popen(
 								cmd,
 								startupinfo=startupinfo,
 								stderr=subprocess.STDOUT,
 								stdout=subprocess.PIPE,
-								cwd=self.caller.tex_dir
+								cwd=encodedTexDir
 							)
 						elif self.caller.plat == "osx":
 							proc = subprocess.Popen(

--- a/makePDF.py
+++ b/makePDF.py
@@ -139,13 +139,13 @@ class CmdThread ( threading.Thread ):
 					# Now create a Popen object
 					try:
 						if self.caller.plat == "windows":
-							encodedTexDir = self.caller.tex_dir.encode(sys.getfilesystemencoding())
+							encoded_tex_dir = self.caller.tex_dir.encode(sys.getfilesystemencoding())
 							proc = subprocess.Popen(
 								cmd,
 								startupinfo=startupinfo,
 								stderr=subprocess.STDOUT,
 								stdout=subprocess.PIPE,
-								cwd=encodedTexDir
+								cwd=encoded_tex_dir
 							)
 						elif self.caller.plat == "osx":
 							proc = subprocess.Popen(

--- a/makePDF.py
+++ b/makePDF.py
@@ -139,7 +139,9 @@ class CmdThread ( threading.Thread ):
 					# Now create a Popen object
 					try:
 						if self.caller.plat == "windows":
-							encoded_tex_dir = self.caller.tex_dir.encode(sys.getfilesystemencoding())
+							encoded_tex_dir = self.caller.tex_dir
+							if not _ST3:
+								encoded_tex_dir = encoded_tex_dir.encode(sys.getfilesystemencoding())
 							proc = subprocess.Popen(
 								cmd,
 								startupinfo=startupinfo,


### PR DESCRIPTION
In ST2, Popen can not handle non ANSI characters in cwd parameter with Unicode type.
This patch fixes a build error if the path of tex file has non ANSI characters, eg. CJK characters, on windows.

I have not tested this in ST3.