### PR TITLE
Preview: Fix overly close math preview cropping

### DIFF
--- a/st_preview/preview_math.py
+++ b/st_preview/preview_math.py
@@ -128,6 +128,8 @@ def _create_image(latex_program, latex_document, base_name, color,
             '-density', '{density}x{density}'.format(density=density),
             # change the color form black to the user-defined
             '-fuzz', '99%', '-fill', color, '-opaque', 'black',
+            # trim the content to the real size     
+            '-trim',
             pdf_path, image_path
         ], shell=sublime.platform() == 'windows')
 

--- a/st_preview/preview_math.py
+++ b/st_preview/preview_math.py
@@ -128,8 +128,12 @@ def _create_image(latex_program, latex_document, base_name, color,
             '-density', '{density}x{density}'.format(density=density),
             # change the color form black to the user-defined
             '-fuzz', '99%', '-fill', color, '-opaque', 'black',
-            # trim the content to the real size     
-            '-trim',
+            # trim the content to the real size
+            '-background', 'black',
+            # trim the left side
+            '-gravity', 'East', '-splice', '1x0', '-trim', '+repage',
+            # trim the right side
+            '-gravity', 'West', '-splice', '1x0', '-trim', '+repage',
             pdf_path, image_path
         ], shell=sublime.platform() == 'windows')
 

--- a/st_preview/preview_math.py
+++ b/st_preview/preview_math.py
@@ -40,7 +40,7 @@ default_latex_template = """
 <<packages>>
 <<preamble>>
 \\begin{document}
-$\\mathstrut$ <<content>>
+<<content>>
 \\end{document}
 """
 
@@ -624,8 +624,9 @@ class MathPreviewPhantomListener(sublime_plugin.ViewEventListener,
             open_str = "\\begin{{{env}{star}}}".format(**locals())
             close_str = "\\end{{{env}{star}}}".format(**locals())
 
+        # wrap content plus invisible mathstrut to ensure minimum height
         document_content = (
-            "{open_str}\n{content}\n{close_str}"
+            "{open_str}\n\\mathstrut {content}\n{close_str}"
             .format(**locals())
         )
 

--- a/st_preview/preview_math.py
+++ b/st_preview/preview_math.py
@@ -36,11 +36,11 @@ except:
 
 # the default and usual template for the latex file
 default_latex_template = """
-\\documentclass[preview]{standalone}
+\\documentclass[preview,border=.2pt]{standalone}
 <<packages>>
 <<preamble>>
 \\begin{document}
-<<content>>
+$\\mathstrut$ <<content>>
 \\end{document}
 """
 
@@ -128,8 +128,6 @@ def _create_image(latex_program, latex_document, base_name, color,
             '-density', '{density}x{density}'.format(density=density),
             # change the color form black to the user-defined
             '-fuzz', '99%', '-fill', color, '-opaque', 'black',
-            # trim the content to the real size
-            '-trim',
             pdf_path, image_path
         ], shell=sublime.platform() == 'windows')
 


### PR DESCRIPTION
Give proper padding to math preview's document template and fix too-high baselines of smaller characters. Also remove redundant `-trim` operation in `convert` command.