### PR TITLE
Improved System Check detection of Ghostscript on Windows

### DIFF
--- a/system_check.py
+++ b/system_check.py
@@ -175,7 +175,8 @@ def get_version_info(executable, env=None):
 
     version = '--version'
     # gs / gswin32c has a different format for --version vs -version
-    if os.path.splitext(os.path.basename(executable))[0] in ['gs', 'gswin32c']:
+    if (os.path.splitext(os.path.basename(executable))[0] in
+            ['gs', 'gswin32c', 'gswin64c']):
         version = '-version'
 
     try:
@@ -432,6 +433,8 @@ class SystemCheckThread(threading.Thread):
                 version_info if version_info is not None else u'unavailable'
             ])
 
+        # a list of programs, each program is either a string or a list
+        # of alternatives (e.g. 32/64 bit version)
         programs = [
             'latexmk' if not self.uses_miktex else 'texify', 'pdflatex',
             'xelatex', 'lualatex', 'biber', 'bibtex', 'bibtex8', 'kpsewhich'
@@ -441,11 +444,23 @@ class SystemCheckThread(threading.Thread):
             # ImageMagick requires gs to work with PDFs
             programs += [
                 'convert',
-                'gs' if sublime.platform() != 'windows' else 'gswin32c'
+                ('gs' if sublime.platform() != 'windows'
+                 else ['gswin32c', 'gswin64c', 'gs'])
             ]
 
         for program in programs:
-            location = which(program, path=texpath)
+            if isinstance(program, list):
+                program_list = program
+                program = program_list[0]
+                location = None
+                for p in program_list:
+                    location = which(p, path=texpath)
+                    if location is not None:
+                        program = p
+                        break
+            else:
+                location = which(program, path=texpath)
+
             available = location is not None
 
             if available:


### PR DESCRIPTION
- The System Check now accepts alternative program names and is successful if any of them is present
- Now GhostScript is found on Windows if either gswin32c or gswin64c or gs is installed.

This was suggested by @Gormador in #891.