### PR TITLE
"Properly" handle the shell=... depending on OS, etc.

### DIFF
--- a/builders/scriptBuilder.py
+++ b/builders/scriptBuilder.py
@@ -88,17 +88,12 @@ class ScriptBuilder(PdfBuilder):
 				else:
 					cmd.append(self.base_name)
 
-			if sublime.platform() != 'windows':
-				if not isinstance(cmd, strbase):
-					cmd = u' '.join([quote(s) for s in cmd])
-				self.display("Invoking '{0}'... ".format(cmd))
+			if not isinstance(cmd, strbase):
+				self.display("Invoking '{0}'... ".format(
+					u' '.join([quote(s) for s in cmd])
+				))
 			else:
-				if not isinstance(cmd, strbase):
-					self.display("Invoking '{0}'... ".format(
-						u' '.join([quote(s) for s in cmd])
-					))
-				else:
-					self.display("Invoking '{0}'... ".format(cmd))
+				self.display("Invoking '{0}'... ".format(cmd))
 
 			yield (
 				# run with use_texpath=False as we have already configured

--- a/latextools_utils/external_command.py
+++ b/latextools_utils/external_command.py
@@ -144,8 +144,12 @@ def external_command(command, cwd=None, shell=False, env=None,
     if env is not None:
         update_env(_env, env)
 
-    # if command is a string rather than a list
-    if isinstance(command, strbase):
+    # if command is a string rather than a list, convert it to a list
+    # unless shell is set to True on a non-Windows platform
+    if (
+        (shell is False or sublime.platform() == 'windows') and
+        isinstance(command, strbase)
+    ):
         if sys.version_info < (3,):
             command = str(command)
 
@@ -153,6 +157,11 @@ def external_command(command, cwd=None, shell=False, env=None,
 
         if sys.version_info < (3,):
             command = [unicode(c) for c in command]
+    elif (
+        shell is True and sublime.platform() != 'windows' and
+        (isinstance(command, list) or isinstance(command, tuple))
+    ):
+        command = u' '.join(command)
 
     # Windows-specific adjustments
     startupinfo = None


### PR DESCRIPTION
On Windows, shell=True supports arguments passed as a list, but not so on Linux and OS X, which has to due with the semantics of the underlying calls.

This should fix #894.

TODO:
- [x] Test changes on Windows
- [x] Test changes on ST2