### PR TITLE
Make Sumatra visible on Windows

### DIFF
--- a/builders/scriptBuilder.py
+++ b/builders/scriptBuilder.py
@@ -88,17 +88,12 @@ class ScriptBuilder(PdfBuilder):
 				else:
 					cmd.append(self.base_name)
 
-			if sublime.platform() != 'windows':
-				if not isinstance(cmd, strbase):
-					cmd = u' '.join([quote(s) for s in cmd])
-				self.display("Invoking '{0}'... ".format(cmd))
+			if not isinstance(cmd, strbase):
+				self.display("Invoking '{0}'... ".format(
+					u' '.join([quote(s) for s in cmd])
+				))
 			else:
-				if not isinstance(cmd, strbase):
-					self.display("Invoking '{0}'... ".format(
-						u' '.join([quote(s) for s in cmd])
-					))
-				else:
-					self.display("Invoking '{0}'... ".format(cmd))
+				self.display("Invoking '{0}'... ".format(cmd))
 
 			yield (
 				# run with use_texpath=False as we have already configured

--- a/latextools_utils/external_command.py
+++ b/latextools_utils/external_command.py
@@ -144,8 +144,12 @@ def external_command(command, cwd=None, shell=False, env=None,
     if env is not None:
         update_env(_env, env)
 
-    # if command is a string rather than a list
-    if isinstance(command, strbase):
+    # if command is a string rather than a list, convert it to a list
+    # unless shell is set to True on a non-Windows platform
+    if (
+        (shell is False or sublime.platform() == 'windows') and
+        isinstance(command, strbase)
+    ):
         if sys.version_info < (3,):
             command = str(command)
 
@@ -153,6 +157,11 @@ def external_command(command, cwd=None, shell=False, env=None,
 
         if sys.version_info < (3,):
             command = [unicode(c) for c in command]
+    elif (
+        shell is True and sublime.platform() != 'windows' and
+        (isinstance(command, list) or isinstance(command, tuple))
+    ):
+        command = u' '.join(command)
 
     # Windows-specific adjustments
     startupinfo = None

--- a/latextools_utils/external_command.py
+++ b/latextools_utils/external_command.py
@@ -125,7 +125,7 @@ __sentinel__ = object()
 def external_command(command, cwd=None, shell=False, env=None,
                      stdin=__sentinel__, stdout=__sentinel__,
                      stderr=__sentinel__, preexec_fn=None,
-                     use_texpath=True):
+                     use_texpath=True, show_window=False):
     '''
     Takes a command object to be passed to subprocess.Popen.
 
@@ -170,6 +170,9 @@ def external_command(command, cwd=None, shell=False, env=None,
         startupinfo = subprocess.STARTUPINFO()
         startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
 
+        if show_window:
+            startupinfo.wShowWindow = 1
+
         # encode cwd in the file system encoding; this is necessary to support
         # some non-ASCII paths; see PR #878. Thanks to anamewing for the
         # suggested fix
@@ -211,7 +214,7 @@ def external_command(command, cwd=None, shell=False, env=None,
 def execute_command(command, cwd=None, shell=False, env=None,
                     stdin=__sentinel__, stdout=__sentinel__,
                     stderr=__sentinel__, preexec_fn=None,
-                    use_texpath=True):
+                    use_texpath=True, show_window=False):
     '''
     Takes a command to be passed to subprocess.Popen and runs it. This is
     similar to subprocess.call().
@@ -242,7 +245,8 @@ def execute_command(command, cwd=None, shell=False, env=None,
         stdout=stdout,
         stderr=stderr,
         preexec_fn=preexec_fn,
-        use_texpath=use_texpath
+        use_texpath=use_texpath,
+        show_window=show_window
     )
 
     stdout, stderr = p.communicate()
@@ -256,7 +260,7 @@ def execute_command(command, cwd=None, shell=False, env=None,
 def check_call(command, cwd=None, shell=False, env=None,
                stdin=__sentinel__, stdout=__sentinel__,
                stderr=__sentinel__, preexec_fn=None,
-               use_texpath=True):
+               use_texpath=True, show_window=False):
     '''
     Takes a command to be passed to subprocess.Popen.
 
@@ -280,7 +284,8 @@ def check_call(command, cwd=None, shell=False, env=None,
         stdin=stdin,
         stderr=stderr,
         preexec_fn=preexec_fn,
-        use_texpath=use_texpath
+        use_texpath=use_texpath,
+        show_window=show_window
     )
 
     if returncode:
@@ -295,7 +300,8 @@ def check_call(command, cwd=None, shell=False, env=None,
 
 def check_output(command, cwd=None, shell=False, env=None,
                  stdin=__sentinel__, stderr=__sentinel__,
-                 preexec_fn=None, use_texpath=True):
+                 preexec_fn=None, use_texpath=True,
+                 show_window=False):
     '''
     Takes a command to be passed to subprocess.Popen.
 
@@ -319,7 +325,8 @@ def check_output(command, cwd=None, shell=False, env=None,
         stdin=stdin,
         stderr=stderr,
         preexec_fn=preexec_fn,
-        use_texpath=use_texpath
+        use_texpath=use_texpath,
+        show_window=show_window
     )
 
     if returncode:

--- a/viewers/sumatra_viewer.py
+++ b/viewers/sumatra_viewer.py
@@ -100,7 +100,7 @@ class SumatraViewer(BaseViewer):
         try:
             external_command(
                 [sumatra_binary] + commands,
-                use_texpath=False
+                use_texpath=False, show_window=True
             )
         except OSError:
             exc_info = sys.exc_info()
@@ -110,7 +110,7 @@ class SumatraViewer(BaseViewer):
                 try:
                     external_command(
                         [sumatra_exe] + commands,
-                        use_texpath=False
+                        use_texpath=False, show_window=True
                     )
                 except OSError:
                     traceback.print_exc()


### PR DESCRIPTION
This builds off of #898 and fixes #900.

The problem is that Sumatra actually *was* being launched, but as a hidden window. This fix may require killing a running Sumatra process via the Task Manager.