### PR TITLE
Cache the result of `_get_convert_command`

### DIFF
--- a/st_preview/preview_utils.py
+++ b/st_preview/preview_utils.py
@@ -15,11 +15,15 @@ _lt_settings = {}
 
 
 def _get_convert_command():
+    if hasattr(_get_convert_command, "result"):
+        return _get_convert_command.result
+
     texpath = get_texpath() or os.environ['PATH']
-    return (
+    _get_convert_command.result = (
         which('magick', path=texpath) or
         which('convert', path=texpath)
     )
+    return _get_convert_command.result
 
 
 def convert_installed():

--- a/system_check.py
+++ b/system_check.py
@@ -57,6 +57,9 @@ except ImportError:
     from .jumpToPDF import DEFAULT_VIEWERS
     from .getTeXRoot import get_tex_root
 
+if sublime.version() >= '3118':
+    from .st_preview.preview_utils import convert_installed
+
 if sys.version_info >= (3,):
     unicode = str
 
@@ -470,11 +473,17 @@ class SystemCheckThread(threading.Thread):
                 location, env=env
             ) if available else None
 
+            available_str = (
+                u'available' if available and version_info is not None
+                else u'missing')
+            if (available and program in ['magick', 'convert'] and
+                    not convert_installed()):
+                available_str = u'restart required'
+
             table.append([
                 program,
                 location,
-                (u'available'
-                    if available and version_info is not None else u'missing'),
+                available_str,
                 version_info if version_info is not None else u'unavailable'
             ])
 


### PR DESCRIPTION
This adds a caching for the result of the `_get_convert_command`.

- it does not change, except from the edge case of installing ImageMagick while running ST (just restart ST)
- I assumed `convert_installed` to be constant time (it takes 0.05 - 0.2 s on my machine w/o caching)