### PR TITLE
Preview: Improve the feedback if previewing fails 

### DIFF
--- a/st_preview/preview_image.py
+++ b/st_preview/preview_image.py
@@ -23,6 +23,8 @@ temp_path = None
 
 # we use png files for the html popup
 _IMAGE_EXTENSION = ".png"
+# we add this extension to log error information
+_ERROR_EXTENSION = ".err"
 
 _lt_settings = {}
 
@@ -68,6 +70,10 @@ def create_thumbnail(image_path, thumbnail_path, width, height):
         '-thumbnail', '{width}x{height}'.format(**locals()),
         image_path, thumbnail_path
     ])
+
+    if not os.path.exists(thumbnail_path):
+        with open(thumbnail_path + _ERROR_EXTENSION, "w") as f:
+            f.write("Failed to create preview thumbnail.")
 
 
 # CONVERT THREADING
@@ -191,6 +197,8 @@ def _get_popup_html(thumbnail_path, width, height):
         )
     elif not convert_installed():
         img_tag = "Install ImageMagick to enable preview."
+    elif os.path.exists(thumbnail_path + _ERROR_EXTENSION):
+        img_tag = "ERROR: Failed to create preview thumbnail."
     else:
         img_tag = "Preparing image for preview..."
     html_content = """
@@ -411,6 +419,8 @@ class PreviewImagePhantomListener(sublime_plugin.ViewEventListener,
                 """.format(**locals())
             elif convert_installed():
                 html_content += """Preparing image for preview..."""
+            elif os.path.exists(p.thumbnail_path + _ERROR_EXTENSION):
+                img_tag = "ERROR: Failed to create preview thumbnail."
             else:
                 html_content += (
                     "Install ImageMagick to enable a preview for "

--- a/st_preview/preview_math.py
+++ b/st_preview/preview_math.py
@@ -182,7 +182,7 @@ def _run_image_jobs():
 
 
 def _wrap_html(html_content, color=None, background_color=None):
-    if background_color:
+    if color or background_color:
         style = "<style>"
         style += "body {"
         if color:

--- a/st_preview/preview_math.py
+++ b/st_preview/preview_math.py
@@ -1,4 +1,5 @@
 import base64
+import html
 import os
 import re
 import struct
@@ -50,6 +51,8 @@ temp_path = None
 
 # we use png files for the html popup
 _IMAGE_EXTENSION = ".png"
+# we add this extension to log error information
+_ERROR_EXTENSION = ".err"
 
 _scale_quotient = 1
 _density = 150
@@ -133,6 +136,17 @@ def _create_image(latex_program, latex_document, base_name, color,
             pdf_path, image_path
         ])
 
+    err_file_path = image_path + _ERROR_EXTENSION
+    if not pdf_exists:
+        with open(err_file_path, "w") as f:
+            f.write(
+                "Failed to run '{latex_program}' to create pdf to preview."
+                .format(**locals())
+            )
+    elif not os.path.exists(image_path):
+        with open(err_file_path, "w") as f:
+            f.write("Failed to convert pdf to png to preview.")
+
     # cleanup created files
     for ext in ["tex", "aux", "log", "pdf", "dvi"]:
         delete_path = os.path.join(temp_path, base_name + "." + ext)
@@ -200,6 +214,17 @@ def _wrap_html(html_content, color=None, background_color=None):
         '</body>'
         .format(**locals())
     )
+    return html_content
+
+
+def _generate_error_html(view, image_path, style_kwargs):
+    content = "ERROR: "
+    with open(image_path + _ERROR_EXTENSION, "r") as f:
+        content += f.read()
+
+    html_content = html.escape(content, quote=False)
+
+    html_content = _wrap_html(html_content, **style_kwargs)
     return html_content
 
 
@@ -650,11 +675,16 @@ class MathPreviewPhantomListener(sublime_plugin.ViewEventListener,
     def _make_cont(self, p, image_path, update_time, style_kwargs):
         def cont():
             # if the image does not exists do nothing
-            if not os.path.exists(image_path):
+            if os.path.exists(image_path):
+                # generate the html
+                html_content = _generate_html(
+                    self.view, image_path, style_kwargs)
+            elif os.path.exists(image_path + _ERROR_EXTENSION):
+                # inform the user about the error
+                html_content = _generate_error_html(
+                    self.view, image_path, style_kwargs)
+            else:
                 return
-
-            # generate the html
-            html_content = _generate_html(self.view, image_path, style_kwargs)
             # move to main thread and update the phantom
             sublime.set_timeout(
                 self._update_phantom_content(p, html_content, update_time)


### PR DESCRIPTION
Add error information in the the phantom/popup, if the generation of the preview image fails.

- The user now knows whether it fails or just takes a long time
- The step where it fails "creating pdf"/"converting pdf to png" is added to improve the debugging
- I creates an error file. We may append further error informations to that file to improve the debugging process further.