### PR TITLE
Preview: Move the color from ImageMagick to the tex file

### DIFF
--- a/LaTeXTools (Advanced).sublime-settings
+++ b/LaTeXTools (Advanced).sublime-settings
@@ -110,7 +110,9 @@
 	// path and the template MUST NOT INCLUDE OTHER FILES.
 	// The file should should contain a field <<content>>, which will be substituted
 	// by the compilation content.
-	"preview_math_latex_template_file": null,
+	// If you want to have colorful equations you should use the package xcolor and
+	// add the field <<set_color>> at the begin of the document (above <<content>>).
+	"preview_math_template_file": null,
 
 	// The maximal number of thread used to convert images for the math live preview
 	// and the image preview (which requires this to convert pdf files to png thumbnails).

--- a/LaTeXTools.sublime-settings
+++ b/LaTeXTools.sublime-settings
@@ -119,6 +119,7 @@
 
 	// An array of the used packages, from which the file for the live preview
 	// will be generated.
+	// (The xcolor package will be present, even if not in this list.)
 	"preview_math_template_packages": [
 		"\\usepackage{amsmath}",
 		"\\usepackage{amssymb}",
@@ -129,6 +130,7 @@
 	// An string of the remaining preamble (not packages) for the file,
 	// which generates the math live preview.
 	// Can also be an array, with an string for each line (as in the packages).
+	// For technical reasons DON'T include other files.
 	"preview_math_template_preamble": "",
 
 	// The preview functionality by default appends a star (*) to each

--- a/LaTeXTools.sublime-settings
+++ b/LaTeXTools.sublime-settings
@@ -105,6 +105,7 @@
 	"preview_math_latex_compile_program": "pdflatex",
 
 	// The color of the text in the preview math phantoms.
+	// Ensure you have the latex xcolor package available to change the color.
 	// The format can either be RGB based "#RRGGBB" (e.g. "#FFFF00") 
 	// or a color name (e.g. "yellow")
 	// If it is the empty string "" it will be guessed based in the color scheme.

--- a/st_preview/preview_math.py
+++ b/st_preview/preview_math.py
@@ -19,6 +19,10 @@ from . import preview_threading as pv_threading
 # export the listener
 exports = ["MathPreviewPhantomListener"]
 
+# increase this number if you change the convert command to mark the
+# generated images as expired
+_version = 1
+
 
 try:
     import mdpopups
@@ -37,9 +41,13 @@ except:
 # the default and usual template for the latex file
 default_latex_template = """
 \\documentclass[preview]{standalone}
+% import xcolor if available and not already present
+\\IfFileExists{xcolor.sty}{\\usepackage{xcolor}}{}%
 <<packages>>
 <<preamble>>
 \\begin{document}
+% set the foreground color
+\\IfFileExists{xcolor.sty}{<<set_color>>}{}%
 <<content>>
 \\end{document}
 """
@@ -126,8 +134,6 @@ def _create_image(latex_program, latex_document, base_name, color,
         run_convert_command([
             # set the image size/density
             '-density', '{density}x{density}'.format(density=density),
-            # change the color form black to the user-defined
-            '-fuzz', '99%', '-fill', color, '-opaque', 'black',
             # trim the content to the real size
             '-trim',
             pdf_path, image_path
@@ -313,7 +319,7 @@ class MathPreviewPhantomListener(sublime_plugin.ViewEventListener,
                 "call_after": update_preamble_str
             },
             "latex_template_file": {
-                "setting": "preview_math_latex_template_file",
+                "setting": "preview_math_template_file",
                 "call_after": update_template_file
             }
         }
@@ -538,6 +544,7 @@ class MathPreviewPhantomListener(sublime_plugin.ViewEventListener,
 
             # create a string, which uniquely identifies the compiled document
             id_str = "\n".join([
+                str(_version),
                 self.latex_program,
                 str(_density),
                 color,
@@ -638,9 +645,16 @@ class MathPreviewPhantomListener(sublime_plugin.ViewEventListener,
         except:
             latex_template = default_latex_template
 
+        if self.color.startswith("#"):
+            color = self.color[1:].upper()
+            set_color = "\\color[HTML]{{{color}}}".format(color=color)
+        else:
+            set_color = "\\color{{{color}}}".format(color=self.color)
+
         latex_document = (
             latex_template
             .replace("<<content>>", document_content, 1)
+            .replace("<<set_color>>", set_color, 1)
             .replace("<<packages>>", self.packages_str, 1)
             .replace("<<preamble>>", self.preamble_str, 1)
         )

--- a/st_preview/preview_math.py
+++ b/st_preview/preview_math.py
@@ -540,7 +540,7 @@ class MathPreviewPhantomListener(sublime_plugin.ViewEventListener,
                 )
 
             # generate the latex template
-            latex_document = self._create_document(scope)
+            latex_document = self._create_document(scope, color)
 
             # create a string, which uniquely identifies the compiled document
             id_str = "\n".join([
@@ -596,7 +596,7 @@ class MathPreviewPhantomListener(sublime_plugin.ViewEventListener,
             _extend_image_jobs(view.id(), self.latex_program, job_args)
             _run_image_jobs()
 
-    def _create_document(self, scope):
+    def _create_document(self, scope, color):
         view = self.view
         content = view.substr(scope)
         env = None
@@ -645,11 +645,11 @@ class MathPreviewPhantomListener(sublime_plugin.ViewEventListener,
         except:
             latex_template = default_latex_template
 
-        if self.color.startswith("#"):
-            color = self.color[1:].upper()
+        if color.startswith("#"):
+            color = color[1:].upper()
             set_color = "\\color[HTML]{{{color}}}".format(color=color)
         else:
-            set_color = "\\color{{{color}}}".format(color=self.color)
+            set_color = "\\color{{{color}}}".format(color=color)
 
         latex_document = (
             latex_template


### PR DESCRIPTION
Now the foreground color is set inside the tex file instead of while converting the pdf to png.

This essentially does what @musm and @ig0774  have suggested in #901.