### PR TITLE
Preview: Try to use the view's scope

### DIFF
--- a/st_preview/preview_image.py
+++ b/st_preview/preview_image.py
@@ -1,4 +1,5 @@
 import imghdr
+import inspect
 import os
 import struct
 import threading
@@ -356,8 +357,12 @@ class PreviewImagePhantomListener(sublime_plugin.ViewEventListener,
 
     @classmethod
     def is_applicable(cls, settings):
-        syntax = settings.get('syntax')
-        return syntax == 'Packages/LaTeX/LaTeX.sublime-syntax'
+        try:
+            view = inspect.currentframe().f_back.f_locals['view']
+            return view.score_selector(0, 'text.tex.latex') > 0
+        except KeyError:
+            syntax = settings.get('syntax')
+            return syntax == 'Packages/LaTeX/LaTeX.sublime-syntax'
 
     @classmethod
     def applies_to_primary_view_only(cls):

--- a/st_preview/preview_math.py
+++ b/st_preview/preview_math.py
@@ -1,5 +1,6 @@
 import base64
 import html
+import inspect
 import os
 import re
 import struct
@@ -411,8 +412,12 @@ class MathPreviewPhantomListener(sublime_plugin.ViewEventListener,
 
     @classmethod
     def is_applicable(cls, settings):
-        syntax = settings.get('syntax')
-        return syntax == 'Packages/LaTeX/LaTeX.sublime-syntax'
+        try:
+            view = inspect.currentframe().f_back.f_locals['view']
+            return view.score_selector(0, 'text.tex.latex') > 0
+        except KeyError:
+            syntax = settings.get('syntax')
+            return syntax == 'Packages/LaTeX/LaTeX.sublime-syntax'
 
     @classmethod
     def applies_to_primary_view_only(cls):


### PR DESCRIPTION
An ugly hack to get a reference to the View object to check the syntax scope. This should allow support for previewing when using syntaxes derived from the new LaTeX syntax. Falls back to the current check if it cannot find the View object.