### PR TITLE
Preview: Safe use of some packages

### DIFF
--- a/LaTeXTools.sublime-settings
+++ b/LaTeXTools.sublime-settings
@@ -120,12 +120,13 @@
 
 	// An array of the used packages, from which the file for the live preview
 	// will be generated.
+	// Just write \\usepackage{packagename} to include other packages.
 	// (The xcolor package will be present, even if not in this list.)
 	"preview_math_template_packages": [
 		"\\usepackage{amsmath}",
 		"\\usepackage{amssymb}",
-		"\\usepackage{latexsym}",
-		"\\usepackage{mathtools}"
+		"\\IfFileExists{latexsym.sty}{\\usepackage{latexsym}}{}",
+		"\\IfFileExists{mathtools.sty}{\\usepackage{mathtools}}{}"
 	],
 
 	// An string of the remaining preamble (not packages) for the file,


### PR DESCRIPTION
This only uses the packages `latexsym` and `mathtools`, if they are present. I don't do this for `amsmath`, because we need the `equation*` environment.
I don't now if this change is realy helpful, because standalone, preview, and amsmath are required anyway.