### PR TITLE
Added "newacronym" in glo_filter_commands

### DIFF
--- a/jumpto_anywhere.py
+++ b/jumpto_anywhere.py
@@ -178,7 +178,7 @@ def _jumpto_glo(view, com_reg, pos, acr=False):
     ana = analysis.analyze_document(tex_root)
     if not acr:
         commands = ana.filter_commands(
-            ["newglossaryentry", "longnewglossaryentry"])
+            ["newglossaryentry", "longnewglossaryentry", "newacronym"])
     else:
         commands = ana.filter_commands("newacronym")
 

--- a/latex_glossary_completions.py
+++ b/latex_glossary_completions.py
@@ -27,7 +27,7 @@ ACR_LINE_RE = re.compile(
 def _get_glo_completions(ana, prefix, ac):
     comp = []
     glo_commands = ana.filter_commands(
-        ["newglossaryentry", "longnewglossaryentry"])
+        ["newglossaryentry", "longnewglossaryentry", "newacronym"])
     if ac:
         comp = [(a.args + "\tGlossary", a.args) for a in glo_commands]
     else:


### PR DESCRIPTION
According to the Documentation of the glossaries latex package, \gls{}
command is used for both, the glossary entries and the acronyms.
Although the acronyms are handled by the \acr[full|short|long] command
in the plugin, these do not support that the first usage of the acronym
is written in full form and afterwards in short. Thus, \acr* commands
needs manual handling in latex, which is usually not desired.