### PR TITLE
Preview: Use ghostscript directly for equation previews

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -78,9 +78,15 @@ in the Command field, and `"%file":%line` in the Arguments field. (This is corre
 
 #### Setup ImageMagick and Ghostscript
 
-If you are using Sublime Text 3 version 3118 or later and want to use the image and equation previewing features, you will need to ensure that both ImageMagick 6 or higher and Ghostscript 9 or higher are installed and available on your machine. If you installed the full MacTeX distribution, Ghostscript is already included. If you installed the BasicTeX distribution, you will need to install Ghostscript yourself.
+If you are using Sublime Text 3 version 3118 or later and want to use the equation preview feature, you will need to ensure that Ghostscript 8 or higher is installed and available on the `texpath` defined for your machine. If you installed the full MacTeX distribution, Ghostscript is already included. If you installed the BasicTeX distribution, you will need to install Ghostscript yourself.
 
-The easiest way to install ImageMagick or Ghostscript is to use either [Homebrew](http://brew.sh/) or [MacPorts](https://www.macports.org/). Installing should be as simple as typing the relevant command in the Terminal:
+If you do not want to use the equation preview feature, change the `preview_math_mode` setting to `"none"` when you are configuring your settings.
+
+Similarly, if you would like to use the image preview feature, you will need to ensure that ImageMagick is installed on your machine and available on your `texpath`. Note that to display some image formats, ImageMagick also requires Ghostscript.
+
+If you do not want to use the image preview feature, change the `preview_image_mode` setting to `"none"` when you are configuring your settings.
+
+The easiest way to install Ghostscript or ImageMagick is to use either [Homebrew](http://brew.sh/) or [MacPorts](https://www.macports.org/). Installing should be as simple as typing the relevant command in the Terminal:
 
 |Product|Package Manager|Command|
 |-------|---------------|-------|
@@ -133,10 +139,29 @@ I'm sorry this is not straightforward---it's not my fault :-)
 
 #### Setup ImageMagick and Ghostscript
 
-If you are using Sublime Text 3 version 3118 or later and want to use the image and equation previewing features, you will need to ensure that both ImageMagick 6 or higher and Ghostscript 9 or higher are installed and available on your machine.
+If you are using Sublime Text 3 version 3118 or later and want to use the equation preview feature, you will need to ensure that Ghostscript 8 or higher is installed and available on the `texpath` defined for your machine.
 
-* If you're using TeXLive and you installed the default profile, you should already have Ghostscript installed in `<drive>:path\to\texlive\<year>\tlpkg\tlgs\bin`. Make sure this is added to your `PATH` system variable or to the `texpath` when setting up LaTeXTools.
-* If you are using MiKTeX or do not have Ghostscript installed with your TeXLive distribution, you can simple download and install the [latest release here](http://ghostscript.com/download/gsdnld.html). MiKTeX does bundle a version of Ghostscript, but ImageMagick will not find it.
+If you do not want to use the equation preview feature, change the `preview_math_mode` setting to `"none"` when you are configuring your settings.
+
+To install and setup Ghostcript:
+
+* If you are using MiKTeX, LaTeXTools should automatically find the MiKTeX Ghostscript install, provided MiKTeX is available on your `PATH` system variable or via the LaTeXTools `texpath` setting.
+* If you are using TeXLive and you installed the default profile, you should already have Ghostscript installed in `<drive>:path\to\texlive\<year>\tlpkg\tlgs\bin`. Make sure this is added to your `PATH` system variable or to the `texpath` when setting up LaTeXTools.
+* If you do not have Ghostscript installed, you can simple download and install the [latest release here](http://ghostscript.com/download/gsdnld.html).
+
+Similarly, if you would like to use the image preview feature, you will need to ensure that ImageMagick is installed on your machine and available on your `texpath`.
+
+Note that to display some image formats, ImageMagick also requires Ghostscript.
+* If you are using TeXLive and you installed the default profile, you should already have Ghostscript installed in `<drive>:path\to\texlive\<year>\tlpkg\tlgs\bin`. Make sure this is added to your `PATH` system variable or to the `texpath` when setting up LaTeXTools.
+* If you are using MiKTeX, you can either install the [latest release here](http://ghostscript.com/download/gsdnld.html) of Ghoscript or else you will need to "trick" ImageMagick into using the included Ghostscript executable called `mgs.exe`. The easiest way to do this is to create a softlink called `gswin32c.exe` in the same folder as `mgs.exe`. To do this, from an command prompt run as administrator run the following command:
+
+```
+mklink C:\Program Files\MiKTeX\miktex\bin\gswin32c.exe C:\Program Files\MiKTeX\miktex\bin\mgs.exe
+```
+
+(Note that you may need to adjust the paths to reflect were you installed MiKTeX.)
+
+If you do not want to use the image preview feature, change the `preview_image_mode` setting to `"none"` when you are configuring your settings.
 
 To install ImageMagick, download and install a release from [the ImageMagick website](http://www.imagemagick.org/script/binary-releases.php#windows). For the easiest setup, make sure you select the **Add application directory to your system path** option when installing. Otherwise, you will need to either manually add it to your system PATH or add it to your `texpath` setting when setting up LaTeXTools.
 
@@ -162,9 +187,17 @@ You need to install TeXlive. We highly recommend installing the version directly
 
 #### Setup ImageMagick and Ghostscript
 
-If you are using Sublime Text 3 version 3118 or later and want to use the image and equation previewing features, you will need to ensure that both ImageMagick 6 or higher and Ghostscript 9 or higher are installed and available on your machine.
+If you are using Sublime Text 3 version 3118 or later and want to use the equation preview feature, you will need to ensure that Ghostscript 8 or higher is installed and available on the `texpath` defined for your machine.
 
-If you installed the full TeXLive profile from TUG, you should already have a version of Ghostscript installed. Otherwise, it can simply be installed using your distribution's package manager. ImageMagick should also be available the same way. Once again, you can use the **LaTeXTools: Check System** command to verify that these are setup.
+If you do not want to use the equation preview feature, change the `preview_math_mode` setting to `"none"` when you are configuring your settings.
+
+Similarly, if you would like to use the image preview feature, you will need to ensure that ImageMagick is installed on your machine and available on your `texpath`. Note that for some image formats, ImageMagick also requires Ghostscript to be installed.
+
+If you do not want to use the image preview feature, change the `preview_image_mode` setting to `"none"` when you are configuring your settings.
+
+If you installed the full TeXLive profile from TUG, you should already have a version of Ghostscript installed. Otherwise, it can simply be installed using your distribution's package manager. ImageMagick should also be available the same way.
+
+Once again, you can use the **LaTeXTools: Check System** command to verify that these are setup in a place LaTeXTools can find.
 
 #### Setup LaTeXTools
 

--- a/README.markdown
+++ b/README.markdown
@@ -78,11 +78,11 @@ in the Command field, and `"%file":%line` in the Arguments field. (This is corre
 
 #### Setup ImageMagick and Ghostscript
 
-If you are using Sublime Text 3 version 3118 or later and want to use the equation preview feature, you will need to ensure that Ghostscript 8 or higher is installed and available on the `texpath` defined for your machine. If you installed the full MacTeX distribution, Ghostscript is already included. If you installed the BasicTeX distribution, you will need to install Ghostscript yourself.
+If you are using Sublime Text 3 version 3118 or later and want to use the equation preview feature or use the image preview feature for PDFs, EPSs, or PSs, you will need to ensure that Ghostscript 8 or higher is installed and available on the `texpath` defined for your machine. If you installed the full MacTeX distribution, Ghostscript is already included. If you installed the BasicTeX distribution, you will need to install Ghostscript yourself.
 
 If you do not want to use the equation preview feature, change the `preview_math_mode` setting to `"none"` when you are configuring your settings.
 
-Similarly, if you would like to use the image preview feature, you will need to ensure that ImageMagick is installed on your machine and available on your `texpath`. Note that to display some image formats, ImageMagick also requires Ghostscript.
+Similarly, if you would like to use the image preview feature to view file types not support by SublimeText or Ghostcript (so anything other than PNGs, JPEGs, GIFs, PDFs, EPSs, and PSs), you will need to ensure that ImageMagick is installed on your machine and available on your `texpath`.
 
 If you do not want to use the image preview feature, change the `preview_image_mode` setting to `"none"` when you are configuring your settings.
 
@@ -139,7 +139,7 @@ I'm sorry this is not straightforward---it's not my fault :-)
 
 #### Setup ImageMagick and Ghostscript
 
-If you are using Sublime Text 3 version 3118 or later and want to use the equation preview feature, you will need to ensure that Ghostscript 8 or higher is installed and available on the `texpath` defined for your machine.
+If you are using Sublime Text 3 version 3118 or later and want to use the equation preview feature or use the image preview feature for PDFs, EPSs, or PSs, you will need to ensure that Ghostscript 8 or higher is installed and available on the `texpath` defined for your machine.
 
 If you do not want to use the equation preview feature, change the `preview_math_mode` setting to `"none"` when you are configuring your settings.
 
@@ -149,17 +149,7 @@ To install and setup Ghostcript:
 * If you are using TeXLive and you installed the default profile, you should already have Ghostscript installed in `<drive>:path\to\texlive\<year>\tlpkg\tlgs\bin`. Make sure this is added to your `PATH` system variable or to the `texpath` when setting up LaTeXTools.
 * If you do not have Ghostscript installed, you can simple download and install the [latest release here](http://ghostscript.com/download/gsdnld.html).
 
-Similarly, if you would like to use the image preview feature, you will need to ensure that ImageMagick is installed on your machine and available on your `texpath`.
-
-Note that to display some image formats, ImageMagick also requires Ghostscript.
-* If you are using TeXLive and you installed the default profile, you should already have Ghostscript installed in `<drive>:path\to\texlive\<year>\tlpkg\tlgs\bin`. Make sure this is added to your `PATH` system variable or to the `texpath` when setting up LaTeXTools.
-* If you are using MiKTeX, you can either install the [latest release here](http://ghostscript.com/download/gsdnld.html) of Ghoscript or else you will need to "trick" ImageMagick into using the included Ghostscript executable called `mgs.exe`. The easiest way to do this is to create a softlink called `gswin32c.exe` in the same folder as `mgs.exe`. To do this, from an command prompt run as administrator run the following command:
-
-```
-mklink C:\Program Files\MiKTeX\miktex\bin\gswin32c.exe C:\Program Files\MiKTeX\miktex\bin\mgs.exe
-```
-
-(Note that you may need to adjust the paths to reflect were you installed MiKTeX.)
+Similarly, if you would like to use the image preview feature to view file types not support by SublimeText or Ghostcript (so anything other than PNGs, JPEGs, GIFs, PDFs, EPSs, and PSs), you will need to ensure that ImageMagick is installed on your machine and available on your `texpath`.
 
 If you do not want to use the image preview feature, change the `preview_image_mode` setting to `"none"` when you are configuring your settings.
 
@@ -187,11 +177,11 @@ You need to install TeXlive. We highly recommend installing the version directly
 
 #### Setup ImageMagick and Ghostscript
 
-If you are using Sublime Text 3 version 3118 or later and want to use the equation preview feature, you will need to ensure that Ghostscript 8 or higher is installed and available on the `texpath` defined for your machine.
+If you are using Sublime Text 3 version 3118 or later and want to use the equation preview feature or use the image preview feature for PDFs, EPSs, or PSs, you will need to ensure that Ghostscript 8 or higher is installed and available on the `texpath` defined for your machine.
 
 If you do not want to use the equation preview feature, change the `preview_math_mode` setting to `"none"` when you are configuring your settings.
 
-Similarly, if you would like to use the image preview feature, you will need to ensure that ImageMagick is installed on your machine and available on your `texpath`. Note that for some image formats, ImageMagick also requires Ghostscript to be installed.
+Similarly, if you would like to use the image preview feature to view file types not support by SublimeText or Ghostcript (so anything other than PNGs, JPEGs, GIFs, PDFs, EPSs, and PSs), you will need to ensure that ImageMagick is installed on your machine and available on your `texpath`. Note that for some image formats, ImageMagick also requires Ghostscript to be installed.
 
 If you do not want to use the image preview feature, change the `preview_image_mode` setting to `"none"` when you are configuring your settings.
 

--- a/st_preview/preview_image.py
+++ b/st_preview/preview_image.py
@@ -12,7 +12,10 @@ from ..getTeXRoot import get_tex_root
 from ..jumpto_tex_file import open_image, find_image
 from ..latextools_utils import cache, get_setting
 from . import preview_utils
-from .preview_utils import convert_installed, run_convert_command
+from .preview_utils import (
+    convert_installed, run_convert_command, ghostscript_installed,
+    run_ghostscript_command
+)
 from . import preview_threading as pv_threading
 
 # export the listeners
@@ -61,15 +64,40 @@ def plugin_unloaded():
     _lt_settings.clear_on_change("lt_preview_image_main")
 
 
+_GS_EXTS = set(['ps', 'eps', 'pdf'])
+
+
+def _uses_gs(file):
+    file, ext = os.path.splitext(file)
+    return ext.lower() in _GS_EXTS
+
+
+def _can_create_preview(file=None):
+    if file is None:
+        return ghostscript_installed() or convert_installed()
+    else:
+        if _uses_gs(file):
+            return ghostscript_installed()
+        else:
+            return convert_installed()
+
+
 def create_thumbnail(image_path, thumbnail_path, width, height):
     # convert the image
     if os.path.exists(thumbnail_path):
         return
 
-    run_convert_command([
-        '-thumbnail', '{width}x{height}'.format(**locals()),
-        image_path, thumbnail_path
-    ])
+    if _uses_gs(image_path):
+        run_ghostscript_command([
+            '-sDEVICE=pngalpha', '-dLastPage=1',
+            '-sOutputFile={thumbnail_path}'.format(**locals()),
+            '-g{width}x{height}'.format(**locals())
+        ])
+    else:
+        run_convert_command([
+            '-thumbnail', '{width}x{height}'.format(**locals()),
+            image_path, thumbnail_path
+        ])
 
     if not os.path.exists(thumbnail_path):
         with open(thumbnail_path + _ERROR_EXTENSION, "w") as f:
@@ -79,7 +107,7 @@ def create_thumbnail(image_path, thumbnail_path, width, height):
 # CONVERT THREADING
 def _append_image_job(image_path, thumbnail_path, width, height, cont):
     global _job_list
-    if not convert_installed():
+    if not _can_create_preview(image_path):
         return
 
     def job():
@@ -184,7 +212,7 @@ def _get_thumbnail_path(image_path, width, height):
     return thumbnail_path
 
 
-def _get_popup_html(thumbnail_path, width, height):
+def _get_popup_html(image_path, thumbnail_path, width, height):
     if os.path.exists(thumbnail_path):
         # adapt the size to keep the width/height ratio, but stay inside
         # the image dimensions
@@ -195,7 +223,9 @@ def _get_popup_html(thumbnail_path, width, height):
             'height="{height}">'
             .format(**locals())
         )
-    elif not convert_installed():
+    elif _uses_gs(image_path) and not ghostscript_installed():
+        img_tag = "Install Ghostscript to enable preview."
+    elif not _uses_gs(image_path) and not convert_installed():
         img_tag = "Install ImageMagick to enable preview."
     elif os.path.exists(thumbnail_path + _ERROR_EXTENSION):
         img_tag = "ERROR: Failed to create preview thumbnail."
@@ -272,7 +302,8 @@ class PreviewImageHoverListener(sublime_plugin.EventListener):
         thumbnail_path = _get_thumbnail_path(
             image_path, tn_width, tn_height)
 
-        html_content = _get_popup_html(thumbnail_path, width, height)
+        html_content = _get_popup_html(
+            image_path, thumbnail_path, width, height)
 
         def on_navigate(href):
             if href == "open_image":
@@ -290,9 +321,11 @@ class PreviewImageHoverListener(sublime_plugin.EventListener):
             on_hide=on_hide)
 
         # if the thumbnail does not exists, create it and update the popup
-        if convert_installed() and not os.path.exists(thumbnail_path):
+        if (_can_create_preview(image_path) and
+                not os.path.exists(thumbnail_path)):
             def update_popup():
-                html_content = _get_popup_html(thumbnail_path, width, height)
+                html_content = _get_popup_html(
+                    image_path, thumbnail_path, width, height)
                 if on_hide.hidden:
                     return
                 view.show_popup(
@@ -563,7 +596,7 @@ class PreviewImagePhantomListener(sublime_plugin.ViewEventListener,
 
         self.phantoms = new_phantoms
 
-        if convert_installed():
+        if _can_create_preview():
             for p in need_thumbnails:
                 _append_image_job(
                     p.image_path, p.thumbnail_path,

--- a/st_preview/preview_math.py
+++ b/st_preview/preview_math.py
@@ -3,6 +3,7 @@ import html
 import os
 import re
 import struct
+import subprocess
 import threading
 import time
 import types
@@ -15,7 +16,7 @@ from ..parseTeXlog import parse_tex_log
 from ..latextools_utils import cache, get_setting
 from ..latextools_utils.external_command import execute_command
 from . import preview_utils
-from .preview_utils import convert_installed, run_convert_command
+from .preview_utils import ghostscript_installed, run_ghostscript_command
 from . import preview_threading as pv_threading
 
 # export the listener
@@ -133,15 +134,59 @@ def _create_image(latex_program, latex_document, base_name, color,
             pdf_exists = True
 
     if pdf_exists:
+        # get the cropping boundaries; note that the relevant output is
+        # written to STDERR rather than STDOUT; we specify 72 dpi in order to
+        # speed up processing; the user-supplied density will be used in
+        # making the actual conversion
+        rc, _, output = run_ghostscript_command([
+            '-sDEVICE=bbox', '-r72', '-dLastPage=1', pdf_path
+        ], stdout=subprocess.DEVNULL, stderr=subprocess.PIPE)
+
+        if rc == 0:
+            # we only check the first line of output which should be in the
+            # format:
+            # %%BoundingBox: int int int int
+            try:
+                bbox = [
+                    int(x) for x in
+                    output.splitlines()[0].lstrip('%%BoundingBox: ').split()
+                ]
+            except ValueError:
+                bbox = None
+        else:
+            bbox = None
+
         # convert the pdf to a png image
-        density = _density
-        run_convert_command([
-            # set the image size/density
-            '-density', '{density}x{density}'.format(density=density),
-            # trim the content to the real size
-            '-trim',
-            pdf_path, image_path
-        ])
+        command = [
+            '-sDEVICE=pngalpha', '-dLastPage=1',
+            '-sOutputFile={image_path}'.format(image_path=image_path),
+            '-r{density}'.format(density=_density)
+        ]
+
+        # calculate and apply cropping boundaries, if we have them
+        if bbox:
+            # coordinates in bounding box given in the form:
+            # (ll_x, ll_y), (ur_x, ur_y)
+            # where ll is lower left and ur is upper right
+            # 4pts are added to each length for some padding
+            # these are then multiplied by the ratio of the final density to
+            # the PDFs DPI (72) to get the final size of the image in pixels
+            width = round((bbox[2] - bbox[0] + 4) * _density / 72)
+            height = round((bbox[3] - bbox[1] + 4) * _density / 72)
+            command.extend([
+                '-g{width}x{height}'.format(**locals()), '-c',
+                # this is the command that does the clipping starting from
+                # the lower left of the displayed contents; we subtract 2pts
+                # to properly center the final image with our padding
+                '<</Install {{{0} {1} translate}}>> setpagedevice'.format(
+                    -1 * (bbox[0] - 2), -1 * (bbox[1] - 2)
+                ),
+                '-f'
+            ])
+
+        command.append(pdf_path)
+
+        run_ghostscript_command(command)
 
     err_file_path = image_path + _ERROR_EXTENSION
     err_log = []
@@ -534,7 +579,7 @@ class MathPreviewPhantomListener(sublime_plugin.ViewEventListener,
         # not sure why this happens, but ignore these cases
         if self.view.window() is None:
             return
-        if not convert_installed():
+        if not ghostscript_installed():
             return
 
         view = self.view

--- a/system_check.py
+++ b/system_check.py
@@ -60,7 +60,7 @@ except ImportError:
 _HAS_PREVIEW = sublime.version() >= '3118'
 if _HAS_PREVIEW:
     from .st_preview.preview_utils import (
-        convert_installed, ghostscript_installed, __get_gs_command
+        convert_installed, ghostscript_installed, __get_gs_command as get_gs_command
     )
 
 if sys.version_info >= (3,):
@@ -498,7 +498,7 @@ class SystemCheckThread(threading.Thread):
             ])
 
         program = 'ghostscript'
-        location = __get_gs_command()
+        location = get_gs_command()
 
         available = location is not None
 

--- a/system_check.py
+++ b/system_check.py
@@ -59,7 +59,9 @@ except ImportError:
 
 _HAS_PREVIEW = sublime.version() >= '3118'
 if _HAS_PREVIEW:
-    from .st_preview.preview_utils import convert_installed
+    from .st_preview.preview_utils import (
+        convert_installed, ghostscript_installed, __get_gs_command
+    )
 
 if sys.version_info >= (3,):
     unicode = str
@@ -448,9 +450,7 @@ class SystemCheckThread(threading.Thread):
         # of alternatives (e.g. 32/64 bit version)
         programs = [
             'latexmk' if not self.uses_miktex else 'texify', 'pdflatex',
-            'xelatex', 'lualatex', 'biber', 'bibtex', 'bibtex8', 'kpsewhich',
-            ('gs' if sublime.platform() != 'windows'
-                else ['gswin32c', 'gswin64c', 'gs'])
+            'xelatex', 'lualatex', 'biber', 'bibtex', 'bibtex8', 'kpsewhich'
         ]
 
         if _HAS_PREVIEW:
@@ -496,6 +496,33 @@ class SystemCheckThread(threading.Thread):
                 available_str,
                 version_info if version_info is not None else u'unavailable'
             ])
+
+        program = 'ghostscript'
+        location = __get_gs_command()
+
+        available = location is not None
+
+        if available:
+            basename, extension = os.path.splitext(location)
+            if extension is not None:
+                location = ''.join((basename, extension.lower()))
+
+        version_info = get_version_info(
+            location, env=env
+        ) if available else None
+
+        available_str = (
+            u'available' if available and version_info is not None
+            else u'missing'
+        )
+
+        if available and _HAS_PREVIEW and not ghostscript_installed():
+            available_str = u'restart required'
+
+        table.append([
+            program, location, available_str,
+            version_info if version_info is not None else u'unavailable'
+        ])
 
         results.append(table)
 


### PR DESCRIPTION
The intention here is to reduce the amount of configuration necessary to get equation previews working, since Ghostscript is usually installed alongside TeX.

This isn't as much help if you're also using the image preview on Windows which also requires an install of Ghostscript, but I've updated the README to include information on how to get ImageMagick to use the version of Ghostscript installed with the TeX distribution.

Finally, because this uses Ghostscript rather than ImageMagick to do the trimming, the results may be slightly different from the current version. However, it seems to do the right thing with regard to inline single-character uses and multiline equations. Admittedly, though, I haven't tried anything too complex.

Some examples:

* <img width="162" alt="equation with fraction" src="https://cloud.githubusercontent.com/assets/212893/20455768/88876548-ae5b-11e6-9e54-46a7ffe1b633.png">

* <img width="35" alt="single letter" src="https://cloud.githubusercontent.com/assets/212893/20455763/7a6420fa-ae5b-11e6-9f1b-2861e5ee7477.png">

