### PR TITLE
Several improvements to loading plugins

### DIFF
--- a/01_reload_submodules.py
+++ b/01_reload_submodules.py
@@ -12,6 +12,8 @@ import traceback
 if sys.version_info >= (3,):
     from imp import reload
 
+_ST3 = sublime.version() >= '3000'
+
 
 def _load_module_exports(module):
     if 'exports' in module.__dict__:
@@ -22,20 +24,17 @@ def _load_module_exports(module):
             except KeyError:
                 print(
                     "Error: {0} not defined in {1}."
-                    .format(name, module.__name__)
-                )
+                    .format(name, module.__name__))
 
 
 MOD_PREFIX = ''
 
-if sublime.version() > '3000':
+if _ST3:
     MOD_PREFIX = 'LaTeXTools.' + MOD_PREFIX
 
 # these modules must be specified in the order they depend on one another
 LOAD_ORDER = [
     'external.latex_chars',
-
-    'latextools_plugin_internal',
 
     # reloaded here so that makePDF imports the current version
     'parseTeXlog',
@@ -72,6 +71,9 @@ LOAD_ORDER = [
     # ensure latex_fill_all is loaded before the modules that depend on it
     'latex_fill_all'
 ]
+
+if _ST3:
+    LOAD_ORDER.insert(1, 'latextools_plugin_internal')
 
 # modules which should be scanned for any exports to be hoisted to this
 # module's context
@@ -110,16 +112,24 @@ def plugin_loaded():
     except ImportError:
         from . import latextools_plugin
 
-    try:
-        with latextools_plugin._latextools_module_hack():
-            for mod in sys.modules:
-                if mod.startswith('_latextools_'):
-                    try:
-                        reload(sys.modules[mod])
-                    except:
-                        traceback.print_exc()
-    except:
-        traceback.print_exc()
+    if _ST3:
+        try:
+            with latextools_plugin._latextools_module_hack():
+                for mod in sys.modules:
+                    if mod.startswith('_latextools_'):
+                        try:
+                            reload(sys.modules[mod])
+                        except ImportError:
+                            traceback.print_exc()
+        except:
+            traceback.print_exc()
+    else:
+        mods = [m for m in sys.modules if m.startswith('_latextools_')]
+        for mod in mods:
+            try:
+                del sys.modules[mod]
+            except:
+                traceback.print_exc()
 
     for module in EXPORT_MODULES:
         mod = MOD_PREFIX + module
@@ -138,5 +148,5 @@ def plugin_unloaded():
             pass
 
 
-if sublime.version() < '3000':
+if not _ST3:
     plugin_loaded()

--- a/builders/pdfBuilder.py
+++ b/builders/pdfBuilder.py
@@ -107,7 +107,7 @@ class PdfBuilder(latextools_plugin.LaTeXToolsPlugin):
 	def cleantemps(self):
 		return NotImplementedError()
 
+
 # ensure pdfBuilder is available to any custom builders
-latextools_plugin.add_whitelist_module('pdfBuilder',
-	sys.modules[PdfBuilder.__module__]
-)
+latextools_plugin.add_whitelist_module(
+	'pdfBuilder', sys.modules[PdfBuilder.__module__])

--- a/latex_cite_completions.py
+++ b/latex_cite_completions.py
@@ -567,7 +567,9 @@ def plugin_loaded():
     # setup
     os_path = os.path
     latextools_plugin.add_plugin_path(
-        os_path.join(os_path.dirname(__file__), 'bibliography_plugins'))
+        os_path.join(
+            sublime.packages_path(), 'LaTeXTools', 'bibliography_plugins'))
+
 
 # ensure plugin_loaded() called on ST2
 if not _ST3:

--- a/latextools_utils/internal_types.py
+++ b/latextools_utils/internal_types.py
@@ -1,5 +1,5 @@
 try:
-    from latextools_plugin import LaTeXToolsPlugin
+    from latextools_plugin_internal import LaTeXToolsPlugin
 except ImportError:
     from LaTeXTools.latextools_plugin import LaTeXToolsPlugin
 

--- a/latextools_utils/settings.py
+++ b/latextools_utils/settings.py
@@ -2,13 +2,29 @@ from __future__ import print_function
 
 import sublime
 
+from functools import partial
+
+try:
+    from .utils import run_on_main_thread
+except:
+    from latextools_utils.utils import run_on_main_thread
+
 __all__ = ['get_setting']
 
 
 def get_setting(setting, default=None, view=None):
+    if default is not None:
+        return run_on_main_thread(
+            partial(_get_setting, setting, default, view),
+            default_value=default)
+    else:
+        return run_on_main_thread(
+            partial(_get_setting, setting, view=view))
+
+
+def _get_setting(setting, default=None, view=None):
     advanced_settings = sublime.load_settings(
-        'LaTeXTools (Advanced).sublime-settings'
-    )
+        'LaTeXTools (Advanced).sublime-settings')
     global_settings = sublime.load_settings('LaTeXTools.sublime-settings')
 
     try:
@@ -60,4 +76,3 @@ def update_setting(settings, values):
         else:
             settings[key] = values[key]
     return settings
-

--- a/makePDF.py
+++ b/makePDF.py
@@ -741,12 +741,16 @@ class make_pdfCommand(sublime_plugin.WindowCommand):
 		try:
 			builder = get_plugin('{0}_builder'.format(builder_name))
 		except NoSuchPluginException:
-			sublime.error_message(
-				"Cannot find builder {0}.\n"
-				"Check your LaTeXTools Preferences".format(builder_name)
-			)
-			self.window.run_command('hide_panel', {"panel": "output.latextools"})
-			return
+			try:
+				builder = get_plugin(builder_name)
+			except NoSuchPluginException:
+				sublime.error_message(
+					"Cannot find builder {0}.\n"
+					"Check your LaTeXTools Preferences".format(builder_name)
+				)
+				self.window.run_command(
+					'hide_panel', {"panel": "output.latextools"})
+				return
 
 		if builder_name == 'script' and script_commands:
 			builder_platform_settings['script_commands'] = script_commands
@@ -1034,11 +1038,6 @@ def plugin_loaded():
 	add_plugin_path(os.path.join(ltt_path, 'pdfBuilder.py'))
 	add_plugin_path(ltt_path)
 
-	# load any .latextools_builder files from User directory
-	add_plugin_path(
-		os.path.join(sublime.packages_path(), 'User'),
-		'*.latextools_builder'
-	)
 
 if not _ST3:
 	plugin_loaded()


### PR DESCRIPTION
1. As suggested by @r-stein, plugins are loaded on a non-main thread. This means that plugin loading should interfere less with start-up time.
1. Removed the automatic support for files with custom extensions. This should also marginally reduce the plugin load time.
1. Fixed the reloading code to work properly on ST2 (FillAll plugins would routinely be left out).
1. Made `get_setting()` thread-safe on ST2. This means we should be able to run more things on separate threads where it makes sense to do so.