### PR TITLE
Use analysis for Ref and Cite commands

### DIFF
--- a/01_reload_submodules.py
+++ b/01_reload_submodules.py
@@ -41,6 +41,8 @@ LOAD_ORDER = [
 
     'latextools_utils',
 
+    'latextools_utils.six',
+
     # no internal dependencies
     'latextools_utils.bibformat',
     'latextools_utils.settings',
@@ -64,7 +66,6 @@ LOAD_ORDER = [
     'latextools_utils.ana_utils',
     'latextools_utils.output_directory',
     'latextools_utils.bibcache',
-    'latextools_utils.output_directory',
 
     'latextools_plugin',
 

--- a/LaTeX.sublime-commands
+++ b/LaTeX.sublime-commands
@@ -1,6 +1,7 @@
 [
 	{ "caption": "LaTeXTools: Check system", "command": "latextools_system_check"},
 	{ "caption": "LaTeXTools: Delete temporary files", "command": "delete_temp_files"},
+	{ "caption": "LaTeXTools: Clear document cache", "command": "clear_local_latex_cache"},
 	{ "caption": "LaTeXTools: View PDF", "command": "view_pdf"},
 	{ "caption": "LaTeXTools: Jump to PDF", "command": "jump_to_pdf"},
 	{ "caption": "LaTeXTools: Show word count", "command": "texcount"},

--- a/LaTeX.sublime-commands
+++ b/LaTeX.sublime-commands
@@ -2,6 +2,7 @@
 	{ "caption": "LaTeXTools: Check system", "command": "latextools_system_check"},
 	{ "caption": "LaTeXTools: Delete temporary files", "command": "delete_temp_files"},
 	{ "caption": "LaTeXTools: Clear document cache", "command": "clear_local_latex_cache"},
+	{ "caption": "LaTeXTools: Clear current bibliography cache", "command": "clear_bibliography_cache"},
 	{ "caption": "LaTeXTools: View PDF", "command": "view_pdf"},
 	{ "caption": "LaTeXTools: Jump to PDF", "command": "jump_to_pdf"},
 	{ "caption": "LaTeXTools: Show word count", "command": "texcount"},
@@ -10,5 +11,7 @@
 	{ "caption": "LaTeXTools: Reset user settings to default", "command": "latextools_migrate"},
 	{ "caption": "LaTeXTools: Create mousemap in user folder", "command": "latextools_create_mousemap"},
 	{ "caption": "LaTeXTools: View TeX package documentation", "command": "latex_pkg_doc"},
-	{ "caption": "LaTeXTools: Build cache of LaTeX packages", "command": "latex_gen_pkg_cache"}
+	{ "caption": "LaTeXTools: Build cache of LaTeX packages", "command": "latex_gen_pkg_cache"},
+	{ "caption": "LaTeXTools: Update document analysis cache", "command": "latextools_analysis_update"},
+	{ "caption": "LaTeXTools: Update bibliography cache", "command": "latextools_bib_update"}
 ]

--- a/LaTeXTools.sublime-settings
+++ b/LaTeXTools.sublime-settings
@@ -584,6 +584,29 @@
 	// whether the local cache should be hidden in the sublime cache path (true)
 	// or in the same directory as the root file (false)
 	"hide_local_cache": true,
+
+	// settings for caches to update on load
+	// leaving these as `true` will ensure LaTeXTools pre-caches the appropriate
+	// data when a TeX document is loaded; setting these to `false` will
+	// cause the cache to be built when first needed
+	"cache_on_load": {
+		// analysis: the internal view that LaTeXTools has of your document
+		"analysis": true,
+		// bibliography: ensures the bibliography is parsed and cached
+		"bibliography": true
+	},
+
+	// settings to update caches when a document is saved
+	// leaving these as `true` will ensure LaTeXTools reloads the data on save,
+	// if necessary; setting these to `false` will cause the cache to be
+	// re-built according to its rules
+	"cache_on_save": {
+		// analysis: the internal view that LaTeXTools has of your document
+		"analysis": true,
+		// bibliography: ensures the bibliography is parsed and cached
+		"bibliography": false
+	},
+
 	/* The life-span of the local cache.
 	After this life-span the local cache will automatically be invalidated and refreshed.
 	You can invalidate the cache manually by removing all temporary files `C-l,backspace`.

--- a/bibliography_plugins/newBibliography.py
+++ b/bibliography_plugins/newBibliography.py
@@ -107,13 +107,17 @@ class EntryWrapper(Mapping):
     def __len__(self):
         return len(self.entry)
 
+
 class NewBibliographyPlugin(LaTeXToolsPlugin):
+
     def get_entries(self, *bib_files):
         entries = []
         parser = Parser()
+
         for bibfname in bib_files:
+            bib_cache = bibcache.BibCache("new", bibfname)
             try:
-                cached_entries = bibcache.read_fmt("new", bibfname)
+                cached_entries = bib_cache.get()
                 entries.extend(cached_entries)
                 continue
             except:
@@ -135,14 +139,23 @@ class NewBibliographyPlugin(LaTeXToolsPlugin):
                     entry = bib_data[key]
                     if entry.entry_type in ('xdata', 'comment', 'string'):
                         continue
+
+                    # purge some unnecessary fields from the bib entry to save
+                    # some space and time reloading
+                    for k in [
+                        'abstract', 'annotation', 'annote', 'execute',
+                        'langidopts', 'options'
+                    ]:
+                        if k in entry:
+                            del entry[k]
+
                     bib_entries.append(EntryWrapper(entry))
 
                 try:
-                    fmt_entries = bibcache.write_fmt("new", bibfname, bib_entries)
+                    bib_cache.set(bib_entries)
+                    fmt_entries = bib_cache.get()
                     entries.extend(fmt_entries)
                 except:
-                    entries.extend(bib_entries)
-                    print('Error occurred while trying to write to cache.')
                     traceback.print_exc()
             finally:
                 try:

--- a/bibliography_plugins/traditionalBibliography.py
+++ b/bibliography_plugins/traditionalBibliography.py
@@ -37,12 +37,15 @@ multip = re.compile(
 # LaTeX -> Unicode decoder
 latex_chars.register()
 
+
 class TraditionalBibliographyPlugin(LaTeXToolsPlugin):
+
     def get_entries(self, *bib_files):
         entries = []
         for bibfname in bib_files:
+            bib_cache = bibcache.BibCache("trad", bibfname)
             try:
-                cached_entries = bibcache.read_fmt("trad", bibfname)
+                cached_entries = bib_cache.get()
                 entries.extend(cached_entries)
                 continue
             except:
@@ -107,11 +110,10 @@ class TraditionalBibliographyPlugin(LaTeXToolsPlugin):
                 print ('Loaded %d bibitems' % (len(bib_entries)))
 
                 try:
-                    fmt_entries = bibcache.write_fmt("trad", bibfname, bib_entries)
+                    bib_cache.set(bib_entries)
+                    fmt_entries = bib_cache.get()
                     entries.extend(fmt_entries)
                 except:
-                    entries.extend(bib_entries)
-                    print('Error occurred while trying to write to cache')
                     traceback.print_exc()
             finally:
                 try:

--- a/delete_temp_files.py
+++ b/delete_temp_files.py
@@ -5,17 +5,19 @@ if sublime.version() < '3000':
 	_ST3 = False
 	# we are on ST2 and Python 2.X
 	import getTeXRoot
-	from latextools_utils import cache, get_setting
+	from latextools_utils import cache, get_setting, is_bib_buffer
 	from latextools_utils.output_directory import (
 		get_aux_directory, get_output_directory
 	)
+	from latextools_utils.six import get_self
 else:
 	_ST3 = True
 	from . import getTeXRoot
-	from .latextools_utils import cache, get_setting
+	from .latextools_utils import cache, get_setting, is_bib_buffer
 	from .latextools_utils.output_directory import (
 		get_aux_directory, get_output_directory
 	)
+	from .latextools_utils.six import get_self
 
 import sublime_plugin
 import os
@@ -44,6 +46,55 @@ class ClearLocalLatexCacheCommand(sublime_plugin.WindowCommand):
 			except:
 				print('Error while trying to delete local cache')
 				traceback.print_exc()
+
+
+class ClearBibliographyCacheCommand(sublime_plugin.WindowCommand):
+
+	def is_visible(self, *args):
+		view = self.window.active_view()
+		return (
+			bool(view.score_selector(0, "text.tex.latex")) or
+			is_bib_buffer(view)
+		)
+
+	def run(self):
+		view = self.window.active_view()
+
+		if view is None:
+			return
+
+		is_tex_file = bool(view.score_selector(0, "text.tex.latex"))
+		if not (is_tex_file or is_bib_buffer(view)):
+			return
+
+		# find the instance of LatextoolsCacheUpdateListener, if any
+		cache_listener = None
+		for callback in sublime_plugin.all_callbacks['on_close']:
+			instance = get_self(callback)
+			if instance.__class__.__name__ == 'LatextoolsCacheUpdateListener':
+				cache_listener = instance
+				break
+
+		if cache_listener is None:
+			return
+
+		# if run from a TeX file, clear all bib caches associated with this
+		# document
+		if is_tex_file:
+			tex_root = getTeXRoot.get_tex_root(view)
+			for bib_cache in cache_listener._BIB_CACHES.get(tex_root, []):
+				bib_cache.invalidate()
+		# if run from a bib file, clear all bib caches that reflect this
+		# document
+		else:
+			file_name = view.file_name()
+			if not file_name:
+				return
+
+			for bib_caches in cache_listener._BIB_CACHES.values():
+				for bib_cache in bib_caches:
+					if bib_cache.bib_file == file_name:
+						bib_cache.invalidate()
 
 
 class DeleteTempFilesCommand(sublime_plugin.WindowCommand):

--- a/delete_temp_files.py
+++ b/delete_temp_files.py
@@ -25,22 +25,32 @@ import traceback
 
 
 class ClearLocalLatexCacheCommand(sublime_plugin.WindowCommand):
+
+	def is_visible(self, *args):
+		view = self.window.active_view()
+		return bool(view.score_selector(0, "text.tex.latex"))
+
 	def run(self):
 		view = self.window.active_view()
 
+		if view is None or not bool(view.score_selector(0, "text.tex.latex")):
+			return
+
 		tex_root = getTeXRoot.get_tex_root(view)
 		if tex_root:
+			# clear the cache
 			try:
-				cache.delete_local_cache(tex_root)
+				cache.LocalCache(tex_root).invalidate()
 			except:
 				print('Error while trying to delete local cache')
 				traceback.print_exc()
 
 
 class DeleteTempFilesCommand(sublime_plugin.WindowCommand):
+
 	def is_visible(self, *args):
 		view = self.window.active_view()
-		return bool(view.score_selector(0, "text.tex"))
+		return bool(view.score_selector(0, "text.tex.latex"))
 
 	def run(self):
 		# Retrieve root file and dirname.
@@ -64,7 +74,7 @@ class DeleteTempFilesCommand(sublime_plugin.WindowCommand):
 
 		# clear the cache
 		try:
-			cache.delete_local_cache(root_file)
+			cache.LocalCache(root_file).invalidate()
 		except:
 			print('Error while trying to delete local cache')
 			traceback.print_exc()

--- a/external/frozendict.py
+++ b/external/frozendict.py
@@ -1,0 +1,85 @@
+# The frozendict is originally available under the following license:
+#
+# Copyright (c) 2012 Santiago Lezica
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+import collections
+import copy
+
+_iteritems = getattr(dict, 'iteritems', dict.items)  # py2-3 compatibility
+
+
+class frozendict(collections.Mapping):
+    """
+    An immutable wrapper around dictionaries that implements the complete
+    :py:class:`collections.Mapping` interface.
+
+    It can be used as a drop-in replacement for dictionaries where immutability
+    is desired.
+    """
+
+    dict_cls = dict
+
+    def __init__(self, *args, **kwargs):
+        self._dict = self.dict_cls(*args, **kwargs)
+        self._hash = None
+
+    def __getitem__(self, key):
+        item = self._dict[key]
+        if isinstance(item, dict):
+            item = self._dict[key] = frozendict(**item)
+        elif isinstance(item, list):
+            item = self._dict[key] = tuple(item)
+        elif isinstance(item, set):
+            item = self._dict[key] = frozenset(item)
+        elif hasattr(item, '__dict__') or hasattr(item, '__slots__'):
+            return copy.copy(item)
+        return item
+
+    def __contains__(self, key):
+        return key in self._dict
+
+    def copy(self, **add_or_replace):
+        return self.__class__(self, **add_or_replace)
+
+    def __iter__(self):
+        return iter(self._dict)
+
+    def __len__(self):
+        return len(self._dict)
+
+    def __repr__(self):
+        return '<%s %r>' % (self.__class__.__name__, self._dict)
+
+    def __deepcopy__(self, memo):
+        cls = self.__class__
+        result = cls.__new__(cls)
+        memo[id(self)] = result
+        result.__dict__.update(dict((
+            (k, copy.deepcopy(v, memo)) for k, v in self.__dict__.items())))
+        return result
+
+    def __hash__(self):
+        if self._hash is None:
+            h = 0
+            for key, value in _iteritems(self._dict):
+                h ^= hash((key, value))
+            self._hash = h
+        return self._hash

--- a/latex_cite_completions.py
+++ b/latex_cite_completions.py
@@ -501,7 +501,10 @@ class CiteFillAllHelper(FillAllHelper):
 
         def formatted_entry(entry):
             try:
-                return entry["<panel_formatted>"]
+                result = entry["<panel_formatted>"]
+                if isinstance(result, tuple):
+                    result = list(result)
+                return result
             except:
                 return [
                     bibformat.format_entry(s, entry)

--- a/latex_cite_completions.py
+++ b/latex_cite_completions.py
@@ -23,62 +23,51 @@ if sublime.version() < '3000':
     _ST3 = False
     import getTeXRoot
     from kpsewhich import kpsewhich
-    from latextools_utils.is_tex_file import is_tex_file, get_tex_extensions
-    from latextools_utils import bibformat, get_setting
+    from latextools_utils import (
+        analysis, bibformat, cache, get_setting
+    )
     from latextools_utils.internal_types import FillAllHelper
+    from latextools_utils.six import strbase, reraise
     import latextools_plugin
-
-    # reraise implementation from 6
-    exec("""def reraise(tp, value, tb=None):
-    raise tp, value, tb
-""")
-
-    strbase = basestring
 else:
     _ST3 = True
     from . import getTeXRoot
     from .kpsewhich import kpsewhich
     from .latex_fill_all import FillAllHelper
-    from .latextools_utils.is_tex_file import is_tex_file, get_tex_extensions
-    from .latextools_utils import bibformat, get_setting
+    from .latextools_utils import (
+        analysis, bibformat, cache, get_setting
+    )
+    from .latextools_utils.six import strbase, reraise
     from . import latextools_plugin
-
-    # reraise implementation from 6
-    def reraise(tp, value, tb=None):
-        if value is None:
-            value = tp()
-        if value.__traceback__ is not tb:
-            raise value.with_traceback(tb)
-        raise value
-
-    strbase = str
-
 
 import os
 import sys
 import re
-import codecs
-
-from string import Formatter
-import collections
 
 import traceback
 
-class NoBibFilesError(Exception): pass
+
+class NoBibFilesError(Exception):
+    pass
+
 
 class BibParsingError(Exception):
+
     def __init__(self, filename=""):
         self.filename = filename
 
-class BibPluginError(Exception): pass
+
+class BibPluginError(Exception):
+    pass
+
 
 OLD_STYLE_CITE_REGEX = re.compile(r"([^_]*_)?\*?([a-z]*?)etic\\")
 # I apoligise profusely for this regex
 # forward version with explanation:
 # \\
 #    (?:
-#       (?# 
-#           first branch matches \foreigntextquote, 
+#       (?#
+#           first branch matches \foreigntextquote,
 #           \hypentextquote, \foreignblockquote, \hyphenblockquote,
 #           \hybridblockquote and starred versions
 #           syntax is:
@@ -103,7 +92,7 @@ OLD_STYLE_CITE_REGEX = re.compile(r"([^_]*_)?\*?([a-z]*?)etic\\")
 #       (?:foreign|hyphen|hybrid(?=block))(?:text|block)cquote\*?
 #           \{[^}]*\}(?:\[[^\]]*\]){0,2}\{(?:(?:[^{},]*,)*)?|
 #       (?#
-#           fourth branch matches \textcquote, \blockcquote and 
+#           fourth branch matches \textcquote, \blockcquote and
 #           starred versions
 #           syntax is:
 #           \textcquote[prenote][postnote]{key}{text}
@@ -181,6 +170,7 @@ NEW_STYLE_CITE_REGEX = re.compile(
             (?:(?P<prefix10>[^{},]*)\{yrtnebib)
         )\\""", re.X)
 
+
 def match(rex, str):
     m = rex.match(str)
     if m:
@@ -188,81 +178,95 @@ def match(rex, str):
     else:
         return None
 
+
+# find bib files
 # recursively search all linked tex files to find all
 # included bibliography tags in the document and extract
 # the absolute filepaths of the bib files
-def find_bib_files(rootdir, src, bibfiles):
-    if not is_tex_file(src):
-        src_tex_file = None
-        for ext in get_tex_extensions():
-            src_tex_file = ''.join((src, ext))
-            if os.path.exists(os.path.join(rootdir, src_tex_file)):
-                src = src_tex_file
-                break
-        if src != src_tex_file:
-            print("Could not find file {0}".format(src))
-            return
 
-    file_path = os.path.normpath(os.path.join(rootdir,src))
-    print("Searching file: " + repr(file_path))
-    # See latex_ref_completion.py for why the following is wrong:
-    #dir_name = os.path.dirname(file_path)
+# known bibliography commands
+SINGLE_BIBCOMMANDS = set([
+    'addbibresource',
+    'addglobalbib',
+    'addsectionbib'
+])
 
-    # read src file and extract all bibliography tags
-    try:
-        src_file = codecs.open(file_path, "r", 'UTF-8')
-    except IOError:
-        sublime.status_message("LaTeXTools WARNING: cannot open included file " + file_path)
-        print ("WARNING! I can't find it! Check your \\include's and \\input's.")
-        return
+MULTI_BIBCOMMANDS = set([
+    'bibliography',
+    'nobibliography'
+])
 
-    src_content = re.sub("%.*","",src_file.read())
-    src_file.close()
 
-    m = re.search(r"\\usepackage\[(.*?)\]\{inputenc\}", src_content)
-    if m:
-        f = None
-        try:
-            f = codecs.open(file_path, "r", m.group(1))
-            src_content = re.sub("%.*", "", f.read())
-        except:
-            pass
-        finally:
-            if f and not f.closed:
-                f.close()
+# filter for find_bib_files
+def _bibfile_filter(c):
+    return (
+        c.command in SINGLE_BIBCOMMANDS or
+        c.command in MULTI_BIBCOMMANDS or
+        c.command == 'newrefsection' or
+        (
+            c.command == 'begin' and
+            c.args == 'refsection'
+        )
+    )
 
-    # While these commands only allow a single resource as their argument...
-    resources = re.findall(r'\\addbibresource(?:\[[^\]]+\])?\{([^\}]+\.bib)\}', src_content)
-    resources += re.findall(r'\\addglobalbib(?:\[[^\]]+\])?\{([^\}]+\.bib)\}', src_content)
-    resources += re.findall(r'\\addsectionbib(?:\[[^\]]+\])?\{([^\}]+\.bib)\}', src_content)
 
-    # ... these can have a comma-separated list of resources as their argument.
-    multi_resources = re.findall(r'\\begin\{refsection\}\[([^\]]+)\]', src_content)
-    multi_resources += re.findall(r'\\bibliography\{([^\}]+)\}', src_content)
-    multi_resources += re.findall(r'\\nobibliography\{([^\}]+)\}', src_content)
+def find_bib_files(root):
+    def _find_bib_files():
+        # the final list of bib files
+        result = []
+        # a list of candidates bib files to check
+        resources = []
 
-    for multi_resource in multi_resources:
-        for res in multi_resource.split(','):
-            res = res.strip()
-            if res[-4:].lower() != '.bib':
-                res = res + '.bib'
-            resources.append(res)
+        # load the analysis
+        doc = analysis.get_analysis(root)
+        # we use ALL_COMMANDS here as any flag will filter some command
+        # we want to support
+        for c in doc.filter_commands(
+            _bibfile_filter, flags=analysis.ALL_COMMANDS
+        ):
+            # process the matching commands
+            # \begin{refsection} / \newrefsection
+            # resource is specified as an optional argument argument
+            if (
+                c.command == 'begin' or c.command == 'newrefsection'
+            ):
+                # NB if the resource doesn't end with .bib, assume its a label
+                # for a bibliography defined elsewhere or a non-.bib file
+                # which we don't handle
+                resources.extend([
+                    s.strip() for s in c.optargs.split(',')
+                    if s.endswith('.bib')])
+            # \bibliography / \nobibliography
+            elif c.command in MULTI_BIBCOMMANDS:
+                for s in c.args.split(','):
+                    s = s.strip()
+                    if not s.endswith('.bib'):
+                        s += '.bib'
+                    resources.append(s)
+            # standard biblatex ocmmands
+            else:
+                # bib file must be followed by .bib
+                if c.args.endswith('.bib'):
+                    resources.append(c.args)
 
-    # extract absolute filepath for each bib file
-    for res in resources:
-        # We join with rootdir, the dir of the master file
-        candidate_file = os.path.normpath(os.path.join(rootdir, res))
-        # if the file doesn't exist, search the default tex paths
-        if not os.path.exists(candidate_file):
-            candidate_file = kpsewhich(res, 'mlbib')
+        # extract absolute filepath for each bib file
+        rootdir = os.path.dirname(root)
+        for res in resources:
+            # We join with rootdir, the dir of the master file
+            candidate_file = os.path.normpath(os.path.join(rootdir, res))
+            # if the file doesn't exist, search the default tex paths
+            if not os.path.exists(candidate_file):
+                candidate_file = kpsewhich(res, 'mlbib')
 
-        if candidate_file is not None and os.path.exists(candidate_file):
-            bibfiles.append(candidate_file)
+            if candidate_file is not None and os.path.exists(candidate_file):
+                result.append(candidate_file)
 
-    # search through input tex files recursively
-    for f in re.findall(r'\\(?:input|include|subfile)\{[^\}]+\}',src_content):
-        input_f = re.search(r'\{([^\}]+)', f).group(1)
-        find_bib_files(rootdir, input_f, bibfiles)
+        # remove duplicates
+        return list(set(result))
+
+    # since the processing can be a bit intensive, cache the results
+    return cache.LocalCache(root).cache('bib_files', _find_bib_files)
+
 
 def run_plugin_command(command, *args, **kwargs):
     '''
@@ -306,8 +310,10 @@ def run_plugin_command(command, *args, **kwargs):
             pass
 
         if not plugin:
-            error_message = 'Could not find bibliography plugin named {0}. Please ensure your LaTeXTools.sublime-settings is configured correctly.'.format(
-                plugin_name)
+            error_message = (
+                'Could not find bibliography plugin named {0}. '
+                'Please ensure your LaTeXTools.sublime-settings is configured'
+                'correctly.'.format(plugin_name))
             print(error_message)
             raise BibPluginError(error_message)
 
@@ -315,10 +321,9 @@ def run_plugin_command(command, *args, **kwargs):
         try:
             plugin = plugin()
         except:
-            error_message = 'Could not instantiate {0}. {0} must have a no-args __init__ method'.format(
-                type(plugin).__name__,
-            )
-
+            error_message = (
+                'Could not instantiate {0}. {0} must have a no-args __init__ '
+                'method'.format(type(plugin).__name__,))
             print(error_message)
             raise BibPluginError(error_message)
 
@@ -326,11 +331,10 @@ def run_plugin_command(command, *args, **kwargs):
             result = getattr(plugin, command)(*args, **kwargs)
         except TypeError as e:
             if "'{0}()'".format(command) in str(e):
-                error_message = '{1} is not properly implemented by {0}.'.format(
-                    type(plugin).__name__,
-                    command
-                )
-
+                error_message = (
+                    '{1} is not properly implemented by {0}.'.format(
+                        type(plugin).__name__,
+                        command))
                 print(error_message)
                 raise BibPluginError(error_message)
             else:
@@ -338,10 +342,7 @@ def run_plugin_command(command, *args, **kwargs):
         except AttributeError as e:
             if "'{0}'".format(command) in str(e):
                 error_message = '{0} does not implement `{1}`'.format(
-                    type(plugin).__name__,
-                    command
-                )
-
+                    type(plugin).__name__, command)
                 print(error_message)
                 raise BibPluginError(error_message)
             else:
@@ -373,7 +374,9 @@ def run_plugin_command(command, *args, **kwargs):
                 break
 
     if expect_result and result is None:
-        raise BibPluginError("Could not find a plugin to handle '{0}'. See the console for more details".format(command))
+        raise BibPluginError(
+            "Could not find a plugin to handle '{0}'. "
+            "See the console for more details".format(command))
 
     return result
 
@@ -387,10 +390,7 @@ def get_cite_completions(view):
         raise NoBibFilesError()
 
     print(u"TEX root: " + repr(root))
-    bib_files = []
-    find_bib_files(os.path.dirname(root), root, bib_files)
-    # remove duplicate bib files
-    bib_files = list(set(bib_files))
+    bib_files = find_bib_files(root)
     print("Bib files found: ")
     print(repr(bib_files))
 
@@ -398,33 +398,12 @@ def get_cite_completions(view):
         # sublime.error_message("No bib files found!") # here we can!
         raise NoBibFilesError()
 
-    bib_files = ([x.strip() for x in bib_files])
-
     completions = run_plugin_command('get_entries', *bib_files)
 
     return completions
 
 
-# Based on html_completions.py
-# see also latex_ref_completions.py
-#
-# It expands citations; activated by 
-# cite<tab>
-# citep<tab> and friends
-#
-# Furthermore, you can "pre-filter" the completions: e.g. use
-#
-# cite_sec
-#
-# to select all citation keywords starting with "sec". 
-#
-# There is only one problem: if you have a keyword "sec:intro", for instance,
-# doing "cite_intro:" will find it correctly, but when you insert it, this will be done
-# right after the ":", so the "cite_intro:" won't go away. The problem is that ":" is a
-# word boundary. Then again, TextMate has similar limitations :-)
-#
-# There is also another problem: * is also a word boundary :-( So, use e.g. citeX if
-# what you want is \cite*{...}; the plugin handles the substitution
+# called by LatexFillAllCommand; provides citations for cite commands
 class CiteFillAllHelper(FillAllHelper):
 
     def get_auto_completions(self, view, prefix, line):
@@ -448,8 +427,7 @@ class CiteFillAllHelper(FillAllHelper):
             return []
         except BibParsingError as e:
             message = "Error occurred parsing {0}. {1}.".format(
-                e.filename, e.message
-            )
+                e.filename, e.message)
             print(message)
             traceback.print_exc()
 
@@ -467,17 +445,14 @@ class CiteFillAllHelper(FillAllHelper):
             return []
 
         cite_autocomplete_format = get_setting(
-            'cite_autocomplete_format',
-            '{keyword}: {title}'
+            'cite_autocomplete_format', '{keyword}: {title}'
         )
 
         def formatted_entry(entry):
             try:
                 return entry['<autocomplete_formatted>']
             except:
-                return bibformat.format_entry(
-                    cite_autocomplete_format, entry
-                )
+                return bibformat.format_entry(cite_autocomplete_format, entry)
 
         completions = [
             (
@@ -569,6 +544,7 @@ def plugin_loaded():
     latextools_plugin.add_plugin_path(
         os_path.join(
             sublime.packages_path(), 'LaTeXTools', 'bibliography_plugins'))
+
 
 
 # ensure plugin_loaded() called on ST2

--- a/latex_own_command_completions.py
+++ b/latex_own_command_completions.py
@@ -23,7 +23,8 @@ def get_own_env_completion(view):
         ana = analysis.get_analysis(tex_root)
         return _make_own_env_completion(ana)
 
-    return cache.cache(tex_root, "own_env_completion", make_completions)
+    return cache.LocalCache(tex_root).cache(
+        "own_env_completion", make_completions)
 
 
 def get_own_command_completion(view):
@@ -46,7 +47,7 @@ def get_own_command_completion(view):
     cache_name = "own_command_completion"
     if is_math:
         cache_name += "_math"
-    return cache.cache(tex_root, cache_name, make_completions)
+    return cache.LocalCache(tex_root).cache(cache_name, make_completions)
 
 
 def _make_own_env_completion(ana):

--- a/latex_ref_completions.py
+++ b/latex_ref_completions.py
@@ -1,23 +1,19 @@
 # ST2/ST3 compat
-from __future__ import print_function 
+from __future__ import print_function
 import sublime
 if sublime.version() < '3000':
     # we are on ST2 and Python 2.X
     _ST3 = False
     import getTeXRoot
     from latex_fill_all import FillAllHelper
-    from latextools_utils.is_tex_file import is_tex_file, get_tex_extensions
-    from latextools_utils import get_setting
+    from latextools_utils import analysis, get_setting
 else:
     _ST3 = True
     from . import getTeXRoot
     from .latex_fill_all import FillAllHelper
-    from .latextools_utils.is_tex_file import is_tex_file, get_tex_extensions
-    from .latextools_utils import get_setting
+    from .latextools_utils import analysis, get_setting
 
-import os
 import re
-import codecs
 
 _ref_special_commands = "|".join([
     "", "eq", "page", "v", "V", "auto", "autopage", "name",
@@ -53,61 +49,10 @@ AUTOCOMPLETE_EXCLUDE_RX = re.compile(
 
 # recursively search all linked tex files to find all
 # included \label{} tags in the document and extract
-def find_labels_in_files(rootdir, src, labels):
-    if not is_tex_file(src):
-        src_tex_file = None
-        for ext in get_tex_extensions():
-            src_tex_file = ''.join((src, ext))
-            if os.path.exists(os.path.join(rootdir, src_tex_file)):
-                src = src_tex_file
-                break
-        if src != src_tex_file:
-            print("Could not find file {0}".format(src))
-            return
-
-    file_path = os.path.normpath(os.path.join(rootdir, src))
-    print ("Searching file: " + repr(file_path))
-    # The following was a mistake:
-    #dir_name = os.path.dirname(file_path)
-    # THe reason is that \input and \include reference files **from the directory
-    # of the master file**. So we must keep passing that (in rootdir).
-
-    # read src file and extract all label tags
-
-    # We open with utf-8 by default. If you use a different encoding, too bad.
-    # If we really wanted to be safe, we would read until \begin{document},
-    # then stop. Hopefully we wouldn't encounter any non-ASCII chars there. 
-    # But for now do the dumb thing.
-    try:
-        src_file = codecs.open(file_path, "r", "UTF-8")
-    except IOError:
-        sublime.status_message("LaTeXTools WARNING: cannot find included file " + file_path)
-        print ("WARNING! I can't find it! Check your \\include's and \\input's." )
-        return
-
-    src_content = re.sub("%.*", "", src_file.read())
-    src_file.close()
-
-    # If the file uses inputenc with a DIFFERENT encoding, try re-opening
-    # This is still not ideal because we may still fail to decode properly, but still... 
-    m = re.search(r"\\usepackage\[(.*?)\]\{inputenc\}", src_content)
-    if m and (m.group(1) not in ["utf8", "UTF-8", "utf-8"]):
-        print("reopening with encoding " + m.group(1))
-        f = None
-        try:
-            f = codecs.open(file_path, "r", m.group(1))
-            src_content = re.sub("%.*", "", f.read())
-        except:
-            print("Uh-oh, could not read file " + file_path + " with encoding " + m.group(1))
-        finally:
-            if f and not f.closed:
-                f.close()
-
-    labels += re.findall(r'\\label\{([^{}]+)\}', src_content)
-
-    # search through input tex files recursively
-    for f in re.findall(r'\\(?:input|include|subfile)\{([^\{\}]+)\}', src_content):
-        find_labels_in_files(rootdir, f, labels)
+def find_labels_in_files(root, labels):
+    doc = analysis.get_analysis(root)
+    for command in doc.filter_commands('label'):
+        labels.append(command.args)
 
 
 # get_ref_completions forms the guts of the parsing shared by both the
@@ -121,8 +66,8 @@ def get_ref_completions(view):
 
     root = getTeXRoot.get_tex_root(view)
     if root:
-        print("TEX root: " + repr(root))
-        find_labels_in_files(os.path.dirname(root), root, completions)
+        print(u"TEX root: " + repr(root))
+        find_labels_in_files(root, completions)
 
     # remove duplicates
     completions = list(set(completions))
@@ -130,25 +75,7 @@ def get_ref_completions(view):
     return completions
 
 
-# Based on html_completions.py
-#
-# It expands references; activated by
-# ref<tab>
-# refp<tab> [this adds parentheses around the ref]
-# eqref<tab> [obvious]
-#
-# Furthermore, you can "pre-filter" the completions: e.g. use
-#
-# ref_sec
-#
-# to select all labels starting with "sec".
-#
-# There is only one problem: if you have a label "sec:intro", for instance,
-# doing "ref_sec:" will find it correctly, but when you insert it, this will be done
-# right after the ":", so the "ref_sec:" won't go away. The problem is that ":" is a
-# word boundary. Then again, TextMate has similar limitations :-)
-
-# called by LatexFillAllCommand
+# called by LatexFillAllCommand; provides a list of labels for any ref commands
 class RefFillAllHelper(FillAllHelper):
 
     def get_auto_completions(self, view, prefix, line):

--- a/latextools_cache_listener.py
+++ b/latextools_cache_listener.py
@@ -1,0 +1,237 @@
+from __future__ import unicode_literals, print_function
+
+import sublime
+import sublime_plugin
+
+import collections
+from functools import partial
+import threading
+import traceback
+
+try:
+    from .latex_cite_completions import (
+        find_bib_files, run_plugin_command
+    )
+    from .latextools_utils import analysis, get_setting
+    from .latextools_utils.bibcache import BibCache
+    from .latextools_utils.cache import LocalCache
+    from .latextools_utils.tex_directives import get_tex_root
+    from .latextools_utils.progress_indicator import ProgressIndicator
+except:
+    from latex_cite_completions import (
+        find_bib_files, run_plugin_command
+    )
+    from latextools_utils import analysis, get_setting
+    from latextools_utils.bibcache import BibCache
+    from latextools_utils.cache import LocalCache
+    from latextools_utils.tex_directives import get_tex_root
+    from latextools_utils.progress_indicator import ProgressIndicator
+
+_ST3 = sublime.version() >= '3000'
+
+
+class LatextoolsCacheUpdater(object):
+
+    def __init__(self):
+        super(LatextoolsCacheUpdater, self).__init__()
+        self._steps = []
+
+    def add_step(self, step):
+        if step is None:
+            raise ValueError('step cannot be None')
+        elif not callable(step):
+            raise TypeError('step must be a no-args function')
+
+        self._steps.append(step)
+
+    def run_cache_update(self):
+        t = threading.Thread(target=self._run_cache_update)
+        t.daemon = True
+        t.start()
+
+        ProgressIndicator(
+            t, 'Updating LaTeXTools cache', 'LaTeXTools cache updated')
+
+    def _run_cache_update(self):
+        for step in self._steps:
+            try:
+                step()
+            except:
+                traceback.print_exc()
+
+
+class LatextoolsAnalysisUpdater(LatextoolsCacheUpdater):
+
+    def run_analysis(self, tex_root):
+        self.add_step(partial(self._run_analysis, tex_root))
+
+    def _run_analysis(self, tex_root):
+        LocalCache(tex_root).set(
+            'analysis', analysis.analyze_document(tex_root)
+        )
+
+
+class LatextoolsBibCacheUpdater(LatextoolsCacheUpdater):
+
+    def run_bib_cache(self, tex_root):
+        self.add_step(partial(self._run_bib_cache, tex_root))
+
+    def _run_bib_cache(self, tex_root):
+        run_plugin_command('get_entries', *(find_bib_files(tex_root) or []))
+
+
+class LatextoolsCacheUpdateListener(
+    sublime_plugin.EventListener, LatextoolsAnalysisUpdater,
+    LatextoolsBibCacheUpdater
+):
+
+    # stores a cache instance per open LaTeX view
+    # note that cache instances share state
+    _TEX_CACHES = {}
+    _TEX_ROOT_REFS = collections.defaultdict(lambda: 0)
+    _BIB_CACHES = {}
+
+    def on_load_async(self, view):
+        if not view.score_selector(0, 'text.tex.latex'):
+            return
+
+        tex_root = get_tex_root(view)
+        if tex_root is None:
+            return
+
+        self._TEX_CACHES[view.id()] = local_cache = LocalCache(tex_root)
+        self._TEX_ROOT_REFS[tex_root] += 1
+
+        on_load = get_setting('cache_on_load', {})
+
+        # because cache state is shared amongst all documents sharing a tex
+        # root, this ensure we only load the analysis ONCE in the on_load
+        # event
+        if (
+            not local_cache.has('analysis') and
+            on_load.get('analysis', True)
+        ):
+            self.run_analysis(tex_root)
+
+        if tex_root not in self._BIB_CACHES:
+            if on_load.get('bibliography', True):
+                self.run_bib_cache(tex_root)
+
+            self._BIB_CACHES[tex_root] = bib_caches = []
+
+            bib_files = find_bib_files(tex_root)
+
+            plugins = get_setting('bibliography_plugins', ['traditional'])
+            if not isinstance(plugins, list):
+                plugins = [plugins]
+
+            if 'new' in plugins or 'new_bibliography' in plugins:
+                for bib_file in bib_files:
+                    bib_caches.append(BibCache('new', bib_file))
+
+            if (
+                'traditional' in plugins or
+                'traditional_bibliography' in plugins
+            ):
+                for bib_file in bib_files:
+                    bib_caches.append(BibCache('trad', bib_file))
+
+        self.run_cache_update()
+
+    def on_close(self, view):
+        if not view.score_selector(0, 'text.tex.latex'):
+            return
+
+        _id = view.id()
+
+        try:
+            tex_root = self._TEX_CACHES[_id].tex_root
+            self._TEX_ROOT_REFS[tex_root] -= 1
+            if self._TEX_ROOT_REFS[tex_root] <= 0:
+                del self._TEX_ROOT_REFS[tex_root]
+                del self._BIB_CACHES[tex_root]
+        except:
+            pass
+
+        try:
+            del self._TEX_CACHES[_id]
+        except:
+            pass
+
+    def on_post_save_async(self, view):
+        if not view.score_selector(0, 'text.tex.latex'):
+            return
+
+        tex_root = get_tex_root(view)
+        if tex_root is None:
+            return
+
+        _id = view.id()
+        if _id not in self._TEX_CACHES:
+            local_cache = self._TEX_CACHES[_id] = LocalCache(tex_root)
+        else:
+            local_cache = self._TEX_CACHES[_id]
+
+        on_save = get_setting('cache_on_save', {})
+
+        if on_save.get('analysis', True):
+            # ensure the cache of bib_files is rebuilt on demand
+            local_cache.invalidate('bib_files')
+            self.run_analysis(tex_root)
+
+        if on_save.get('bibliography', False):
+            self.run_bib_cache(tex_root)
+
+        self.run_cache_update()
+
+    if not _ST3:
+        on_load = on_load_async
+        on_post_save = on_post_save_async
+
+
+class LatextoolsCacheUpdateCommand(object):
+
+    def is_visible(self):
+        return sublime.active_window().active_view().score_selector(
+            0, 'text.tex.latex'
+        ) > 0
+
+
+class LatextoolsAnalysisUpdateCommand(
+    sublime_plugin.TextCommand, LatextoolsCacheUpdateCommand,
+    LatextoolsAnalysisUpdater
+):
+
+    def __init__(self, *args, **kwargs):
+        super(LatextoolsAnalysisUpdateCommand, self).__init__(*args, **kwargs)
+
+    def run(self, edit):
+        if not self.view.score_selector(0, 'text.tex.latex'):
+            return
+
+        tex_root = get_tex_root(self.view)
+        if tex_root is None:
+            return
+
+        self.run_analysis(tex_root)
+        self.run_cache_update()
+
+
+class LatextoolsBibcacheUpdateCommand(
+    sublime_plugin.TextCommand, LatextoolsCacheUpdateCommand,
+    LatextoolsBibCacheUpdater
+):
+
+    def __init__(self, *args, **kwargs):
+        super(LatextoolsBibcacheUpdateCommand, self).__init__(*args, **kwargs)
+
+    def run(self, edit):
+        if not self.view.score_selector(0, 'text.tex.latex'):
+            return
+
+        tex_root = get_tex_root(self.view)
+        if tex_root is None:
+            return
+
+        self.run_bib_cache(tex_root)
+        self.run_cache_update()

--- a/latextools_utils/bibcache.py
+++ b/latextools_utils/bibcache.py
@@ -6,14 +6,16 @@ import sublime
 if sublime.version() < '3000':
     _ST3 = False
     from latextools_utils import bibformat, cache, get_setting
+    from external.frozendict import frozendict
     from latextools_utils.system import make_dirs
 else:
     _ST3 = True
     from . import bibformat, cache, get_setting
+    from ..external.frozendict import frozendict
     from .six import long
     from .system import make_dirs
 
-_VERSION = 1
+_VERSION = 2
 
 
 class BibCache(cache.InstanceTrackingCache, cache.GlobalCache):
@@ -142,23 +144,24 @@ class BibCache(cache.InstanceTrackingCache, cache.GlobalCache):
         autocomplete_format = get_setting("cite_autocomplete_format")
         panel_format = get_setting("cite_panel_format")
 
-        meta_data = {
-            "cache_time": long(time.time()),
-            "version": _VERSION,
-            "autocomplete_format": autocomplete_format,
-            "panel_format": panel_format
-        }
-        formatted_entries = [
-            {
+        meta_data = frozendict(
+            cache_time=long(time.time()),
+            version=_VERSION,
+            autocomplete_format=autocomplete_format,
+            panel_format=panel_format
+        )
+
+        formatted_entries = tuple(
+            frozendict(**{
                 "keyword": entry["keyword"],
                 "<prefix_match>": bibformat.create_prefix_match_str(entry),
-                "<panel_formatted>": [
+                "<panel_formatted>": tuple(
                     bibformat.format_entry(s, entry) for s in panel_format
-                ],
+                ),
                 "<autocomplete_formatted>":
                     bibformat.format_entry(autocomplete_format, entry)
-            }
+            })
             for entry in bib_entries
-        ]
+        )
 
         return meta_data, formatted_entries

--- a/latextools_utils/bibcache.py
+++ b/latextools_utils/bibcache.py
@@ -6,118 +6,159 @@ import sublime
 if sublime.version() < '3000':
     _ST3 = False
     from latextools_utils import bibformat, cache, get_setting
+    from latextools_utils.system import make_dirs
 else:
     _ST3 = True
     from . import bibformat, cache, get_setting
+    from .six import long
+    from .system import make_dirs
 
 _VERSION = 1
 
 
-def write_fmt(bib_name, bib_file, bib_entries):
-    """
-    Writes the entries resulting from the bibliography into the cache.
-    The entries are pre-formatted to improve the time for the cite
-    completion command.
-    These pre-formatted entries are returned and should be used in the
-    to improve the time and be consistent with the return values.
+class BibCache(cache.InstanceTrackingCache, cache.GlobalCache):
+    '''
+    implements a cache for a bibliography file
 
-    Arguments:
-    bib_name -- the (unique) name of the bibliography
-    bib_file -- the bibliography file, which resulted in the entries
-    bib_entries -- the entries, which are parsed from the bibliography
+    note that this differs somewhat from the other cache objects because it
+    does not store multiple values, but only values derived from a single
+    bib file
 
-    Returns:
-    The pre-formatted entries, which should be passed to the cite
-    completions
-    """
-    cache_name, formatted_cache_name = _cache_name(bib_name, bib_file)
+    note that the bibliography entries themselves are NOT stored in the
+    in-memory cache which ONLY stores the formatted entries; instead,
+    they are read from disk as necessary
+    '''
 
-    current_time = time.time()
+    def __init__(self, bib_plugin_name, bib_file):
+        self._inst_name = (bib_plugin_name, bib_file)
+        super(BibCache, self).__init__()
 
-    # write the full unformatted bib entries into the cache together
-    # with a time stamp
-    print("Writing bibliography into cache {0}".format(cache_name))
-    cache.write_global(cache_name, (current_time, bib_entries))
+        file_hash = cache.hash_digest(bib_file)
+        self.bib_file = bib_file
+        self.cache_name = "bib_{0}_{1}".format(bib_plugin_name, file_hash)
+        self.formatted_cache_name = "bib_{0}_fmt_{1}".format(
+            bib_plugin_name, file_hash
+        )
 
-    # create and cache the formatted entries
-    formatted_entries = _create_formatted_entries(formatted_cache_name,
-                                                  bib_entries, current_time)
-    return formatted_entries
+    def get(self):
+        try:
+            result = self._objects[self.formatted_cache_name]
+        except KeyError:
+            try:
+                result = self.load(self.formatted_cache_name)
+            except cache.CacheMiss:
+                result = None
 
+        try:
+            return self.validate_on_get(result)
+        except cache.CacheMiss:
+            return self._get_bib_cache()[1]
 
-def read_fmt(bib_name, bib_file):
-    """
-    Reads the cache file of a bibliography file.
-    If the bibliography file has been changed after the caching, this
-    will result in a CacheMiss.
-    These entries are pre-formatted and compatible with cite
-    completions.
+    def set(self, bib_entries):
+        def _write_bib_cache():
+            try:
+                cache.pickle.dumps(bib_entries, protocol=-1)
+            except cache.pickle.PicklingError:
+                print('bib_entries must be pickleable')
+            else:
+                with self._disk_lock:
+                    make_dirs(self.cache_path)
+                    self._write(
+                        self.cache_name,
+                        {self.cache_name: bib_entries}
+                    )
 
-    Arguments:
-    bib_name -- the (unique) name of the bibliography
-    bib_file -- the bibliography file, which resulted in the entries
+        # write bib_entries to disk
+        self._pool.apply_async(_write_bib_cache)
 
-    Returns:
-    The cached pre-formatted entries, which should be passed to the
-    cite completions
-    """
-    cache_name, formatted_cache_name = _cache_name(bib_name, bib_file)
+        formatted_entries = self._create_formatted_entries(bib_entries)
 
-    try:
-        meta_data, formatted_entries = cache.read_global(formatted_cache_name)
-    except:
-        raise cache.CacheMiss()
+        with self._write_lock:
+            self._objects[self.formatted_cache_name] = formatted_entries
+            self._dirty = True
+        self._schedule_save()
 
-    # raise a cache miss if the modification took place after the caching
-    modified_time = os.path.getmtime(bib_file)
-    if modified_time > meta_data["cache_time"]:
-        raise cache.CacheMiss()
+    def cache(self, func):
+        try:
+            return self.get()
+        except:
+            result = func()
+            self.set(result)
 
-    # validate the version and format strings are still valid
-    if (meta_data["version"] != _VERSION or
-            any(meta_data[s] != get_setting("cite_" + s)
-                for s in ["panel_format", "autocomplete_format"])):
-        print("Formatting string has changed, updating cache...")
-        # read the base information from the unformatted cache
-        current_time, bib_entries = cache.read_global(cache_name)
-        # format and cache the entries
-        formatted_entries = _create_formatted_entries(formatted_cache_name,
-                                                      bib_entries,
-                                                      current_time)
+    def validate_on_get(self, obj):
+        if obj is None:
+            raise cache.CacheMiss()
 
-    return formatted_entries
+        meta_data, formatted_entries = obj
 
+        try:
+            mtime = os.path.getmtime(self.bib_file)
+        except:
+            raise cache.CacheMiss()
+        else:
+            if mtime > meta_data['cache_time']:
+                raise cache.CacheMiss('outdated formatted entries')
 
-def _cache_name(bib_name, bib_file):
-    file_hash = cache.hash_digest(bib_file)
-    cache_name = "bib_{0}_{1}".format(bib_name, file_hash)
-    formatted_cache_name = "bib_{0}_fmt_{1}".format(bib_name, file_hash)
-    return cache_name, formatted_cache_name
+        if _VERSION != meta_data['version'] or any(
+            meta_data[s] != get_setting("cite_" + s)
+            for s in ["panel_format", "autocomplete_format"]
+        ):
+            return self._get_bib_cache()[1]
 
+        return formatted_entries
 
-def _create_formatted_entries(formatted_cache_name, bib_entries, cache_time):
-    # create the formatted entries
-    autocomplete_format = get_setting("cite_autocomplete_format")
-    panel_format = get_setting("cite_panel_format")
+    def _get_inst_key(self, *args, **kwargs):
+        if not hasattr(self, '_inst_name'):
+            if len(args) > 1:
+                return (args[0], args[1])
+            else:
+                return None
+        else:
+            return self._inst_name
 
-    meta_data = {
-        "cache_time": cache_time,
-        "version": _VERSION,
-        "autocomplete_format": autocomplete_format,
-        "panel_format": panel_format
-    }
-    formatted_entries = [
-        {
-            "keyword": entry["keyword"],
-            "<prefix_match>": bibformat.create_prefix_match_str(entry),
-            "<panel_formatted>": [
-                bibformat.format_entry(s, entry) for s in panel_format
-            ],
-            "<autocomplete_formatted>":
-                bibformat.format_entry(autocomplete_format, entry)
+    def _get_bib_cache(self):
+        try:
+            cache_mtime = os.path.getmtime(
+                os.path.join(self.cache_path, self.cache_name))
+
+            bib_mtime = os.path.getmtime(self.bib_file)
+        except:
+            raise cache.CacheMiss()
+        else:
+            if cache_mtime < bib_mtime:
+                raise cache.CacheMiss('outdated bib entry cache')
+
+        bib_entries = self._read(self.cache_name)
+        formatted_entries = self._create_formatted_entries(bib_entries)
+        with self._write_lock:
+            self._objects[self.formatted_cache_name] = formatted_entries
+            self._dirty = True
+        self._schedule_save()
+
+        return formatted_entries
+
+    def _create_formatted_entries(self, bib_entries):
+        # create the formatted entries
+        autocomplete_format = get_setting("cite_autocomplete_format")
+        panel_format = get_setting("cite_panel_format")
+
+        meta_data = {
+            "cache_time": long(time.time()),
+            "version": _VERSION,
+            "autocomplete_format": autocomplete_format,
+            "panel_format": panel_format
         }
-        for entry in bib_entries
-    ]
+        formatted_entries = [
+            {
+                "keyword": entry["keyword"],
+                "<prefix_match>": bibformat.create_prefix_match_str(entry),
+                "<panel_formatted>": [
+                    bibformat.format_entry(s, entry) for s in panel_format
+                ],
+                "<autocomplete_formatted>":
+                    bibformat.format_entry(autocomplete_format, entry)
+            }
+            for entry in bib_entries
+        ]
 
-    cache.write_global(formatted_cache_name, (meta_data, formatted_entries))
-    return formatted_entries
+        return meta_data, formatted_entries

--- a/latextools_utils/cache.py
+++ b/latextools_utils/cache.py
@@ -68,6 +68,112 @@ def hash_digest(text):
     return hash_result.hexdigest()
 
 
+def cache(tex_root, key, func):
+    '''
+    alias for cache() on the LocalCache instance corresponding to the tex_root:
+
+    convenience method to attempt to get the value from the cache and
+    generate the value if it hasn't been cached yet or the entry has
+    otherwise been invalidated
+
+    :param tex_root:
+        the tex_root the data should be associated with
+
+    :param key:
+        the key to retrieve or set
+
+    :param func:
+        a callable that takes no arguments and when invoked will return
+        the proper value
+    '''
+    return LocalCache(tex_root).cache(key, func)
+
+
+def set(tex_root, key, obj):
+    '''
+    alias for set() on the LocalCache instance corresponding to the tex_root:
+
+    set the cache value for the given key
+
+    :param tex_root:
+        the tex_root the data should be associated with
+
+    :param key:
+        the key to set
+
+    :param obj:
+        the value to store; note that obj *must* be picklable
+    '''
+    return LocalCache(tex_root).set(key, obj)
+
+
+def get(tex_root, key):
+    '''
+    alias for get() on the LocalCache instance corresponding to the tex_root:
+
+    retrieve the cached value for the corresponding key
+
+    raises CacheMiss if value has not been cached
+
+    :param tex_root:
+        the tex_root the data should be associated with
+
+    :param key:
+        the key to set
+    '''
+    return LocalCache(tex_root).get(key)
+
+
+def cache_global(key, func):
+    '''
+    alias for cache() on the GlobalCache:
+
+    convenience method to attempt to get the value from the cache and
+    generate the value if it hasn't been cached yet or the entry has
+    otherwise been invalidated
+
+    :param key:
+        the key to retrieve or set
+
+    :param func:
+        a callable that takes no arguments and when invoked will return
+        the proper value
+    '''
+    return GlobalCache().cache(key, func)
+
+
+def set_global(key, obj):
+    '''
+    alias for set() on the GlobalCache:
+
+    set the cache value for the given key
+
+    :param key:
+        the key to set
+
+    :param obj:
+        the value to store; note that obj *must* be picklable
+    '''
+    return GlobalCache().set(key, obj)
+
+
+def get_global(key):
+    '''
+    alias for get() on the GlobablCache:
+
+    retrieve the cached value for the corresponding key
+
+    raises CacheMiss if value has not been cached
+
+    :param tex_root:
+        the tex_root the data should be associated with
+
+    :param key:
+        the key to set
+    '''
+    return GlobalCache().get(key)
+
+
 if _ST3:
     def _global_cache_path():
         return os.path.normpath(os.path.join(

--- a/latextools_utils/cache.py
+++ b/latextools_utils/cache.py
@@ -1,8 +1,13 @@
+import collections
+import copy
+import hashlib
 import os
 import re
 import shutil
-import hashlib
 import time
+import threading
+import traceback
+
 try:
     import cPickle as pickle
 except ImportError:
@@ -12,11 +17,15 @@ import sublime
 
 if sublime.version() < '3000':
     _ST3 = False
-    from latextools_utils import get_setting
+    from latextools_utils import get_setting, utils
+    from latextools_utils.six import unicode, long, strbase
+    from latextools_utils.system import make_dirs
 else:
     _ST3 = True
-    from . import get_setting
-    long = int
+    from . import get_setting, utils
+    from .six import unicode, long, strbase
+    from .system import make_dirs
+
 
 # the folder, if the local cache is not hidden, i.e. folder in the same
 # folder as the tex root
@@ -27,7 +36,9 @@ HIDDEN_LOCAL_CACHE_FOLDER = "local_cache"
 # folder to store the global and the local cache
 ST2_GLOBAL_CACHE_FOLDER = ".lt_cache"
 
-
+# re for parsing the local_cache_life_span setting when written
+# in "natural" language:
+# 100 d(ays) 100 h(ours) 100 m((in)utes) 100 s((ec)onds)
 TIME_RE = re.compile(
     r"\s*(?:(?P<day>\d+)\s*d(?:ays?)?)?"
     r"\s*(?:(?P<hour>\d+)\s*h(?:ours?)?)?"
@@ -55,313 +66,563 @@ def hash_digest(text):
     return hash_result.hexdigest()
 
 
-def delete_local_cache(tex_root):
-    """
-    Removes the local cache folder and the local cache files
-    """
-    print(u"Deleting local cache for '{0}'.".format(repr(tex_root)))
-    local_cache_paths = [_hidden_local_cache_path(),
-                         _local_cache_path(tex_root)]
-    for cache_path in local_cache_paths:
-        if os.path.exists(cache_path):
-            print(u"Delete local cache folder '{0}'".format(repr(cache_path)))
-            shutil.rmtree(cache_path)
+if _ST3:
+    def _global_cache_path():
+        return os.path.normpath(os.path.join(
+            sublime.cache_path(), "LaTeXTools"))
+else:
+    def _global_cache_path():
+        return os.path.normpath(os.path.join(
+            sublime.packages_path(), "User", ST2_GLOBAL_CACHE_FOLDER))
 
 
-def invalidate_local_cache(cache_path):
-    """
-    Invalidates the local cache by removing the cache folders
-    """
-    if os.path.exists(cache_path):
-        print(u"Invalidate local cache '{0}'.".format(repr(cache_path)))
-        shutil.rmtree(cache_path)
+# marker object for invalidated result
+try:
+    _invalid_object
+except NameError:
+    _invalid_object = object()
 
 
-def cache(tex_root, name, generate):
-    """
-    Alias for cache_local:
-    Uses the local cache to retrieve the entry for the name.
-    If the entry is not available, it will be calculated via the
-    generate-function and cached using pickle.
-    The local cache is per tex document and the path will extracted
-    from the tex root.
+class Cache(object):
+    '''
+    default cache object and definition
 
-    Arguments:
-    tex_root -- the root of the tex file (for the folder of the cache)
-    name -- the relative file name to write the object
-    generate -- a function pointer/closure to create the cached object
-        for case it is not available in the cache,
-        must be compatible with pickle
-    """
-    return cache_local(tex_root, name, generate)
+    implements the shared functionality between the various caches
+    '''
 
+    def __new__(cls, *args, **kwargs):
+        # don't allow this class to be instantiated directly
+        if cls is Cache:
+            raise NotImplemented
 
-def write(tex_root, name, obj):
-    """
-    Alias for write_local:
-    Writes the object to the local cache using pickle.
-    The local cache is per tex document and the path will extracted
-    from the tex root
+        return super(Cache, cls).__new__(cls)
 
-    Arguments:
-    tex_root -- the root of the tex file (for the folder of the cache)
-    name -- the relative file name to write the object
-    obj -- the object to write, must be compatible with pickle
-    """
-    write_local(tex_root, name, obj)
+    def __init__(self):
+        # initialize state but ONLY if it hasn't already been initialized
+        if not hasattr(self, '_disk_lock'):
+            self._disk_lock = threading.Lock()
+        if not hasattr(self, '_write_lock'):
+            self._write_lock = threading.Lock()
+        if not hasattr(self, '_save_lock'):
+            self._save_lock = threading.Lock()
+        if not hasattr(self, '_objects'):
+            self._objects = {}
+        if not hasattr(self, '_dirty'):
+            self._dirty = False
+        if not hasattr(self, '_save_queue'):
+            self._save_queue = []
+        if not hasattr(self, '_pool'):
+            self._pool = utils.ThreadPool(2)
 
+        self.cache_path = self._get_cache_path()
 
-def read(tex_root, name):
-    """
-    Alias for read_local:
-    Reads the object from the local cache using pickle.
-    The local cache is per tex document and the path will extracted
-    from the tex root
+    def get(self, key):
+        '''
+        retrieve the cached value for the corresponding key
 
-    Arguments:
-    tex_root -- the root of the tex file (for the folder of the cache)
-    name -- the relative file name to read the object
+        raises CacheMiss if value has not been cached
 
-    Returns:
-    The object at the location with the name
-    """
-    return read_local(tex_root, name)
+        :param key:
+            the key that the value has been stored under
+        '''
+        if key is None:
+            raise ValueError('key cannot be None')
 
-
-def cache_local(tex_root, name, generate):
-    """
-    Uses the local cache to retrieve the entry for the name.
-    If the entry is not available, it will be calculated via the
-    generate-function and cached using pickle.
-    The local cache is per tex document and the path will extracted
-    from the tex root.
-
-    Arguments:
-    tex_root -- the root of the tex file (for the folder of the cache)
-    name -- the relative file name to write the object
-    generate -- a function pointer/closure to create the cached object
-        for case it is not available in the cache,
-        must be compatible with pickle
-    """
-    try:
-        result = read_local(tex_root, name)
-    except CacheMiss:
-        result = generate()
-        write_local(tex_root, name, result)
-    return result
-
-
-def write_local(tex_root, name, obj):
-    """
-    Writes the object to the local cache using pickle.
-    The local cache is per tex document and the path will extracted
-    from the tex root
-
-    Arguments:
-    tex_root -- the root of the tex file (for the folder of the cache)
-    name -- the relative file name to write the object
-    obj -- the object to write, must be compatible with pickle
-    """
-    cache_path = _local_cache_path(tex_root)
-    _write(cache_path, name, obj)
-    _create_cache_timestamp(cache_path)
-
-
-def read_local(tex_root, name):
-    """
-    Reads the object from the local cache using pickle.
-    The local cache is per tex document and the path will extracted
-    from the tex root
-
-    Arguments:
-    tex_root -- the root of the tex file (for the folder of the cache)
-    name -- the relative file name to read the object
-
-    Returns:
-    The object at the location with the name
-    """
-    cache_path = _local_cache_path(tex_root)
-    _validate_life_span(cache_path)
-    return _read(cache_path, name)
-
-
-def cache_global(name, generate):
-    """
-    Uses the global sublime cache retrieve the entry for the name.
-    If the entry is not available, it will be calculated via the
-    generate-function and cached using pickle.
-
-    Arguments:
-    name -- the relative file name to write the object
-    generate -- a function pointer/closure to create the cached object
-        for case it is not available in the cache,
-        must be compatible with pickle
-    """
-    try:
-        result = read_global(name)
-    except CacheMiss:
-        result = generate()
-        write_global(name, result)
-    return result
-
-
-def write_global(name, obj):
-    """
-    Writes the object to the global sublime cache path using pickle
-
-    Arguments:
-    name -- the relative file name to write the object
-    obj -- the object to write, must be compatible with pickle
-    """
-    cache_path = _global_cache_path()
-    _write(cache_path, name, obj)
-
-
-def read_global(name):
-    """
-    Reads the object from the global sublime cache path using pickle
-
-    Arguments:
-    name -- the relative file name to read the object
-
-    Returns:
-    The object at the location with the name
-    """
-    cache_path = _global_cache_path()
-    return _read(cache_path, name)
-
-
-def _local_cache_path(tex_root):
-    hide_cache = get_setting("hide_local_cache", True)
-
-    if not hide_cache:
-        root_folder = os.path.dirname(tex_root)
-        return os.path.join(root_folder, LOCAL_CACHE_FOLDER)
-    else:
-        cache_path = _hidden_local_cache_path()
-        # convert the root to plain string and hash it
-        root_hash = hash_digest(tex_root)
-        return os.path.join(cache_path, root_hash)
-
-
-def _hidden_local_cache_path():
-    global_path = _global_cache_path()
-    return os.path.join(global_path, HIDDEN_LOCAL_CACHE_FOLDER)
-
-
-def _global_cache_path():
-    # For ST3, put the cache files in cache dir
-    # and for ST2, put it in the user packages dir
-    if _ST3:
-        cache_path = os.path.join(sublime.cache_path(), "LaTeXTools")
-    else:
-        cache_path = os.path.join(sublime.packages_path(),
-                                  "User",
-                                  ST2_GLOBAL_CACHE_FOLDER)
-    return os.path.normpath(cache_path)
-
-
-def _write(cache_path, name, obj):
-    if _ST3:
         try:
-            os.makedirs(cache_path, exist_ok=True)
-        except FileExistsError:
-            pass
-    else:
-        if not os.path.isdir(cache_path):
-            os.makedirs(cache_path)
+            result = self._objects[key]
+        except KeyError:
+            # note: will raise CacheMiss if can't be found
+            result = self.load(key)
 
-    file_path = os.path.join(cache_path, name)
-    with open(file_path, "wb") as f:
-        pickle.dump(obj, f, protocol=-1)
+        if result is _invalid_object:
+            raise CacheMiss('{0} is invalid'.format(key))
 
+        return result
 
-def _read(cache_path, name):
-    file_path = os.path.join(cache_path, name)
-    if not os.path.exists(file_path):
-        raise CacheMiss()
+    def has(self, key):
+        '''
+        check if cache has a value for the corresponding key
 
-    with open(file_path, "rb") as f:
-        return pickle.load(f)
+        :param key:
+            the key that the value has been stored under
+        '''
+        if key is None:
+            raise ValueError('key cannot be None')
 
+        return (
+            key in self._objects and
+            self._objects[key] is not _invalid_object
+        )
 
-_CACHE_TIMESTAMP_FILE = "created_time_stamp"
+    def set(self, key, obj):
+        '''
+        set the cache value for the given key
 
+        :param key:
+            the key to store the value under
 
-def _create_cache_timestamp(cache_path):
-    """
-    Creates a life span with the current time (cache folder exist).
-    Does only create a timestamp if it does not already exists.
-    """
-    access_path = os.path.join(cache_path, _CACHE_TIMESTAMP_FILE)
-    if not os.path.exists(access_path):
-        print(u"Writing cache creation timestamp")
-        created = long(time.time())
+        :param obj:
+            the value to store; note that obj *must* be picklable
+        '''
+        if key is None:
+            raise ValueError('key cannot be None')
+
         try:
-            with open(access_path, "w") as f:
-                f.write(str(created))
-        except Exception as e:
-            print(u"Error occured writing cache creation timestamp")
-            print(e)
+            pickle.dumps(obj, protocol=-1)
+        except pickle.PicklingError:
+            raise ValueError('obj must be picklable')
+
+        with self._write_lock:
+            self._objects[key] = obj
+            self._dirty = True
+        self._schedule_save()
+
+    def cache(self, key, func):
+        '''
+        convenience method to attempt to get the value from the cache and
+        generate the value if it hasn't been cached yet or the entry has
+        otherwise been invalidated
+
+        :param key:
+            the key to retrieve or set
+
+        :param func:
+            a callable that takes no arguments and when invoked will return
+            the proper value
+        '''
+        if key is None:
+            raise ValueError('key cannot be None')
+
+        try:
+            return self.get(key)
+        except:
+            result = func()
+            self.set(key, result)
+            return result
+
+    def invalidate(self, key=None):
+        '''
+        invalidates either this whole cache, a single entry or a list of
+        entries in this cache
+
+        :param key:
+            the key of the entry to invalidate; if None, the entire cache
+            will be invalidated
+        '''
+        def _invalidate(key):
+            try:
+                self._objects[key] = _invalid_object
+            except:
+                print('error occurred while invalidating {0}'.format(key))
+                traceback.print_exc()
+
+        with self._write_lock:
+            if key is None:
+                for k in self._objects.keys():
+                    _invalidate(k)
+            else:
+                if isinstance(key, strbase):
+                    _invalidate(key)
+                else:
+                    for k in key:
+                        _invalidate(k)
+
+        self._schedule_save()
+
+    def _get_cache_path(self):
+        return _global_cache_path()
+
+    def load(self, key=None):
+        '''
+        loads the value specified from the disk and stores it in the in-memory
+        cache
+
+        :param key:
+            the key to load from disk; if None, all entries in the cache
+            will be read from disk
+        '''
+        with self._write_lock:
+            if key is None:
+                for entry in os.listdir(self.cache_path):
+                    if os.path.isfile(entry):
+                        entry_name = os.path.basename[entry]
+                        try:
+                            self._objects[entry_name] = self._read(entry_name)
+                        except:
+                            print(
+                                u'error while loading {0}'.format(entry_name))
+            else:
+                self._objects[key] = self._read(key)
+
+    def load_async(self, key=None):
+        '''
+        an async version of load; does the loading in a new thread
+        '''
+        self._pool.apply_async(self.load, key)
+
+    def _read(self, key):
+        file_path = os.path.join(self.cache_path, key)
+        with self._disk_lock:
+            try:
+                with open(file_path, 'rb') as f:
+                    return pickle.load(f)
+            except:
+                raise CacheMiss(u'cannot read cache file {0}'.format(key))
+
+    def save(self, key=None):
+        '''
+        saves the cache entry specified to disk
+
+        :param key:
+            the entry to flush to disk; if None, all entries in the cache will
+            be written to disk
+        '''
+        if not self._dirty:
+            return
+
+        # lock is aquired here so that all keys being flushed reflect the
+        # same state; note that this blocks disk reads, but not cache reads
+        with self._disk_lock:
+            # operate on a stable copy of the object
+            with self._write_lock:
+                _objs = copy.deepcopy(self._objects)
+                self._dirty = False
+
+            if key is None:
+                # remove all InvalidObjects
+                delete_keys = [
+                    k for k in _objs if _objs[k] is _invalid_object
+                ]
+
+                for k in delete_keys:
+                    del _objs[k]
+
+                if _objs:
+                    make_dirs(self.cache_path)
+                    for k in _objs.keys():
+                        try:
+                            self._write(k, _objs)
+                        except:
+                            traceback.print_exc()
+                else:
+                    # cache has been emptied, so remove it
+                    try:
+                        shutil.rmtree(self.cache_path)
+                    except:
+                        print(
+                            'error while deleting {0}'.format(self.cache_path))
+                        traceback.print_exc()
+            elif key in _objs:
+                if _objs[key] is _invalid_object:
+                    file_path = os.path.join(self.cache_path, key)
+                    try:
+                        os.path.remove(file_path)
+                    except:
+                        print('error while deleting {0}'.format(file_path))
+                        traceback.print_exc()
+                else:
+                    make_dirs(self.cache_path)
+                    self._write(key, _objs)
+
+    def save_async(self, key=None):
+        '''
+        an async version of save; does the save in a new thread
+        '''
+        self._pool.apply_async(self.save, key)
+
+    def _write(self, key, obj):
+        try:
+            _obj = obj[key]
+        except KeyError:
+            raise CacheMiss()
+
+        try:
+            with open(os.path.join(self.cache_path, key), 'wb') as f:
+                pickle.dump(_obj, f, protocol=-1)
+        except OSError:
+            print('error while writing to {0}'.format(key))
+            traceback.print_exc()
+            raise CacheMiss()
+
+    def _schedule_save(self):
+        with self._save_lock:
+            self._save_queue.append(0)
+            threading.Timer(0.5, self._debounce_save).start()
+
+    def _debounce_save(self):
+        with self._save_lock:
+            if len(self._save_queue) > 1:
+                self._save_queue.pop()
+            else:
+                self._save_queue = []
+                sublime.set_timeout(self.save_async, 0)
+
+    # ensure cache is saved to disk when removed from memory
+    def __del__(self):
+        self.save_async()
+        self._pool.terminate()
 
 
-def _validate_life_span(cache_path):
-    life_span = _read_life_span()
-    # if life span is none: only manual deletion
-    if life_span is None:
-        return
+class GlobalCache(Cache):
+    '''
+    the global cache
 
-    created = _read_cache_timestamp(cache_path)
+    stores data in the appropriate global cache folder; SHOULD NOT be used
+    for data related to a particular tex document
 
-    current_time = long(time.time())
-    if created + life_span < current_time:
-        print(u"Life span of local cache is over. Invalidate local cache.")
-        invalidate_local_cache(cache_path)
-        raise CacheMiss(u"Cache life span expired")
+    note that all instance of the global cache share state, meaning that it
+    behaves as though there were a single object
+    '''
 
+    __STATE = {}
 
-def _read_cache_timestamp(cache_path):
-    access_path = os.path.join(cache_path, _CACHE_TIMESTAMP_FILE)
-    try:
-        with open(access_path, "r") as f:
-            created = long(f.read())
-    except:
-        print(u"No creation timestamp for local cache")
-        invalidate_local_cache(cache_path)
-        raise CacheMiss(u"Life span timestamp missing")
-    return created
+    def __new__(cls, *args, **kwargs):
+        # almost-singleton implementation; all instances share the same state
+        inst = super(GlobalCache, cls).__new__(cls, *args, **kwargs)
+        inst.__dict__ = cls.__STATE
+        return inst
+
+    def invalidate(self, key):
+        if key is None:
+            raise ValueError('key must not be None')
+        super(GlobalCache, self).invalidate(key)
 
 
-def _read_life_span():
-    try:
-        life_span_string = get_setting("local_cache_life_span")
-        if not life_span_string:
-            raise Exception(u"No lifespan defined")
-        if life_span_string == "infinite":
+class ValidatingCache(Cache):
+    '''
+    an abstract class for a cache which implements validation either when an
+    entry is retrieved or changed
+
+    implementing subclasses SHOULD override validate_on_get or validate_on_set
+    as appropriate
+    '''
+
+    def __new__(cls, *args, **kwargs):
+        # don't allow this class to be instantiated directly
+        if cls is ValidatingCache:
+            raise NotImplemented
+
+        return super(ValidatingCache, cls).__new__(cls, *args, **kwargs)
+
+    def validate_on_get(self, key):
+        '''
+        subclasses should override this to run validation when an object is
+        retrieved from the cache
+
+        subclasses should raise a ValueError if the validation shouldn't
+        succeed
+        '''
+
+    def validate_on_set(self, key, obj):
+        '''
+        subclasses should override this to run validation when an object is
+        added or modified in the cache
+
+        subclasses should raise a ValueError if the validation shouldn't
+        succeed
+        '''
+
+    def get(self, key):
+        try:
+            self.validate_on_get(key)
+        except ValueError as e:
+            self.invalidate()
+            raise CacheMiss(unicode(e))
+
+        return super(ValidatingCache, self).get(key)
+
+    get.__doc__ = Cache.get.__doc__
+
+    def set(self, key, obj):
+        if key is None:
+            raise ValueError('key cannot be None')
+
+        self.validate_on_set(key, obj)
+
+        return super(ValidatingCache, self).set(key, obj)
+
+    set.__doc__ = Cache.set.__doc__
+
+
+class InstanceTrackingCache(Cache):
+    '''
+    an abstract class for caches that share state between different instances
+    that point to the same underlying data; in addition, when all instances
+    of a given cache have been removed from memory, the cache is written to
+    disk
+
+    this is used, for example, by the local cache to ensure that all documents
+    with the same tex_root share a local cache instance; this helps minimize
+    memory usage and ensure data consistency across multiple cache instances,
+    e.g., caches instantiated in different functions or multiple ST views of
+    the "same" document
+
+    subclasses MUST implement the _get_inst_key method
+    '''
+
+    _CLASSES = set([])
+
+    def __new__(cls, *args, **kwargs):
+        if cls is InstanceTrackingCache:
+            raise NotImplemented
+
+        InstanceTrackingCache._CLASSES.add(cls)
+
+        if not hasattr(cls, '_INSTANCES'):
+            cls._INSTANCES = collections.defaultdict(lambda: {})
+            cls._REF_COUNTS = collections.defaultdict(lambda: 0)
+            cls._LOCKS = collections.defaultdict(lambda: threading.Lock())
+
+        inst = super(InstanceTrackingCache, cls).__new__(cls, *args, **kwargs)
+        inst_key = inst._get_inst_key(*args, **kwargs)
+
+        with cls._LOCKS[inst_key]:
+            inst.__dict__ = cls._INSTANCES[inst_key]
+            cls._REF_COUNTS[inst_key] += 1
+
+        return inst
+
+    def _get_inst_key(self, *args, **kwargs):
+        '''
+        subclasses MUST override this method to return a key which identifies
+        this instance; this key MUST be able to be used as a dictionary key
+
+        the key is intended to be shared by multiple instances of the cache,
+        but only those which represent the same underlying data; for example,
+        the LocalCache uses the tex_root value as its key, so that all
+        documents with the same tex_root share the same cache instance
+
+        NB this method is called in TWO DISTINCT ways and subclass
+        implementations MUST be able to generate the same response for both or
+        else the behavior of the instance-tracking cannot be guaranteed.
+
+            1)  This method is called from __new__ with the args and kwargs
+                passed to the constructor; subclasses SHOULD derive the key
+                from those args
+            2)  This method is called from __del__ without the args and kwargs
+                passed to the construtor; subclasses MUST ensure that the same
+                key derived in #1 can be derived in this case from information
+                stored in the object
+        '''
+        raise NotImplemented
+
+    # ensure the cache is written to disk when LAST copy of this instance is
+    # removed
+    def __del__(self):
+        inst_key = self._get_inst_key()
+        if inst_key is None:
+            return
+
+        with self._LOCKS[inst_key]:
+            ref_count = self._REF_COUNTS[inst_key]
+            ref_count -= 1
+            self._REF_COUNTS[inst_key] = ref_count
+
+            if ref_count <= 0:
+                self.save_async()
+                self._pool.terminate()
+                del self._REF_COUNTS[inst_key]
+                del self._INSTANCES[inst_key]
+
+
+class LocalCache(ValidatingCache, InstanceTrackingCache):
+    '''
+    the local cache
+
+    stores data related to a particular tex document (identified by the
+    tex_root) to a uniquely named folder in the cache directory
+
+    all data in this cache SHOULD relate directly to the tex_root
+    '''
+
+    _CACHE_TIMESTAMP = "created_time_stamp"
+    _LIFE_SPAN_LOCK = threading.Lock()
+
+    def __init__(self, tex_root):
+        self.tex_root = tex_root
+        # although this could change, currently only the value when the
+        # cache is created is relevant
+        self.hide_cache = get_setting('hide_local_cache', True)
+        super(LocalCache, self).__init__()
+
+    def validate_on_get(self, key):
+        try:
+            cache_time = Cache.get(self, self._CACHE_TIMESTAMP)
+        except:
+            raise ValueError('cannot load created timestamp')
+        else:
+            if not self.is_up_to_date(key, cache_time):
+                raise ValueError('value outdated')
+
+    def validate_on_set(self, key, obj):
+        if not self.has(self._CACHE_TIMESTAMP):
+            Cache.set(self, self._CACHE_TIMESTAMP, long(time.time()))
+
+    def _get_inst_key(self, *args, **kwargs):
+        if not hasattr(self, 'tex_root'):
+            if len(args) > 0:
+                return args[0]
             return None
-        life_span = _parse_life_span_string(life_span_string)
-    except:
-        life_span = 30 * 60  # default: 30 mins
-    return life_span
+        else:
+            return self.tex_root
 
+    def _get_cache_path(self):
+        if self.hide_cache:
+            cache_path = super(LocalCache, self)._get_cache_path()
+            root_hash = hash_digest(self.tex_root)
+            return os.path.join(
+                cache_path, HIDDEN_LOCAL_CACHE_FOLDER, root_hash)
+        else:
+            root_folder = os.path.dirname(self.tex_root)
+            return os.path.join(root_folder, LOCAL_CACHE_FOLDER)
 
-def _parse_life_span_string(life_span_string):
-    """Parses a life span string, raises an exception if it cannot parse"""
-    try:
-        life_span = int(life_span_string)
-    except:
-        life_span = _convert_life_span_string(life_span_string)
-    if life_span <= 0:
-        raise Exception("Life span must be greater than 0")
-    return life_span
+    def is_up_to_date(self, key, timestamp):
+        if timestamp is None:
+            return False
 
+        cache_life_span = LocalCache._get_cache_life_span()
 
-def _convert_life_span_string(life_span_string):
-    """Converts a TIME_RE compatible life span string,
-    raises an exception if it is not compatible"""
-    (d, h, m, s) = TIME_RE.match(life_span_string).groups()
-    # time conversions in seconds
-    times = [(s, 1), (m, 60), (h, 3600), (d, 86400)]
-    # sum the converted times
-    # if not specified (None) use 0
-    return sum(int(t[0] or 0) * t[1] for t in times)
+        current_time = long(time.time())
+        if timestamp + cache_life_span < current_time:
+            return False
+
+        return True
+
+    @classmethod
+    def _get_cache_life_span(cls):
+        '''
+        gets the length of time an item should remain in the local cache
+        before being evicted
+
+        note that previous values are calculated and stored since this method
+        is used on every cache read
+        '''
+        def __parse_life_span_string():
+            try:
+                return long(life_span_string)
+            except ValueError:
+                try:
+                    (d, h, m, s) = TIME_RE.match(life_span_string).groups()
+                    # time conversions in seconds
+                    times = [(s, 1), (m, 60), (h, 3600), (d, 86400)]
+                    # sum the converted times
+                    # if not specified (None) use 0
+                    return sum(long(t[0] or 0) * t[1] for t in times)
+                except:
+                    print('error parsing life_span_string {0}'.format(
+                        life_span_string))
+                    traceback.print_exc()
+                    # default 30 minutes in seconds
+                    return 1800
+
+        with cls._LIFE_SPAN_LOCK:
+            life_span_string = get_setting('local_cache_life_span')
+            try:
+                if cls._PREV_LIFE_SPAN_STR == life_span_string:
+                    return cls._PREV_LIFE_SPAN
+            except AttributeError:
+                pass
+
+            cls._PREV_LIFE_SPAN_STR = life_span_string
+            cls._PREV_LIFE_SPAN = life_span = __parse_life_span_string()
+            return life_span

--- a/latextools_utils/cache.py
+++ b/latextools_utils/cache.py
@@ -89,7 +89,7 @@ def cache(tex_root, key, func):
     return LocalCache(tex_root).cache(key, func)
 
 
-def set(tex_root, key, obj):
+def write(tex_root, key, obj):
     '''
     alias for set() on the LocalCache instance corresponding to the tex_root:
 
@@ -107,7 +107,7 @@ def set(tex_root, key, obj):
     return LocalCache(tex_root).set(key, obj)
 
 
-def get(tex_root, key):
+def read(tex_root, key):
     '''
     alias for get() on the LocalCache instance corresponding to the tex_root:
 
@@ -142,7 +142,7 @@ def cache_global(key, func):
     return GlobalCache().cache(key, func)
 
 
-def set_global(key, obj):
+def write_global(key, obj):
     '''
     alias for set() on the GlobalCache:
 
@@ -157,7 +157,7 @@ def set_global(key, obj):
     return GlobalCache().set(key, obj)
 
 
-def get_global(key):
+def read_global(key):
     '''
     alias for get() on the GlobablCache:
 

--- a/latextools_utils/output_directory.py
+++ b/latextools_utils/output_directory.py
@@ -2,7 +2,6 @@ import hashlib
 import json
 import os
 import sublime
-import sys
 import tempfile
 
 try:
@@ -12,11 +11,13 @@ try:
         get_tex_root, parse_tex_directives
     )
     from latextools_utils.sublime_utils import get_project_file_name
+    from latextools_utils.system import make_dirs
 except ImportError:
     from . import get_setting
     from .distro_utils import using_miktex
     from .tex_directives import get_tex_root, parse_tex_directives
     from .sublime_utils import get_project_file_name
+    from .system import make_dirs
 
 
 __all__ = [
@@ -282,32 +283,6 @@ def resolve_to_absolute_path(root, value, root_path):
         result = os.path.realpath(result)
 
     return result
-
-# wrapper for os.makedirs which will not raise an error is path already
-# exists
-def make_dirs(path):
-    try:
-        os.makedirs(path)
-    except OSError:
-        if not os.path.exists(path):
-            reraise(*sys.exc_info())
-
-
-if sys.version_info < (3,):
-    # reraise implementation from 6
-    exec("""def reraise(tp, value, tb=None):
-    raise tp, value, tb
-""")
-
-else:
-    # reraise implementation from 6
-    def reraise(tp, value, tb=None):
-        if value is None:
-            value = tp()
-        if value.__traceback__ is not tb:
-            raise value.with_traceback(tb)
-        raise value
-
 
 if sublime.version() < '3000':
     def get_cache_directory():

--- a/latextools_utils/six.py
+++ b/latextools_utils/six.py
@@ -1,0 +1,43 @@
+import sys
+
+if sys.version_info < (3,):
+    # reraise implementation from 6
+    exec("""def reraise(tp, value, tb=None):
+    raise tp, value, tb
+""")
+
+    strbase = basestring
+    unicode = unicode
+    long = long
+
+    def get_self(method):
+        '''gets reference to the instance for a specific method'''
+        try:
+            if not method.__class__.__name__ == 'method':
+                raise ValueError('method must be a method')
+        except AttributeError:
+            raise ValueError('method must be a method')
+
+        return method.im_self
+else:
+    # reraise implementation from 6
+    def reraise(tp, value, tb=None):
+        if value is None:
+            value = tp()
+        if value.__traceback__ is not tb:
+            raise value.with_traceback(tb)
+        raise value
+
+    strbase = str
+    long = int
+    unicode = str
+
+    def get_self(method):
+        '''gets reference to the instance for a specific method'''
+        try:
+            if not method.__class__.__name__ == 'method':
+                raise ValueError('method must be a method')
+        except AttributeError:
+            raise ValueError('method must be a method')
+
+        return method.__self__

--- a/latextools_utils/system.py
+++ b/latextools_utils/system.py
@@ -1,6 +1,19 @@
 import os
 import sys
 
+from .six import reraise
+
+
+def make_dirs(path):
+    '''
+    wraps os.makedirs to surpress any error as long as the directory exists
+    '''
+    try:
+        os.makedirs(path)
+    except OSError:
+        if not os.path.isdir(path):
+            reraise(*sys.exc_info())
+
 
 if sys.version_info < (3, 3):
     def which(cmd, mode=os.F_OK | os.X_OK, path=None):

--- a/latextools_utils/utils.py
+++ b/latextools_utils/utils.py
@@ -1,11 +1,26 @@
 import sublime
 import codecs
+import itertools
+import sys
 import threading
+import time
+
+try:
+    from os import cpu_count
+except ImportError:
+    from multiprocessing import cpu_count
+
+try:
+    from Queue import Queue
+except ImportError:
+    from queue import Queue
 
 if sublime.version() < '3000':
     _ST3 = False
+    from latextools_utils.six import reraise
 else:
     _ST3 = True
+    from .six import reraise
 
 
 def run_after_loading(view, func):
@@ -59,32 +74,37 @@ def read_file_unix_endings(file_name, encoding="utf8", ignore=True):
     return file_content
 
 
-def _get_view_content(view):
-    if view is not None:
-        return view.substr(sublime.Region(0, view.size()))
-
-
 def get_view_content(file_name):
     """
     If the file is open in a view, then this will return its content.
     Otherwise this will return None
     """
+    view = get_open_view(file_name)
+    if view is not None:
+        return view.substr(sublime.Region(0, view.size()))
+
+
+def get_open_view(file_name):
+    '''
+    Returns the view for the specified file_name if it exists
+    '''
     active_window = sublime.active_window()
     active_view = active_window.active_view()
     # search for the file name in 3 hierarchical steps
     # 1. check the active view
     if active_view.file_name() == file_name:
-        return _get_view_content(active_view)
+        return active_view
     # 2. check all views in the active windows
     view = active_window.find_open_file(file_name)
     if view:
-        return _get_view_content(view)
+        return view
     # 3. check all other views
     for window in sublime.windows():
         if window == active_window:
             continue
         view = window.find_open_file(file_name)
-        return _get_view_content(view)
+        if view:
+            return view
 
 
 def get_file_content(file_name, encoding="utf8", ignore=True,
@@ -107,6 +127,7 @@ def get_file_content(file_name, encoding="utf8", ignore=True,
 
 class TimeoutError(Exception):
     pass
+
 
 __sentinel__ = object()
 
@@ -153,3 +174,179 @@ def run_on_main_thread(func, timeout=10, default_value=__sentinel__):
             return default_value
 
     return _get_result.result
+
+
+class ThreadPool(object):
+    '''A relatively simple ThreadPool designed to maintain a number of thread
+    workers
+
+    By default, each pool manages a number of processes equal to the number
+    of CPU cores. This can be adjusted by setting the processes parameter
+    when creating the pool.
+
+    Returned results are similar to multiprocessing.pool.AsyncResult'''
+
+    def __init__(self, processes=None):
+        self._task_queue = Queue()
+        self._result_queue = Queue()
+        # used to indicate if the ThreadPool should be stopped
+        self._should_stop = threading.Event()
+
+        # default value is two less than the number of CPU cores to handle
+        # the supervisor thread and result thread
+        self._processes = max(processes or (cpu_count() or 3) - 2, 1)
+        self._workers = []
+        self._populate_pool()
+
+        self._job_counter = itertools.count()
+        self._result_cache = {}
+
+        self._result_handler = threading.Thread(target=self._handle_results)
+        self._result_handler.daemon = True
+        self._result_handler.name = u'{0!r} handler'.format(self)
+        self._result_handler.start()
+
+        self._supervisor = threading.Thread(target=self._maintain_pool)
+        self._supervisor.daemon = True
+        self._supervisor.name = u'{0!r} supervisor'.format(self)
+        self._supervisor.start()
+
+    # - Public API
+    def apply_async(self, func, args=(), kwargs={}):
+        job = next(self._job_counter)
+        self._task_queue.put((job, (func, args, kwargs)))
+        return _ThreadPoolResult(job, self._result_cache)
+
+    def is_running(self):
+        return not self._should_stop.is_set()
+
+    def terminate(self):
+        '''Stops this thread pool. Note stopping is not immediate. If you
+        need to wait for the termination to complete, you should call join()
+        after this.'''
+        self._should_stop.set()
+
+    def join(self, timeout=None):
+        self._supervisor.join(timeout)
+        if self._supervisor.is_alive():
+            raise TimeoutError
+
+    # - Internal API
+    # this is the supervisory task, which will clear workers that have stopped
+    # and start fresh workers
+    def _maintain_pool(self):
+        while self.is_running():
+            cleared_processes = False
+            for i in reversed(range(len(self._workers))):
+                w = self._workers[i]
+                if not w.is_alive():
+                    w.join()
+                    cleared_processes = True
+                    del self._workers[i]
+
+            if cleared_processes:
+                self._populate_pool()
+
+            time.sleep(0.1)
+
+        # send sentinels to end threads
+        for _ in range(len(self._workers)):
+            self._task_queue.put(None)
+
+        # ensure worker threads end
+        for w in self._workers:
+            w.join()
+
+        # stop the result handler
+        self._result_queue.put(None)
+        self._result_handler.join()
+
+    def _handle_results(self):
+        while True:
+            result = self._result_queue.get()
+            if result is None:
+                break
+
+            job, _result = result
+            try:
+                result_handler = self._result_cache.get(job)
+                if result_handler:
+                    result_handler._set_result(_result)
+            finally:
+                self._result_queue.task_done()
+
+    # creates and adds worker threads
+    def _populate_pool(self):
+        for _ in range(self._processes - len(self._workers)):
+            w = _ThreadPoolWorker(self._task_queue, self._result_queue)
+            self._workers.append(w)
+            w.start()
+
+
+class _ThreadPoolWorker(threading.Thread):
+
+    def __init__(self, task_queue, result_queue, *args, **kwargs):
+        super(_ThreadPoolWorker, self).__init__(*args, **kwargs)
+        self.daemon = True
+        self._task_queue = task_queue
+        self._result_queue = result_queue
+
+    def run(self):
+        while True:
+            task = self._task_queue.get()
+            if task is None:
+                break
+
+            job = task[0]
+            func, args, kwargs = task[1]
+
+            if args is None:
+                args = ()
+            if kwargs is None:
+                kwargs = {}
+
+            try:
+                self._result_queue.put((job, func(*args, **kwargs)))
+            except Exception:
+                self._result_queue.put((job, sys.exc_info()))
+            finally:
+                self._task_queue.task_done()
+
+
+class _ThreadPoolResult(object):
+
+    def __init__(self, job, result_cache):
+        self._ready = threading.Event()
+        self._value = None
+        self._result_cache = result_cache
+        self._job = job
+        self._result_cache[job] = self
+
+    def ready(self):
+        return self._ready.is_set()
+
+    def wait(self, timeout=None):
+        self._ready.wait(timeout)
+
+    def get(self, timeout=None):
+        self.wait(timeout)
+        if not self.ready():
+            raise TimeoutError
+
+        # handle an exception, which is passed as a sys.exc_info tuple
+        if (
+            isinstance(self._value, tuple) and
+            len(self._value) == 3 and
+            issubclass(self._value[0], Exception)
+        ):
+            reraise(*self._value)
+        else:
+            return self._value
+
+    def then(self, callback, timeout=None):
+        callback(self.get(timeout))
+
+    def _set_result(self, _value):
+        self._value = _value
+        self._ready.set()
+        del self._result_cache[self._job]


### PR DESCRIPTION
TL;DR With this PR ref and cite completions use the cached analysis of the document which is asynchronously updated on save.

Essentially, I wanted to use the analysis to provide reference and citation completions, which is pretty straight-forward thanks to @r-stein's wonderful work. The problem is that in the current state, the analysis cache is only updated around once every 30 minutes, which is fine for most uses,  but becomes annoying when adding a label to a document as it may not be available immediately to be used from referencing commands.

There are a few simpler solutions to this problem:
1. Live with a 30-minute span between adding a label and LaTeXTools "seeing" it. This seems like it would get complaints from a usability perspective.
1. Ratchet down the default value for the cache lifespan. This seems like it would negate the value of caching increasingly, especially if it got to small enough values that no one complained any more.
1. Use a non-cached analysis to get the label completions. This would probably perform worse than the current implementation, especially on very large documents.
1. Stick with what we currently have. I'm very open to this, but I think this PR could ultimately make the analysis more useful.

This does three main things:
1. The cache is re-written to provide an in-memory cache, which defers writing to disk to a background thread. These in-memory caches share state across multiple instances that are the "same", so it effectively appears as though there is a single global cache, a single cache for each document (i.e., series of files sharing a `tex_root`), etc.
1. It updates the analysis so that it can be used in a background thread on ST2.
1. It adds a listener which supports running the analysis in the background when a document is loaded and / or when it is saved, so that the in-memory copy of the analysis is kept in sync with the document. These listeners can be disabled via preferences.

This means, in most cases, LaTeXTools will have a fresh copy of the analysis to work with without blocking the GUI and most cache reads and writes don't immediately involve disk access.