### PR TITLE
Fixed bug on opening external pdf viewer

### DIFF
--- a/latextools_utils/external_command.py
+++ b/latextools_utils/external_command.py
@@ -183,7 +183,7 @@ def external_command(command, cwd=None, shell=False, env=None,
                 command[0], path=_env['PATH'] or os.environ['PATH']
             )
 
-            if command:
+            if _command:
                 command[0] = _command
 
         # encode cwd in the file system encoding; this is necessary to support


### PR DESCRIPTION
In some cases _command becomes a None. Also check a command has no sense: command[0] already exists, so i think it was a typo.