### PR TITLE
Added keyboard shortcut for small caps text (Ctrl+L, Ctrl+S)

### DIFF
--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -249,7 +249,7 @@ LaTeX Package keymap for Linux
 			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"}],
 		"command": "latex_change_environment"},
 
-	// Wrap selected text in emph, bold or underline
+	// Wrap selected text in emph, bold, underline or small caps
 	{ "keys": ["ctrl+l","ctrl+e"],  
 		"context":  [
 			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"}],
@@ -266,6 +266,10 @@ LaTeX Package keymap for Linux
 		"context":  [
 			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"}],
 		"command": "insert_snippet", "args": {"name":"Packages/LaTeXTools/Text monospace.sublime-snippet"}},
+	{ "keys": ["ctrl+l","ctrl+s"],  
+		"context":  [
+			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"}],
+		"command": "insert_snippet", "args": {"name":"Packages/LaTeXTools/Text small-caps.sublime-snippet"}},
 
 	// Replace the `C-r` overlay with a whole document overlay as opt-out
 	// Also add this overlay to `C-l, C-r`

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -249,7 +249,7 @@ LaTeX Package keymap for OS X
 			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"}],
 		"command": "latex_change_environment"},
 
-	// Wrap selected text in emph, bold or underline
+	// Wrap selected text in emph, bold, underline or small caps
 	{ "keys": ["super+l","super+e"],  
 		"context":  [
 			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"}],
@@ -266,6 +266,10 @@ LaTeX Package keymap for OS X
 		"context":  [
 			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"}],
 		"command": "insert_snippet", "args": {"name":"Packages/LaTeXTools/Text monospace.sublime-snippet"}},
+	{ "keys": ["super+l","super+s"],  
+		"context":  [
+			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"}],
+		"command": "insert_snippet", "args": {"name":"Packages/LaTeXTools/Text small-caps.sublime-snippet"}},
 
 	// Replace the `C-r` overlay with a whole document overlay as opt-out
 	// Also add this overlay to `C-l, C-r`

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -249,7 +249,7 @@ LaTeX Package keymap for Windows
 			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"}],
 		"command": "latex_change_environment"},
 
-	// Wrap selected text in emph, bold or underline
+	// Wrap selected text in emph, bold, underline or small caps
 	{ "keys": ["ctrl+l","ctrl+e"],  
 		"context":  [
 			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"}],
@@ -266,6 +266,10 @@ LaTeX Package keymap for Windows
 		"context":  [
 			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"}],
 		"command": "insert_snippet", "args": {"name":"Packages/LaTeXTools/Text monospace.sublime-snippet"}},
+	{ "keys": ["ctrl+l","ctrl+s"],  
+		"context":  [
+			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"}],
+		"command": "insert_snippet", "args": {"name":"Packages/LaTeXTools/Text small-caps.sublime-snippet"}},
 
 	// Replace the `C-r` overlay with a whole document overlay as opt-out
 	// Also add this overlay to `C-l, C-r`

--- a/LaTeX.sublime-completions
+++ b/LaTeX.sublime-completions
@@ -7,6 +7,7 @@
                 { "trigger": "bf", "contents": "\\textbf{$1}$0"},
                 { "trigger": "em", "contents": "\\emph{$1}$0"},
                 { "trigger": "tt", "contents": "\\texttt{$1}$0"},
+                { "trigger": "sc", "contents": "\\textsc{$1}$0"},
                 { "trigger": "un", "contents": "\\underline{$1}$0"},
 
                 { "trigger": "bs", "contents": "\\bigskip"},

--- a/README.markdown
+++ b/README.markdown
@@ -574,6 +574,7 @@ LaTeXTools' wrapping facility helps you in just these circumstances. All command
 - `C-l,C-b` gives you `\textbf{blah}`
 - `C-l,C-u` gives you `\underline{blah}`
 - `C-l,C-t` gives you `\texttt{blah}`
+- `C-l,C-s` gives you `\textsc{blah}`
 - `C-l,C-n` wraps the selected text in a LaTeX environment structure. You get `\begin{env}`,`blah`, `\end{env}` on three separate lines, with `env` selected. Change `env` to whatever environment you want, then hit Tab to move to the end of the environment.
 
 

--- a/Text small-caps.sublime-snippet
+++ b/Text small-caps.sublime-snippet
@@ -1,0 +1,9 @@
+<snippet>
+    <description>Small-caps text</description>
+    <content><![CDATA[
+\\textsc{${1:$SELECTION}}
+]]></content>
+    <!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
+    <!-- <tabTrigger>hello</tabTrigger> -->
+    <scope>text.tex.latex</scope>
+</snippet>


### PR DESCRIPTION
Well, I often need to write small caps text, so I wrote a shortcut for this and want give it to the community. I propose Ctrl+L, Ctrl+S.