### PR TITLE
Preview: Provide clearer equation previews

### DIFF
--- a/LaTeXTools.sublime-settings
+++ b/LaTeXTools.sublime-settings
@@ -142,10 +142,13 @@
 	"preview_math_no_star_envs": [],
 
 	// The density of the preview image. The higher the density the bigger the phantom.
-	"preview_math_density": 300,
+	"preview_math_density": 150,
 	// If the image is not sharp enough increase this scale to get a better resolution.
 	// However also change the density by the same factor to keep the size.
-	"preview_math_scale_quotient": 2,
+	"preview_math_scale_quotient": 1,
+	// If this is true, the image will be rendered at a higher resolution and
+	// then scaled down. This generally results in a clearer image.
+	"preview_math_hires": true,
 
 	// IMAGE PREVIEW
 

--- a/st_preview/preview_math.py
+++ b/st_preview/preview_math.py
@@ -70,16 +70,18 @@ _ERROR_EXTENSION = ".err"
 
 _scale_quotient = 1
 _density = 150
+_hires = True
 _lt_settings = {}
 
 _name = "preview_math"
 
 
 def _on_setting_change():
-    global _density, _scale_quotient
+    global _density, _scale_quotient, _hires
     _scale_quotient = _lt_settings.get(
         "preview_math_scale_quotient", _scale_quotient)
     _density = _lt_settings.get("preview_math_density", _density)
+    _hires = _lt_settings.get("preview_path_hires", _hires)
     max_threads = get_setting(
         "preview_max_convert_threads", default=None, view={})
     if max_threads is not None:
@@ -161,11 +163,16 @@ def _create_image(latex_program, latex_document, base_name, color,
         else:
             bbox = None
 
+        # hires renders the image at 8 times the dpi, then scales it down
+        scale_factor = 8 if _hires else 1
+
         # convert the pdf to a png image
         command = [
             '-sDEVICE=pngalpha', '-dLastPage=1',
             '-sOutputFile={image_path}'.format(image_path=image_path),
-            '-r{density}'.format(density=_density)
+            '-r{density}'.format(density=_density * scale_factor),
+            '-dDownScaleFactor={0}'.format(scale_factor),
+            '-dTextAlphaBits=4', '-dGraphicsAlphaBits=4'
         ]
 
         # calculate and apply cropping boundaries, if we have them
@@ -176,17 +183,17 @@ def _create_image(latex_program, latex_document, base_name, color,
             # 4pts are added to each length for some padding
             # these are then multiplied by the ratio of the final density to
             # the PDFs DPI (72) to get the final size of the image in pixels
-            width = round((bbox[2] - bbox[0] + 4) * _density / 72)
-            height = round((bbox[3] - bbox[1] + 4) * _density / 72)
+            width = round(
+                (bbox[2] - bbox[0] + 4) * _density * scale_factor / 72)
+            height = round(
+                (bbox[3] - bbox[1] + 4) * _density * scale_factor / 72)
             command.extend([
                 '-g{width}x{height}'.format(**locals()), '-c',
                 # this is the command that does the clipping starting from
                 # the lower left of the displayed contents; we subtract 2pts
                 # to properly center the final image with our padding
                 '<</Install {{{0} {1} translate}}>> setpagedevice'.format(
-                    -1 * (bbox[0] - 2), -1 * (bbox[1] - 2)
-                ),
-                '-f'
+                    -1 * (bbox[0] - 2), -1 * (bbox[1] - 2)), '-f'
             ])
 
         command.append(pdf_path)
@@ -458,6 +465,10 @@ class MathPreviewPhantomListener(sublime_plugin.ViewEventListener,
             "_watch_density": {
                 "setting": "preview_math_density",
                 "call_after": self.reset_phantoms
+            },
+            "_watch_hires": {
+                "setting": "preview_math_hires",
+                "call_after": self.reset_phantoms
             }
         }
         for attr_name, d in watch_attr.items():
@@ -708,6 +719,7 @@ class MathPreviewPhantomListener(sublime_plugin.ViewEventListener,
                 str(_version),
                 self.latex_program,
                 str(_density),
+                str(_hires),
                 color,
                 latex_document
             ])


### PR DESCRIPTION
This works by adding the `dTextAlphaBits` and `dGraphicAlphaBits` settings recommended in the [Ghostscript documentation](http://www.ghostscript.com/doc/9.20/Devices.htm#File_formats). In addition, it adds a new setting `"preview_math_hires"` which, if set to `true` (default), the image is rendered at 8x the requested density and then scaled down (by Ghostscript) to the requested size. This seems to result in a clearer image. Finally, I've changed the default settings for the preview density and scale factor as image scaling in ST seems to add a small amount of distortion.

Over all, this seems to make previews crisper. For whatever reason, the current distortion seems to be more pronounced on Windows and Linux than on macOS, at least for me, and hence this has a bigger impact on Windows or Linux users.

A quick example, using the generated PNGs.

Current state:

![PNG from Linux](https://cloud.githubusercontent.com/assets/212893/21085085/11e01dd4-c005-11e6-99b4-8d858f11ecfb.png)

After change:

![PNG from Linux](https://cloud.githubusercontent.com/assets/212893/21085136/918290d0-c005-11e6-9abd-681473b93a7d.png)

New Rendering in action:

<img alt="screenshot showing new rendering" src="https://cloud.githubusercontent.com/assets/212893/21085207/abb4be46-c006-11e6-8ef3-20807b27fb98.png">




