### PR TITLE
Okular viewer prepend pdf path with 'file:' in forward sync, ref #989

### DIFF
--- a/viewers/okular_viewer.py
+++ b/viewers/okular_viewer.py
@@ -39,7 +39,7 @@ class OkularViewer(BaseViewer):
     def forward_sync(self, pdf_file, tex_file, line, col, **kwargs):
         self._ensure_okular()
         self._run_okular(
-            '{pdf_file}#src:{line}{tex_file}'.format(**locals()),
+            'file:{pdf_file}#src:{line}{tex_file}'.format(**locals()),
             **kwargs
         )
 


### PR DESCRIPTION
Issue was introduced with Okular version 0.99.80+, see this tracker: https://bugs.kde.org/show_bug.cgi?id=373855

This PR fixes #989

