### PR TITLE
Don't set stdout to PIPE or redirect stderr in external_command

### DIFF
--- a/latextools_utils/external_command.py
+++ b/latextools_utils/external_command.py
@@ -196,10 +196,10 @@ def external_command(command, cwd=None, shell=False, env=None,
         stdin = None
 
     if stdout is __sentinel__:
-        stdout = PIPE
+        stdout = None
 
     if stderr is __sentinel__:
-        stderr = STDOUT
+        stderr = None
 
     try:
         print(u'Running "{0}"'.format(u' '.join([quote(s) for s in command])))
@@ -248,6 +248,12 @@ def execute_command(command, cwd=None, shell=False, env=None,
             return u'\n'.join(
                 re.split(r'\r?\n', stream.decode('utf-8', 'ignore').rstrip())
             )
+
+    if stdout is __sentinel__:
+        stdout = PIPE
+
+    if stderr is __sentinel__:
+        stderr = STDOUT
 
     p = external_command(
         command,


### PR DESCRIPTION
This is my actual recommendation for fixing #937. It, ultimately, does the same thing as the quick fix I made [here](https://github.com/SublimeText/LaTeXTools/issues/937#issuecomment-268834256), but also prevents similar issues from arising in other contexts, which seems to be related to not checking the stdout and / or stderr pipes.

For the most part, where external_command is used, as opposed to execute_command or check_call, etc., we don't actually care about the output. Moreover, setting stdout and stderr to PIPE seems to create issues when running certain executables, possibly because the piped stream is never read.