### PR TITLE
Only use preview_math_hires if using Ghostscript 9.14 or newer

### DIFF
--- a/st_preview/preview_math.py
+++ b/st_preview/preview_math.py
@@ -17,7 +17,8 @@ from ..parseTeXlog import parse_tex_log
 from ..latextools_utils import cache, get_setting
 from ..latextools_utils.external_command import execute_command
 from . import preview_utils
-from .preview_utils import ghostscript_installed, run_ghostscript_command
+from .preview_utils import (
+    ghostscript_installed, get_ghostscript_version, run_ghostscript_command)
 from . import preview_threading as pv_threading
 
 # export the listener
@@ -25,7 +26,7 @@ exports = ["MathPreviewPhantomListener"]
 
 # increase this number if you change the convert command to mark the
 # generated images as expired
-_version = 1
+_version = 2
 
 # use this variable to disable the plugin for a session
 # (until ST is restarted)
@@ -164,7 +165,8 @@ def _create_image(latex_program, latex_document, base_name, color,
             bbox = None
 
         # hires renders the image at 8 times the dpi, then scales it down
-        scale_factor = 8 if _hires else 1
+        scale_factor = \
+            8 if _hires and get_ghostscript_version() >= (9, 14) else 1
 
         # convert the pdf to a png image
         command = [
@@ -719,7 +721,7 @@ class MathPreviewPhantomListener(sublime_plugin.ViewEventListener,
                 str(_version),
                 self.latex_program,
                 str(_density),
-                str(_hires),
+                str(_hires and get_ghostscript_version() >= (9, 14)),
                 color,
                 latex_document
             ])

--- a/st_preview/preview_utils.py
+++ b/st_preview/preview_utils.py
@@ -1,4 +1,5 @@
 import os
+import re
 import threading
 import time
 import traceback
@@ -15,7 +16,7 @@ except:
 from ..latextools_utils import cache, get_setting
 from ..latextools_utils.distro_utils import using_miktex
 from ..latextools_utils.external_command import (
-    get_texpath, execute_command, __sentinel__
+    get_texpath, execute_command, check_output, __sentinel__
 )
 from ..latextools_utils.system import which
 
@@ -56,12 +57,44 @@ def run_convert_command(args):
     execute_command(args, shell=sublime.platform() == 'windows')
 
 
-def _get_gs_command():
-    if hasattr(_get_gs_command, "result"):
-        return _get_gs_command.result
+_GS_COMMAND = None
+_GS_VERSION_LOCK = threading.Lock()
+_GS_VERSION = None
+_GS_VERSION_REGEX = re.compile(r'Ghostscript (?P<major>\d+)\.(?P<minor>\d{2})')
 
-    _get_gs_command.result = __get_gs_command()
-    return _get_gs_command.result
+
+def _get_gs_command():
+    global _GS_COMMAND
+    if _GS_COMMAND is not None:
+        return _GS_COMMAND
+
+    _GS_COMMAND = __get_gs_command()
+
+    # load the GS version on a background thread
+    t = threading.Thread(target=_update_gs_version)
+    t.daemon = True
+    t.start()
+
+    return _GS_COMMAND
+
+
+def _update_gs_version():
+    global _GS_VERSION
+    with _GS_VERSION_LOCK:
+        if _GS_VERSION is not None:
+            return
+
+        try:
+            raw_version = check_output([_GS_COMMAND, '-version'])
+            m = _GS_VERSION_REGEX.search(raw_version)
+            if m:
+                _GS_VERSION = tuple(int(x) for x in m.groups())
+        except OSError:
+            print('Error finding Ghostscript version for {0}'.format(
+                _GS_COMMAND))
+            traceback.print_exc()
+        except Exception:
+            traceback.print_exc()
 
 
 # broken out to be called from system_check
@@ -76,7 +109,7 @@ def __get_gs_command():
             which('gs', path=texpath)
         )
 
-        if not using_miktex():
+        if result is None and not using_miktex():
             result = _get_tl_gs_path(texpath)
 
         # try to find Ghostscript from the registry
@@ -174,6 +207,15 @@ def _get_gs_exe_from_registry():
 
 def ghostscript_installed():
     return _get_gs_command() is not None
+
+
+def get_ghostscript_version():
+    global _GS_VERSION
+    with _GS_VERSION_LOCK:
+        if _GS_VERSION is None:
+            _update_gs_version()
+
+        return _GS_VERSION if _GS_VERSION is not None else (-1, -1)
 
 
 def run_ghostscript_command(args, stdout=__sentinel__, stderr=__sentinel__):


### PR DESCRIPTION
This should deal with #999, the underlying problem for which is that earlier versions of Ghostscript didn't support the `-dDownScaleFactor` parameter.