### PR TITLE
Limit the TOC quickpanel to the current document

### DIFF
--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -267,14 +267,28 @@ LaTeX Package keymap for Linux
 			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"}],
 		"command": "insert_snippet", "args": {"name":"Packages/LaTeXTools/Text monospace.sublime-snippet"}},
 
-	// Replace the `C-r` overlay with a whole document overlay as opt-out
-	// Also add this overlay to `C-l, C-r`
-	{ "keys": ["ctrl+r"],
+	// Replace the `C-r` overlay and the `C-shift-r` overlay with a 
+	// whole document overlay as opt-out
+	// Also add these overlays to `C-l, C-r` and `C-l, C-shift-r`
+	{ "keys": ["ctrl+r"], "command": "latex_toc_quickpanel",
+		"args": {"only_current_file": true},
 		"context":  [
 			{"key": "selector", "operator": "equal", "operand": "text.tex"},
-			{"key": "overwrite_goto_overlay"}],
-		"command": "latex_toc_quickpanel"},
+			{"key": "overwrite_goto_overlay"}]
+	},
+	{ "keys": ["ctrl+shift+r"], "command": "latex_toc_quickpanel",
+		"args": {"only_current_file": false},
+		"context":  [
+			{"key": "selector", "operator": "equal", "operand": "text.tex"},
+			{"key": "overwrite_goto_overlay"}]
+	},
 	{ "keys": ["ctrl+l","ctrl+r"],
+		"args": {"only_current_file": true},
+		"context":  [
+			{"key": "selector", "operator": "equal", "operand": "text.tex"}],
+		"command": "latex_toc_quickpanel"},
+	{ "keys": ["ctrl+l","ctrl+shift+r"], "command": "latex_toc_quickpanel",
+		"args": {"only_current_file": false},
 		"context":  [
 			{"key": "selector", "operator": "equal", "operand": "text.tex"}],
 		"command": "latex_toc_quickpanel"},

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -267,14 +267,28 @@ LaTeX Package keymap for OS X
 			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"}],
 		"command": "insert_snippet", "args": {"name":"Packages/LaTeXTools/Text monospace.sublime-snippet"}},
 
-	// Replace the `C-r` overlay with a whole document overlay as opt-out
-	// Also add this overlay to `C-l, C-r`
-	{ "keys": ["super+r"],
+	// Replace the `C-r` overlay and the `C-shift-r` overlay with a 
+	// whole document overlay as opt-out
+	// Also add these overlays to `C-l, C-r` and `C-l, C-shift-r`
+	{ "keys": ["super+r"], "command": "latex_toc_quickpanel",
+		"args": {"only_current_file": true},
 		"context":  [
 			{"key": "selector", "operator": "equal", "operand": "text.tex"},
-			{"key": "overwrite_goto_overlay"}],
-		"command": "latex_toc_quickpanel"},
+			{"key": "overwrite_goto_overlay"}]
+	},
+	{ "keys": ["super+shift+r"], "command": "latex_toc_quickpanel",
+		"args": {"only_current_file": false},
+		"context":  [
+			{"key": "selector", "operator": "equal", "operand": "text.tex"},
+			{"key": "overwrite_goto_overlay"}]
+	},
 	{ "keys": ["super+l","super+r"],
+		"args": {"only_current_file": true},
+		"context":  [
+			{"key": "selector", "operator": "equal", "operand": "text.tex"}],
+		"command": "latex_toc_quickpanel"},
+	{ "keys": ["super+l","super+shift+r"], "command": "latex_toc_quickpanel",
+		"args": {"only_current_file": false},
 		"context":  [
 			{"key": "selector", "operator": "equal", "operand": "text.tex"}],
 		"command": "latex_toc_quickpanel"},

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -267,14 +267,28 @@ LaTeX Package keymap for Windows
 			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"}],
 		"command": "insert_snippet", "args": {"name":"Packages/LaTeXTools/Text monospace.sublime-snippet"}},
 
-	// Replace the `C-r` overlay with a whole document overlay as opt-out
-	// Also add this overlay to `C-l, C-r`
-	{ "keys": ["ctrl+r"],
+	// Replace the `C-r` overlay and the `C-shift-r` overlay with a 
+	// whole document overlay as opt-out
+	// Also add these overlays to `C-l, C-r` and `C-l, C-shift-r`
+	{ "keys": ["ctrl+r"], "command": "latex_toc_quickpanel",
+		"args": {"only_current_file": true},
 		"context":  [
 			{"key": "selector", "operator": "equal", "operand": "text.tex"},
-			{"key": "overwrite_goto_overlay"}],
-		"command": "latex_toc_quickpanel"},
+			{"key": "overwrite_goto_overlay"}]
+	},
+	{ "keys": ["ctrl+shift+r"], "command": "latex_toc_quickpanel",
+		"args": {"only_current_file": false},
+		"context":  [
+			{"key": "selector", "operator": "equal", "operand": "text.tex"},
+			{"key": "overwrite_goto_overlay"}]
+	},
 	{ "keys": ["ctrl+l","ctrl+r"],
+		"args": {"only_current_file": true},
+		"context":  [
+			{"key": "selector", "operator": "equal", "operand": "text.tex"}],
+		"command": "latex_toc_quickpanel"},
+	{ "keys": ["ctrl+l","ctrl+shift+r"], "command": "latex_toc_quickpanel",
+		"args": {"only_current_file": false},
 		"context":  [
 			{"key": "selector", "operator": "equal", "operand": "text.tex"}],
 		"command": "latex_toc_quickpanel"},

--- a/LaTeXTools.sublime-settings
+++ b/LaTeXTools.sublime-settings
@@ -52,8 +52,8 @@
 	// Sync PDF to current editor position after building (true) or not
 	"forward_sync": true,
 
-	// Set this to false to disable the overwriting of the goto overlay for the hotkey `C-r`
-	// You can still access the "table of content quickpanel" via `C-l, C-r`
+	// Set this to false to disable the overwriting of the goto overlay for the hotkey `C-r` and `C-shift-r`
+	// You can still access the "table of content quickpanel" via `C-l, C-r` and  `C-shift-l, C-r`
 	"overwrite_goto_overlay": true,
 
 	// When to trigger cwl-command completion (requires the LaTeX-cwl package)

--- a/README.markdown
+++ b/README.markdown
@@ -497,9 +497,9 @@ The `C-l,C-alt-f` keyboard shortcut is identical to the `C-l,C-f` shortcut, exce
 
 ### Jumping to sections and labels
 
-**Keybinding:** `C-r` (standard ST keybinding)
+**Keybinding:** `C-r`, `C-shift-r` (standard ST keybinding) and `C-l, C-r`, `C-l, C-shift-r`
 
-The LaTeXtools plugin integrates with the awesome ST "Goto Anything" facility. Hit `C-r`to get a list of all section headings, and all labels. You can filter by typing a few initial letters. Note that section headings are preceded by the letter "S", and labels by "L"; so, if you only want section headings, type "S" when the drop-down list appears.
+LaTeXTools replaces the integrated "Goto Anything" facility. This enables better multi-file support, because the sections remains ordered. In addition you can toggle the appearance of labels. You can filter by typing a few initial letters. You can disable this and use the default overlay by settings `overwrite_goto_overlay` to `false` in your LaTeXTools settings.
 
 Selecting any entry in the list will take you to the corresponding place in the text.
 
@@ -647,6 +647,8 @@ The following options are currently available (defaults in parentheses):
 - `temp_files_exts`: list of file extensions to be considered temporary, and hence deleted using the `C-l, backspace` command.
 - `temp_files_ignored_folders`: subdirectories to skip when deleting temp files.
 * `tex_file_exts` (`['.tex']`): a list of extensions that should be considered TeX documents. Any extensions in this list will be treated exactly the same as `.tex` files. See the section on [Support for non-`.tex` files](#support-for-non-tex-files).
+* `overwrite_goto_overlay` (`true`): Set this to `false` to disable the overwriting of the goto overlay for the hotkey `C-r` and `C-shift-r` You can still access the "table of content quickpanel" via `C-l, C-r` and `C-shift-l, C-r`
+  ,
 * `latextools_set_syntax` (`true`): if `true` LaTeXTools will automatically set the syntax to `LaTeX` when opening or saving any file with an extension in the `tex_file_exts` list.
 * `use_biblatex`: (`false`): if `true` LaTeXTools will use BibLaTeX defaults for editing `.bib` files. If `false`, LaTeXTools will use BibTeX defaults. See the section on [Support for Editing Bibliographies](#support-for-editing-bibliographies) for details.
 * `tex_spellcheck_paths` (`{}`): A mapping from the locales to the paths of the dictionaries. See the section [Spell-checking](#spell-checking).

--- a/search_commands.py
+++ b/search_commands.py
@@ -17,13 +17,17 @@ def _make_caption(ana, entry):
 
 
 class LatexSearchCommandCommand(sublime_plugin.WindowCommand):
-    def run(self, commands):
+    def run(self, commands, only_current_file=False):
         window = self.window
         view = window.active_view()
         tex_root = get_tex_root(view)
 
         ana = analysis.analyze_document(tex_root)
         entries = ana.filter_commands(commands, flags=analysis.ALL_COMMANDS)
+
+        if only_current_file:
+            file_name = view.file_name()
+            entries = [e for e in entries if e.file_name == file_name]
 
         captions = [_make_caption(ana, e) for e in entries]
         quickpanel.show_quickpanel(captions, entries)
@@ -34,12 +38,16 @@ class LatexSearchCommandInputCommand(sublime_plugin.WindowCommand):
         view = self.window.active_view()
         return bool(view.score_selector(0, "text.tex"))
 
-    def run(self):
+    def run(self, only_current_file=False):
         window = self.window
 
         def on_done(text):
             commands = [c.strip() for c in text.split(",")]
-            window.run_command("latex_search_command", {"commands": commands})
+            kwargs = {
+                "commands": commands,
+                "only_current_file": only_current_file
+            }
+            window.run_command("latex_search_command", kwargs)
 
         def do_nothing(text):
             pass

--- a/toc_quickpanel.py
+++ b/toc_quickpanel.py
@@ -33,7 +33,7 @@ class show_toc_quickpanel(quickpanel.CancelEntriesQuickpanel):
     __hide_string = "Hide Labels"
     __toggles = [__show_string, __hide_string]
 
-    def __init__(self, ana):
+    def __init__(self, ana, only_file=None):
         # retrieve the labels and the sections
         toc_section_commands = get_setting("toc_section_commands", [])
         toc_indentations = get_setting("toc_indentations", {})
@@ -43,6 +43,10 @@ class show_toc_quickpanel(quickpanel.CancelEntriesQuickpanel):
         # filter the labels and sections to only get the labels
         # (faster than an additional query)
         secs = [c for c in labels if c.command in toc_section_commands]
+
+        if only_file:
+            labels = [l for l in labels if l.file_name == only_file]
+            secs = [s for s in secs if s.file_name == only_file]
 
         # create the user readably captions
         # get the minimal indent (to lower the minimal section indent to 0)
@@ -114,14 +118,15 @@ def show_commands(captions, entries, show_cancel=True):
 
 
 class LatexTocQuickpanelCommand(sublime_plugin.WindowCommand):
-    def run(self):
+    def run(self, only_current_file=False):
         view = self.window.active_view()
         tex_root = get_tex_root(view)
         if not tex_root:
             return
         ana = analysis.analyze_document(tex_root)
 
-        show_toc_quickpanel(ana)
+        only_file = None if not only_current_file else view.file_name()
+        show_toc_quickpanel(ana, only_file=only_file)
 
 
 class LatexTocQuickpanelContext(sublime_plugin.EventListener):


### PR DESCRIPTION
This adds a `only_current_file` flag to the toc quickpanel and the command search quickpanel as suggested in #942 by @jdumas.

Open discussion:
We could limit the usual ctrl+r to the file (as usual) and the ctrl+shift+r command to the whole document.

- [x] add the flag to the keybinding (such that the users can see it)

PS. If someone want to try this you can add these keybindings:

``` js
    { 
        "keys": ["ctrl+r"], "command": "latex_toc_quickpanel",
        "args": {"only_current_file": true},
        "context": [
            {"key": "selector", "operator": "equal", "operand": "text.tex"}
        ]
    },
    { 
        "keys": ["ctrl+shift+r"], "command": "latex_toc_quickpanel",
        "args": {"only_current_file": false},
        "context": [
            {"key": "selector", "operator": "equal", "operand": "text.tex"}
        ]
    },
```