### PR TITLE
Change the bracket completing algorithm to be less agressive

### DIFF
--- a/LaTeXTools (Advanced).sublime-settings
+++ b/LaTeXTools (Advanced).sublime-settings
@@ -178,5 +178,16 @@
 
 	// these entries should only be used for project settings or
 	// while you want to test new entries
-	"dynamic_fillall_helper_entries": []
+	"dynamic_fillall_helper_entries": [],
+
+	// this determines whether or not the smart bracket autotriggering
+	// will scan the full document or only a pre-configured number of lines
+	// enabling full document scan will likely be more accurate for straight-
+	// forward LaTeX documents, since it counts the number of open and closed
+	// brackets, but in some circumstances, will yield undesirable results
+	"smart_bracket_scan_full_document": false,
+
+	// this setting determines the number of lines that smart bracket
+	// auto triggering will look behind each selection
+	"smart_bracket_look_behind": 5
 }


### PR DESCRIPTION
Per @r-stein's suggestion, the new algorithm defaults to only scanning 5 lines before the selection to determin if there is an unopened bracket that needs to be closed. This, hopefully, helps resolve the issues in #1011.

The number of lines scanned can be configured using the `smart_bracket_look_behind` advanced setting, and the present behaviour of scanning the full document can be restored by using the `smart_bracket_scan_full_document` advanced setting.