### PR TITLE
Change the bracket completing algorithm to be less agressive

### DIFF
--- a/LaTeXTools (Advanced).sublime-settings
+++ b/LaTeXTools (Advanced).sublime-settings
@@ -178,5 +178,18 @@
 
 	// these entries should only be used for project settings or
 	// while you want to test new entries
-	"dynamic_fillall_helper_entries": []
+	"dynamic_fillall_helper_entries": [],
+
+	// this determines whether or not the smart bracket autotriggering
+	// will scan the full document or only a pre-configured number of lines
+	// enabling full document scan will likely be more accurate for straight-
+	// forward LaTeX documents, since it counts the number of open and closed
+	// brackets, but in some circumstances, will yield undesirable results
+	"smart_bracket_scan_full_document": false,
+
+	// this setting determines the number of lines that smart bracket
+	// auto triggering will look around each selection. by default, smart
+	// bracket auto triggering looks 5 lines before the selection and 5 lines
+	// after
+	"smart_bracket_look_around": 5
 }

--- a/latex_fill_all.py
+++ b/latex_fill_all.py
@@ -131,22 +131,17 @@ class LatexFillHelper(object):
                             if word_region.empty():
                                 new_regions.append(
                                     getRegion(
-                                        word_region.end(), word_region.end()
-                                    )
-                                )
+                                        word_region.end(), word_region.end()))
                             else:
-                                new_point = word_region.end() + \
-                                    len(close_bracket)
-                                new_regions.append(
-                                    getRegion(new_point, new_point)
-                                )
+                                new_point = word_region.end() + len(
+                                    close_bracket)
+                                new_regions.append(getRegion(
+                                    new_point, new_point))
                         else:
                             new_regions.append(
                                 getRegion(
                                     sel.begin(),
-                                    word_region.end() + len(close_bracket)
-                                )
-                            )
+                                    word_region.end() +len(close_bracket)))
                     else:
                         new_regions.append(sel)
 
@@ -194,9 +189,22 @@ class LatexFillHelper(object):
         # to find all matches once per bracket type
         # if the view has changed, we reset the candidates
         candidates = None
+
         if not hasattr(self, 'last_view') or self.last_view != view.id():
             self.last_view = view.id()
+            self.use_full_scan = get_setting(
+                'smart_bracket_scan_full_document', False)
             candidates = self.candidates = {}
+
+        if not self.use_full_scan:
+            # always clear the candidates when not using a full scan
+            candidates = {}
+            # when not using a full scan, get the number of lines to
+            # look-behind
+            try:
+                look_around = int(get_setting('smart_bracket_look_around', 5))
+            except ValueError:
+                look_around = 5
 
         if candidates is None:
             try:
@@ -210,7 +218,17 @@ class LatexFillHelper(object):
         else:
             start = end = sel
 
-        prefix = view.substr(getRegion(0, start))
+        if self.use_full_scan:
+            prefix = view.substr(getRegion(0, start))
+            prefix_start = 0
+            suffix_end = view.size()
+        else:
+            prefix_start = view.lines(
+                getRegion(0, start))[-look_around].begin()
+            suffix_end = view.lines(
+                getRegion(end, view.size()))[look_around].end()
+
+            prefix = view.substr(getRegion(prefix_start, start))
 
         open_bracket, last_index = None, -1
         for char in self.MATCH_CHARS:
@@ -231,17 +249,28 @@ class LatexFillHelper(object):
         if open_bracket not in candidates:
             # find all open / close brackets in the current buffer,
             # removing all comments
-            candidates[open_bracket] = [
-                c for c in view.find_all(
-                    re.escape(open_bracket) + '|' +
-                    re.escape(close_bracket)
-                )
-                if view.score_selector(c.begin(), 'comment') == 0
-            ]
+            candidates[open_bracket] = results = []
+
+            start = prefix_start
+            re_str = re.escape(open_bracket) + '|' + re.escape(close_bracket)
+            while True:
+                c = view.find(re_str, start)
+                if c is None:
+                    break
+
+                if c.end() > suffix_end:
+                    break
+
+                if view.score_selector(c.begin(), 'comment') != 0:
+                    start = c.end()
+                    continue
+
+                results.append(c)
+                start = c.end()
 
         for candidate in candidates[open_bracket]:
             if view.substr(candidate) == open_bracket:
-                if candidate.begin() > end:
+                if len(open_brackets) == 0 and candidate.begin() > end:
                     break
 
                 open_brackets.append(candidate)
@@ -281,6 +310,11 @@ class LatexFillHelper(object):
 
         try:
             del self.last_view
+        except:
+            pass
+
+        try:
+            del self.use_full_scan
         except:
             pass
 


### PR DESCRIPTION
Per @r-stein's suggestion, the new algorithm defaults to only scanning 5 lines before (and after) the selection to determine if there is an unopened bracket that needs to be closed. This, hopefully, helps resolve the issues in #1011.

The number of lines scanned can be configured using the `smart_bracket_look_around` advanced setting, and the present behaviour of scanning the full document can be restored by using the `smart_bracket_scan_full_document` advanced setting.

I would appreciate any feedback from testing this change since it works in a couple of documents I'm currently using, but I think my documents are probably quite a bit simpler than others (I don't use too much math among other things).