### PR TITLE
Improve cache sanity

### DIFF
--- a/latextools_cache_listener.py
+++ b/latextools_cache_listener.py
@@ -211,9 +211,11 @@ class LatextoolsCacheUpdateListener(
             self.run_bib_cache(tex_root)
 
         with self._UPDATING_DOCS_LOCK:
-            self._UPDATING_DOCS.add(tex_root)
-        t = self.run_cache_update()
-        self._monitor_update_thread(t, tex_root)
+            if tex_root not in self._UPDATING_DOCS:
+                self._UPDATING_DOCS.add(tex_root)
+
+                t = self.run_cache_update()
+                self._monitor_update_thread(t, tex_root)
 
     if not _ST3:
         on_load = on_load_async

--- a/latextools_cache_listener.py
+++ b/latextools_cache_listener.py
@@ -100,7 +100,7 @@ class LatextoolsCacheUpdateListener(
     _TEX_CACHES = {}
     _TEX_ROOT_REFS = collections.defaultdict(lambda: 0)
     _BIB_CACHES = {}
-    _UPDATING_DOCS_LOCK = threading.Lock()
+    _UPDATING_DOCS_LOCK = threading.RLock()
     _UPDATING_DOCS = set([])
 
     def on_load_async(self, view):

--- a/latextools_cache_listener.py
+++ b/latextools_cache_listener.py
@@ -18,7 +18,7 @@ try:
     from .latextools_utils.cache import LocalCache
     from .latextools_utils.tex_directives import get_tex_root
     from .latextools_utils.progress_indicator import ProgressIndicator
-except:
+except (ValueError, ImportError):
     from latex_cite_completions import (
         find_bib_files, run_plugin_command
     )

--- a/latextools_utils/bibcache.py
+++ b/latextools_utils/bibcache.py
@@ -88,7 +88,8 @@ class BibCache(cache.InstanceTrackingCache, cache.GlobalCache):
         except cache.CacheMiss:
             result = func()
             self.set(result)
-            return result
+            return self._objects[self.formatted_cache_name]
+
 
     def validate_on_get(self, obj):
         if obj is None:
@@ -124,10 +125,8 @@ class BibCache(cache.InstanceTrackingCache, cache.GlobalCache):
 
     def _get_bib_cache(self):
         try:
-            # use the lock to not contend with writing the file
-            with self._disk_lock:
-                cache_mtime = os.path.getmtime(
-                    os.path.join(self.cache_path, self.cache_name))
+            cache_mtime = os.path.getmtime(
+                os.path.join(self.cache_path, self.cache_name))
 
             bib_mtime = os.path.getmtime(self.bib_file)
         except OSError as e:

--- a/latextools_utils/bibcache.py
+++ b/latextools_utils/bibcache.py
@@ -19,6 +19,13 @@ else:
 _VERSION = 2
 
 
+def _list_to_tuple(v):
+    if isinstance(v, list):
+        return tuple(v)
+    else:
+        return v
+
+
 class BibCache(cache.InstanceTrackingCache, cache.GlobalCache):
     '''
     implements a cache for a bibliography file
@@ -90,7 +97,6 @@ class BibCache(cache.InstanceTrackingCache, cache.GlobalCache):
             self.set(result)
             return self._objects[self.formatted_cache_name]
 
-
     def validate_on_get(self, obj):
         if obj is None:
             raise cache.CacheMiss()
@@ -107,7 +113,7 @@ class BibCache(cache.InstanceTrackingCache, cache.GlobalCache):
                 raise cache.CacheMiss('outdated formatted entries')
 
         if _VERSION != meta_data['version'] or any(
-            meta_data[s] != get_setting("cite_" + s)
+            meta_data[s] != _list_to_tuple(get_setting("cite_" + s))
             for s in ["panel_format", "autocomplete_format"]
         ):
             return self._get_bib_cache()[1]

--- a/latextools_utils/cache.py
+++ b/latextools_utils/cache.py
@@ -758,3 +758,11 @@ class LocalCache(ValidatingCache, InstanceTrackingCache):
             cls._PREV_LIFE_SPAN_STR = life_span_string
             cls._PREV_LIFE_SPAN = life_span = __parse_life_span_string()
             return life_span
+
+
+# terminates the cache threadpool
+def _terminate_cache_threadpool():
+    try:
+        Cache._pool.terminate()
+    except Exception:
+        traceback.print_exc()

--- a/latextools_utils/cache.py
+++ b/latextools_utils/cache.py
@@ -205,6 +205,10 @@ class Cache(object):
     implements the shared functionality between the various caches
     '''
 
+    # these threads are used for IO, so having too many is probably OK
+    # NB: This pool is shared by all caches
+    _pool = ThreadPool()
+
     def __new__(cls, *args, **kwargs):
         # don't allow this class to be instantiated directly
         if cls is Cache:
@@ -226,8 +230,6 @@ class Cache(object):
             self._dirty = False
         if not hasattr(self, '_save_queue'):
             self._save_queue = []
-        if not hasattr(self, '_pool'):
-            self._pool = ThreadPool(2)
 
         self.cache_path = self._get_cache_path()
 

--- a/latextools_utils/cache.py
+++ b/latextools_utils/cache.py
@@ -462,7 +462,10 @@ class Cache(object):
         '''
         an async version of save; does the save in a new thread
         '''
-        self._pool.apply_async(self.save, key)
+        try:
+            self._pool.apply_async(self.save, key)
+        except ValueError:
+            pass
 
     def _write(self, key, obj):
         try:

--- a/latextools_utils/cache.py
+++ b/latextools_utils/cache.py
@@ -219,11 +219,11 @@ class Cache(object):
     def __init__(self):
         # initialize state but ONLY if it hasn't already been initialized
         if not hasattr(self, '_disk_lock'):
-            self._disk_lock = threading.Lock()
+            self._disk_lock = threading.RLock()
         if not hasattr(self, '_write_lock'):
-            self._write_lock = threading.Lock()
+            self._write_lock = threading.RLock()
         if not hasattr(self, '_save_lock'):
-            self._save_lock = threading.Lock()
+            self._save_lock = threading.RLock()
         if not hasattr(self, '_objects'):
             self._objects = {}
         if not hasattr(self, '_dirty'):
@@ -607,7 +607,7 @@ class InstanceTrackingCache(Cache):
         if not hasattr(cls, '_INSTANCES'):
             cls._INSTANCES = collections.defaultdict(lambda: {})
             cls._REF_COUNTS = collections.defaultdict(lambda: 0)
-            cls._LOCKS = collections.defaultdict(lambda: threading.Lock())
+            cls._LOCKS = collections.defaultdict(lambda: threading.RLock())
 
         inst = super(InstanceTrackingCache, cls).__new__(cls, *args, **kwargs)
         inst_key = inst._get_inst_key(*args, **kwargs)
@@ -671,7 +671,7 @@ class LocalCache(ValidatingCache, InstanceTrackingCache):
     '''
 
     _CACHE_TIMESTAMP = "created_time_stamp"
-    _LIFE_SPAN_LOCK = threading.Lock()
+    _LIFE_SPAN_LOCK = threading.RLock()
 
     def __init__(self, tex_root):
         self.tex_root = tex_root

--- a/latextools_utils/cache.py
+++ b/latextools_utils/cache.py
@@ -326,7 +326,7 @@ class Cache(object):
 
         try:
             return self.get(key)
-        except:
+        except CacheMiss:
             result = func()
             self.set(key, result)
             return result
@@ -343,7 +343,7 @@ class Cache(object):
         def _invalidate(key):
             try:
                 self._objects[key] = _invalid_object
-            except:
+            except Exception:
                 print('error occurred while invalidating {0}'.format(key))
                 traceback.print_exc()
 

--- a/latextools_utils/cache.py
+++ b/latextools_utils/cache.py
@@ -625,7 +625,8 @@ class InstanceTrackingCache(Cache):
             raise NotImplemented
 
         if not hasattr(cls, '_INSTANCES'):
-            cls._INSTANCES = collections.defaultdict(lambda: InstanceReference())
+            cls._INSTANCES = collections.defaultdict(
+                lambda: InstanceReference())
 
         inst = super(InstanceTrackingCache, cls).__new__(cls, *args, **kwargs)
         inst_key = inst._get_inst_key(*args, **kwargs)
@@ -667,9 +668,12 @@ class InstanceTrackingCache(Cache):
         if inst_key is None:
             return
 
-        if self._INSTANCES[inst_key].dec_ref() == 0:
-            self.save_async()
-            del self._INSTANCES[inst_key]
+        try:
+            if self._INSTANCES[inst_key].dec_ref() == 0:
+                self.save_async()
+                del self._INSTANCES[inst_key]
+        except KeyError:
+            pass
 
 
 class LocalCache(ValidatingCache, InstanceTrackingCache):

--- a/latextools_utils/utils.py
+++ b/latextools_utils/utils.py
@@ -205,25 +205,24 @@ class ThreadPool(object):
     '''A relatively simple ThreadPool designed to maintain a number of thread
     workers
 
-    By default, each pool manages a number of processes equal to the number
-    of CPU cores. This can be adjusted by setting the processes parameter
-    when creating the pool.
+    By default, each pool manages a number of processes up to one less than
+    the number of CPU cores. This can be adjusted by setting the processes
+    parameter when creating the pool.
 
     Returned results are similar to multiprocessing.pool.AsyncResult'''
 
-    def __init__(self, processes=None):
+    def __init__(self, max_processes=None):
         self._task_queue = Queue()
         self._result_queue = Queue()
         # used to indicate if the ThreadPool should be stopped
         self._should_stop = threading.Event()
 
-        if processes and processes > 0:
-            self._processes = processes
+        if max_processes and max_processes > 0:
+            self._max_processes = max_processes
         else:
             # defaults to one less than the number of CPU cores
-            self._processes = max(cpu_count() - 1, 1)
+            self.max_processes = max(cpu_count() - 1, 1)
         self._workers = []
-        self._populate_pool()
 
         self._job_counter = itertools.count()
         self._result_cache = {}
@@ -240,11 +239,21 @@ class ThreadPool(object):
 
     # - Public API
     def apply_async(self, func, args=(), kwargs={}):
+        '''Similar to the built-in apply() function, but executed on a worker
+        thread rather than the calling thread. Returns a _ThreadPoolResult
+        object which can be used to obtain the results of the supplied
+        function.'''
+        if self._should_stop.is_set():
+            raise ValueError('Pool not running')
         job = next(self._job_counter)
-        self._task_queue.put((job, (func, args, kwargs)))
+        self._task_queue.put((job, (func, args, kwargs)), False)
         return _ThreadPoolResult(job, self._result_cache)
 
     def is_running(self):
+        '''Returns whether or not the pool is actively running. Note that
+        a False result does not necessarily indicate that the pool has
+        stopped, only that it has been instructed to stop and no further tasks
+        will be accepted.'''
         return not self._should_stop.is_set()
 
     def terminate(self):
@@ -263,16 +272,23 @@ class ThreadPool(object):
     # and start fresh workers
     def _maintain_pool(self):
         while self.is_running():
-            cleared_processes = False
             for i in reversed(range(len(self._workers))):
                 w = self._workers[i]
                 if not w.is_alive():
                     w.join()
-                    cleared_processes = True
                     del self._workers[i]
 
-            if cleared_processes:
-                self._populate_pool()
+            if not self._task_queue.empty():
+                if len(self._workers) < self._max_processes:
+                    w = _ThreadPoolWorker(
+                        self._task_queue,
+                        self._result_queue
+                    )
+                    self._workers.append(w)
+                    w.start()
+            else:
+                for _ in range(len(self._workers)):
+                    self._task_queue.put(None, False)
 
             time.sleep(0.1)
 
@@ -302,15 +318,9 @@ class ThreadPool(object):
             finally:
                 self._result_queue.task_done()
 
-    # creates and adds worker threads
-    def _populate_pool(self):
-        for _ in range(self._processes - len(self._workers)):
-            w = _ThreadPoolWorker(self._task_queue, self._result_queue)
-            self._workers.append(w)
-            w.start()
-
 
 class _ThreadPoolWorker(threading.Thread):
+    '''Worker thread from the ThreadPool. Should not be used.'''
 
     def __init__(self, task_queue, result_queue, *args, **kwargs):
         super(_ThreadPoolWorker, self).__init__(*args, **kwargs)
@@ -341,6 +351,8 @@ class _ThreadPoolWorker(threading.Thread):
 
 
 class _ThreadPoolResult(object):
+    '''Class for obtaining results from worker threads. This is modeled
+    on multiprocessing.pool.AsyncResult.'''
 
     def __init__(self, job, result_cache):
         self._ready = threading.Event()
@@ -373,6 +385,7 @@ class _ThreadPoolResult(object):
     def then(self, callback, timeout=None):
         callback(self.get(timeout))
 
+    # - Internal API
     def _set_result(self, _value):
         self._value = _value
         self._ready.set()

--- a/makePDF.py
+++ b/makePDF.py
@@ -546,7 +546,7 @@ class make_pdfCommand(sublime_plugin.WindowCommand):
 	def __init__(self, *args, **kwargs):
 		sublime_plugin.WindowCommand.__init__(self, *args, **kwargs)
 		self.proc = None
-		self.proc_lock = threading.Lock()
+		self.proc_lock = threading.RLock()
 
 	# **kwargs is unused but there so run can safely ignore any unknown
 	# parameters

--- a/zz_terminate_cache.py
+++ b/zz_terminate_cache.py
@@ -3,9 +3,9 @@ import sublime
 try:
     try:
         from .latextools_utils.cache import _terminate_cache_threadpool
-    except (NameError, ImportError):
+    except (ValueError, ImportError):
         from latextools_utils.cache import _terminate_cache_threadpool
-except (NameError, ImportError):
+except (ValueError, ImportError):
     pass
 else:
     plugin_unloaded = _terminate_cache_threadpool

--- a/zz_terminate_cache.py
+++ b/zz_terminate_cache.py
@@ -1,0 +1,14 @@
+import sublime
+
+try:
+    try:
+        from .latextools_utils.cache import _terminate_cache_threadpool
+    except (NameError, ImportError):
+        from latextools_utils.cache import _terminate_cache_threadpool
+except (NameError, ImportError):
+    pass
+else:
+    plugin_unloaded = _terminate_cache_threadpool
+
+    if sublime.version() < '3000':
+        unload_handler = plugin_unloaded

--- a/zz_terminate_cache.py
+++ b/zz_terminate_cache.py
@@ -11,4 +11,14 @@ else:
     plugin_unloaded = _terminate_cache_threadpool
 
     if sublime.version() < '3000':
-        unload_handler = plugin_unloaded
+        import inspect
+
+        def unload_handler():
+            frame = inspect.currentframe()
+            try:
+                if frame.f_back.f_back.f_code.co_name == 'reload_plugin':
+                    return
+            finally:
+                del frame
+
+            _terminate_cache_threadpool()


### PR DESCRIPTION
An attempt to fix a series of issues raised from the v3.13 release:

* Caches now use a shared, lazy thread pool (no one mentioned this explicitly, but it should stop some resource hogging)
* Saves when the cache for the document is being rebuilt are ignored (as suggested by @benruijl in [#1056](https://github.com/SublimeText/LaTeXTools/issues/1056#issuecomment-288772816)
* `cpu_count()` should work under ST2 (dealing with #1054)
* Updating analysis now invalidates the rest of the local cache, but only after the new analysis is cached
* ThreadPool is properly stopped on plugin unload (i.e. when upgrading or removing LaTeXTools, etc.)
* Addresses several minor bugs in the current implementation

I haven't done anything to remake the cache on save or load the default behaviour.