### PR TITLE
Added a setting to make the preview math scopes configurable

### DIFF
--- a/LaTeXTools.sublime-settings
+++ b/LaTeXTools.sublime-settings
@@ -99,6 +99,13 @@
 	// "none"      to disable math live preview
 	"preview_math_mode": "selected",
 
+	// Change the scope selectors to preview math
+	// E.g. set it to "text.tex.latex meta.environment.math.block.be"
+	// to only preview math environment
+	// Set it to "text.tex.latex meta.environment.math"
+	// to preview every math command or environment
+	"preview_math_scope": "text.tex.latex meta.environment.math.block",
+
 	// The program to compile the latex template files, possible values are
 	// pdflatex, xelatex, lualatex, latex
 	// DON'T(!) use tex engines like pdftex

--- a/st_preview/preview_math.py
+++ b/st_preview/preview_math.py
@@ -442,6 +442,10 @@ class MathPreviewPhantomListener(sublime_plugin.ViewEventListener,
                 "setting": "preview_math_background_color",
                 "call_after": self.reset_phantoms
             },
+            "math_scope": {
+                "setting": "preview_math_scope",
+                "call_after": self.reset_phantoms
+            },
             "packages": {
                 "setting": "preview_math_template_packages",
                 "call_after": update_packages_str
@@ -646,11 +650,9 @@ class MathPreviewPhantomListener(sublime_plugin.ViewEventListener,
                 return
             scopes = []
         elif self.visible_mode == "all":
-            scopes = view.find_by_selector(
-                "text.tex.latex meta.environment.math")
+            scopes = view.find_by_selector(self.math_scope)
         elif self.visible_mode == "selected":
-            math_scopes = view.find_by_selector(
-                "text.tex.latex meta.environment.math")
+            math_scopes = view.find_by_selector(self.math_scope)
             scopes = [scope for scope in math_scopes
                       if any(scope.contains(sel) for sel in view.sel())]
         else:


### PR DESCRIPTION
This is option 2 of https://github.com/SublimeText/LaTeXTools/issues/944#issuecomment-261520926. By default it only show block environments `\begin{...}/\end{...}` and `\[...\]`