### PR TITLE
Override output_directory, aux_directory and jobname from current view

### DIFF
--- a/delete_temp_files.py
+++ b/delete_temp_files.py
@@ -135,11 +135,11 @@ class DeleteTempFilesCommand(sublime_plugin.WindowCommand):
 			traceback.print_exc()
 
 		aux_directory, aux_directory_setting = get_aux_directory(
-			root_file, return_setting=True
+			view, return_setting=True
 		)
 
 		output_directory, output_directory_setting = get_output_directory(
-			root_file, return_setting=True
+			view, return_setting=True
 		)
 
 		if aux_directory is not None:

--- a/jumpToPDF.py
+++ b/jumpToPDF.py
@@ -121,7 +121,7 @@ class JumpToPdf(sublime_plugin.TextCommand):
 			return
 
 		root = getTeXRoot.get_tex_root(view)
-		file_name = get_jobname(root)
+		file_name = get_jobname(view)
 
 		output_directory = get_output_directory(view)
 		if output_directory is None:
@@ -211,7 +211,7 @@ class ViewPdf(sublime_plugin.WindowCommand):
 			view = self.window.active_view()
 
 			root = getTeXRoot.get_tex_root(view)
-			file_name = get_jobname(root)
+			file_name = get_jobname(view)
 
 			output_directory = get_output_directory(view)
 			if output_directory is None:

--- a/latex_input_completions.py
+++ b/latex_input_completions.py
@@ -303,8 +303,8 @@ def parse_completions(view, line):
             else:
                 folders = [tex_base_path]
             for base_path in folders:
-                output_directory = get_output_directory(root)
-                aux_directory = get_aux_directory(root)
+                output_directory = get_output_directory(view)
+                aux_directory = get_aux_directory(view)
                 completions.extend(get_file_list(
                     root, entry["extensions"],
                     entry.get("strip_extensions", []),

--- a/latextools_utils/output_directory.py
+++ b/latextools_utils/output_directory.py
@@ -51,8 +51,10 @@ def get_aux_directory(view_or_root, return_setting=False):
 
     root = get_root(view_or_root)
 
-    aux_directory = None
-    if root is not None:
+    aux_directory = get_directive(view_or_root, 'aux_directory')
+
+    if (aux_directory is None or aux_directory == '') and (
+            root is not None and view_or_root != root):
         aux_directory = get_directive(root, 'aux_directory')
 
     if aux_directory is not None and aux_directory != '':
@@ -115,8 +117,10 @@ def get_output_directory(view_or_root, return_setting=False):
 
     root = get_root(view_or_root)
 
-    output_directory = None
-    if root is not None:
+    output_directory = get_directive(view_or_root, 'output_directory')
+
+    if (output_directory is None or output_directory == '') and (
+            root is not None and view_or_root != root):
         output_directory = get_directive(root, 'output_directory')
 
     if output_directory is not None and output_directory != '':
@@ -173,16 +177,19 @@ def get_output_directory(view_or_root, return_setting=False):
 # Note: returns None if root is unsaved
 def get_jobname(view_or_root):
     root = get_root(view_or_root)
-
     if root is None:
         return None
 
+    # exit condition: texify and simple do not support jobname
+    # so always return the root path
     if using_texify_or_simple():
         return os.path.splitext(
             os.path.basename(root)
         )[0]
 
-    jobname = get_directive(root, 'jobname')
+    jobname = get_directive(view_or_root, 'jobname')
+    if (jobname is None or jobname == '') and view_or_root != root:
+        jobname = get_directive(root, 'jobname')
 
     if jobname is None or jobname == '':
         jobname = get_setting('jobname')
@@ -283,6 +290,7 @@ def resolve_to_absolute_path(root, value, root_path):
         result = os.path.realpath(result)
 
     return result
+
 
 if sublime.version() < '3000':
     def get_cache_directory():

--- a/latextools_utils/settings.py
+++ b/latextools_utils/settings.py
@@ -58,13 +58,13 @@ def _get_setting(setting, default=None, view=None):
             result
         ):
             # recursively load settings
-            update_setting(values, s)
+            _update_setting(values, s)
         result = values
 
     return result
 
 
-def update_setting(settings, values):
+def _update_setting(settings, values):
     for key in values:
         if (
             key in settings and (
@@ -72,7 +72,7 @@ def update_setting(settings, values):
                 isinstance(settings[key], sublime.Settings)
             )
         ):
-            update_setting(settings[key], values[key])
+            _update_setting(settings[key], values[key])
         else:
             settings[key] = values[key]
     return settings

--- a/makePDF.py
+++ b/makePDF.py
@@ -622,7 +622,7 @@ class make_pdfCommand(sublime_plugin.WindowCommand):
 		output_view_settings.set("gutter", False)
 		output_view_settings.set("scroll_past_end", False)
 
-		if get_setting("highlight_build_panel", True):
+		if get_setting("highlight_build_panel", True, view=view):
 			self.output_view.set_syntax_file(
 				"Packages/LaTeXTools/LaTeXTools Console.hidden-tmLanguage"
 			)
@@ -638,7 +638,8 @@ class make_pdfCommand(sublime_plugin.WindowCommand):
 		# up as the result buffer
 		self.window.get_output_panel("latextools")
 
-		self.hide_panel_level = get_setting("hide_build_panel", "no_warnings")
+		self.hide_panel_level = get_setting(
+			"hide_build_panel", "no_warnings", view=view)
 		if self.hide_panel_level == "never":
 			self.show_output_panel(force=True)
 
@@ -654,13 +655,14 @@ class make_pdfCommand(sublime_plugin.WindowCommand):
 			return
 
 		# Get platform settings, builder, and builder settings
-		platform_settings = get_setting(self.plat, {})
-		self.display_bad_boxes = get_setting("display_bad_boxes", False)
+		platform_settings = get_setting(self.plat, {}, view=view)
+		self.display_bad_boxes = get_setting(
+			"display_bad_boxes", False, view=view)
 
 		if builder is not None:
 			builder_name = builder
 		else:
-			builder_name = get_setting("builder", "traditional")
+			builder_name = get_setting("builder", "traditional", view=view)
 
 		# Default to 'traditional' builder
 		if builder_name in ['', 'default']:
@@ -670,7 +672,7 @@ class make_pdfCommand(sublime_plugin.WindowCommand):
 		# to new style plugin names (a_really_long_name)
 		builder_name = _classname_to_internal_name(builder_name)
 
-		builder_settings = get_setting("builder_settings", {})
+		builder_settings = get_setting("builder_settings", {}, view=view)
 
 		# override the command
 		if command is not None:
@@ -715,8 +717,8 @@ class make_pdfCommand(sublime_plugin.WindowCommand):
 			not opt.startswith('--jobname')
 		)]
 
-		self.aux_directory = get_aux_directory(self.file_name)
-		self.output_directory = get_output_directory(self.file_name)
+		self.aux_directory = get_aux_directory(view)
+		self.output_directory = get_output_directory(view)
 
 		# Read the env option (platform specific)
 		builder_platform_settings = builder_settings.get(self.plat, {})
@@ -734,7 +736,7 @@ class make_pdfCommand(sublime_plugin.WindowCommand):
 			builder_path = None
 		else:
 			# relative to ST packages dir!
-			builder_path = get_setting("builder_path", "")
+			builder_path = get_setting("builder_path", "", view=view)
 
 		if builder_path:
 			bld_path = os.path.join(sublime.packages_path(), builder_path)
@@ -785,8 +787,8 @@ class make_pdfCommand(sublime_plugin.WindowCommand):
 
 		# setup the progress indicator
 		display_message_length = long(
-			get_setting('build_finished_message_length', 2.0) * 1000
-		)
+			get_setting(
+				'build_finished_message_length', 2.0, view=view) * 1000)
 		# NB CmdThread will change the success message
 		self.progress_indicator = ProgressIndicator(
 			thread, 'Building', 'Build failed',
@@ -867,7 +869,8 @@ class make_pdfCommand(sublime_plugin.WindowCommand):
 			# if using output_directory, follow the copy_output_on_build setting
 			# files are copied to the same directory as the main tex file
 			if self.output_directory is not None:
-				copy_on_build = get_setting('copy_output_on_build', True)
+				copy_on_build = get_setting(
+					'copy_output_on_build', True, view=self.view)
 				if copy_on_build is None or copy_on_build is True:
 					shutil.copy2(
 						os.path.join(
@@ -886,7 +889,7 @@ class make_pdfCommand(sublime_plugin.WindowCommand):
 							os.path.dirname(self.file_name)
 						)
 
-			if get_setting('open_pdf_on_build', True):
+			if get_setting('open_pdf_on_build', True, view=self.view):
 				self.view.run_command("jump_to_pdf", {"from_keybinding": False})
 
 	if _HAS_PHANTOMS:

--- a/system_check.py
+++ b/system_check.py
@@ -639,15 +639,15 @@ class SystemCheckThread(threading.Thread):
             ])
 
             table = [[u'LaTeX Output Setting', u'Value']]
-            output_directory = get_output_directory(tex_root)
+            output_directory = get_output_directory(view)
             if output_directory:
                 table.append(
                     ['output_directory', output_directory]
                 )
-            aux_directory = get_aux_directory(tex_root)
+            aux_directory = get_aux_directory(view)
             if aux_directory:
                 table.append(['aux_directory', aux_directory])
-            jobname = get_jobname(tex_root)
+            jobname = get_jobname(view)
             if jobname and jobname != os.path.splitext(
                 os.path.basename(tex_root)
             )[0]:


### PR DESCRIPTION
This is intended as a fix to address the workflow outlined in #1076. I've extended it beyond `jobname` since it seem reasonable to do so to accommodate other workflow we haven't yet considered.