### PR TITLE
Prerelease README

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -21,6 +21,16 @@ by Ian Bacher, Marciano Siniscalchi, and Richard Stein
 - Improved fill all completions for large files
 - %!TEX directives now override settings in all circumstances
 
+## Prereleases
+
+LaTeXTools uses pre-releases to beta test new features and improve the stability of releases. If you also want to get the newest features and help us testing them. Just open *Preferences > Package Settings > Package Control > Settings - User* and insert at a reasonable (correct JSON syntax) position: 
+
+``` js
+    "install_prereleases": ["LaTeXTools"],
+```
+
+If you also use prereleases of other packages just add them comma separated into the list.
+
 
 ## Overview
 


### PR DESCRIPTION
This is a template to change the README to use prereleases in the future. In addition I created `develop` branch, where we can merge PRs before, such that we don't need to merge all PRs at once at the release day (You can just retarged PRs if you click `Edit` in the title). We should develop and issue prereleases on the `develop` branch and merge them before the release to the `master` branch.