### PR TITLE
Extend parser to allow more citekey names

### DIFF
--- a/external/bibtex/lexer.py
+++ b/external/bibtex/lexer.py
@@ -79,10 +79,10 @@ class Lexer(object):
                         self.whitespace_token()     or
                         self.comma_token()          or
                         self.key_token()            or
-                        self.identifier_token()     or
-                        self.number_token()         or
                         self.value_token()          or
                         self.quoted_string_token()  or
+                        self.identifier_token()     or
+                        self.number_token()         or
                         self.hash_token()           or
                         self.entry_end_token()      or
                         self.token_error()
@@ -342,7 +342,7 @@ STRING              = re.compile(r'@(string)\s*\{', re.UNICODE | re.IGNORECASE)
 COMMENT             = re.compile(r'@(comment)[^\n]+', re.UNICODE | re.IGNORECASE)
 ENTRY_START         = re.compile(r'@(?=[^\W][^,\s]*\s*\{)', re.UNICODE)
 ENTRY_TYPE          = re.compile(r'([^\W\d_][^,\s]*)\s*\{', re.UNICODE)
-IDENTIFIER          = re.compile(r'[^\W][^,\s}#]*(?=\s*[,]|\s*#\s*|\s*\}?(?:\n|$))', re.UNICODE)
+IDENTIFIER          = re.compile(r'[^,\s}#]+(?=\s*[,]|\s*#\s*|\s*\}?(?:\n|$))', re.UNICODE)
 NUMBER              = re.compile(r'\d+', re.UNICODE)
 KEY                 = re.compile(r'([^\W\d][^,\s=]*)\s*=\s*', re.UNICODE)
 

--- a/external/bibtex/tests/lexer_tests.py
+++ b/external/bibtex/tests/lexer_tests.py
@@ -543,6 +543,18 @@ class TestIdentifierToken(LexerTest):
             )
         )
 
+    def test_identifier_token_matches_doi(self):
+        self.lexer.code = ':/content/aapt/journal/ajp/70/7/10.1119/1.1477428'
+        result = self.lexer.identifier_token()
+
+        self.assertEqual(
+            result,
+            49,
+            'expecting 49 characters to be consumed, found {0}'.format(
+                result
+            )
+        )
+
 
 class TestNumberToken(LexerTest):
 
@@ -2131,6 +2143,109 @@ class TestTokenize(LexerTest):
             tokens[4][1],
             'https://books.google.ch/books?id=bar',
             'expected fifth token value to be "https://books.google.ch/books?id=bar", was "{0}"'.format(
+                tokens[3][1]
+            )
+        )
+
+        self.assertEqual(
+            tokens[5][0],
+            'ENTRY_END',
+            'expected sixth token to be an "ENTRY_END" token, was "{0}"'.format(
+                tokens[5][0]
+            )
+        )
+
+        self.assertEqual(
+            tokens[-1][0],
+            'EOF',
+            'expected last token to be an "EOF" token, was "{0}"'.format(
+                tokens[-1][0]
+            )
+        )
+
+    def test_entry_with_doi(self):
+        tokens = self.lexer.tokenize('''
+            @book{:/content/aapt/journal/ajp/70/7/10.1119/1.1477428,
+                Author = { Bloggs, Joe }
+            }
+        ''')
+
+        self.assertEqual(
+            len(tokens),
+            7,
+            'expected 7 tokens, found {0}'.format(
+                len(tokens)
+            )
+        )
+
+        self.assertEqual(
+            tokens[0][0],
+            'ENTRY_START',
+            'expected first token to be an "ENTRY_START" token, was "{0}"'.format(
+                tokens[0][0]
+            )
+        )
+
+        self.assertEqual(
+            tokens[1][0],
+            'ENTRY_TYPE',
+            'expected second token to be an "ENTRY_TYPE" token, was "{0}"'.format(
+                tokens[1][0]
+            )
+        )
+
+        self.assertEqual(
+            tokens[1][1],
+            'book',
+            'expected second token value to be "book", was "{0}"'.format(
+                tokens[1][1]
+            )
+        )
+
+        self.assertEqual(
+            tokens[2][0],
+            'IDENTIFIER',
+            'expected third token to be an "IDENTIFIER" token, was "{0}"'.format(
+                tokens[2][0]
+            )
+        )
+
+        self.assertEqual(
+            tokens[2][1],
+            ':/content/aapt/journal/ajp/70/7/10.1119/1.1477428',
+            'expected third token value to be "citekey", was "{0}"'.format(
+                tokens[2][1]
+            )
+        )
+
+        self.assertEqual(
+            tokens[3][0],
+            'KEY',
+            'expected fourth token to be an "KEY" token, was "{0}"'.format(
+                tokens[3][0]
+            )
+        )
+
+        self.assertEqual(
+            tokens[3][1],
+            'Author',
+            'expected fourth token value to be "author", was "{0}"'.format(
+                tokens[3][1]
+            )
+        )
+
+        self.assertEqual(
+            tokens[4][0],
+            'VALUE',
+            'expected fifth token to be an "VALUE" token, was "{0}"'.format(
+                tokens[4][0]
+            )
+        )
+
+        self.assertEqual(
+            tokens[4][1],
+            'Bloggs, Joe',
+            'expected fifth token value to be "Bloggs, Joe", was "{0}"'.format(
                 tokens[3][1]
             )
         )

--- a/external/bibtex/tests/parser_tests.py
+++ b/external/bibtex/tests/parser_tests.py
@@ -10,7 +10,6 @@ class ParserTest(unittest.TestCase):
     def setUp(self):
         self.parser = Parser(None)
 
-
 class TestValue(ParserTest):
 
     def test_value_with_identifier(self):


### PR DESCRIPTION
This should fix the underlying issue in #1115.