### PR TITLE
Add a command to clear the whole cache

### DIFF
--- a/LaTeX.sublime-commands
+++ b/LaTeX.sublime-commands
@@ -1,6 +1,7 @@
 [
 	{ "caption": "LaTeXTools: Check system", "command": "latextools_system_check"},
 	{ "caption": "LaTeXTools: Delete temporary files", "command": "delete_temp_files"},
+	{ "caption": "LaTeXTools: Clear cache", "command": "latextools_clear_cache"},
 	{ "caption": "LaTeXTools: Clear document cache", "command": "clear_local_latex_cache"},
 	{ "caption": "LaTeXTools: Clear current bibliography cache", "command": "clear_bibliography_cache"},
 	{ "caption": "LaTeXTools: View PDF", "command": "view_pdf"},

--- a/LaTeXTools.sublime-settings
+++ b/LaTeXTools.sublime-settings
@@ -591,10 +591,6 @@
 // Cache options
 // ------------------------------------------------------------------
 
-	// whether the local cache should be hidden in the sublime cache path (true)
-	// or in the same directory as the root file (false)
-	"hide_local_cache": true,
-
 	// settings for caches to update on load
 	// leaving these as `true` will ensure LaTeXTools pre-caches the appropriate
 	// data when a TeX document is loaded; setting these to `false` will

--- a/delete_temp_files.py
+++ b/delete_temp_files.py
@@ -26,6 +26,24 @@ import shutil
 import traceback
 
 
+class LatextoolsClearCacheCommand(sublime_plugin.WindowCommand):
+	def run(self):
+		try:
+			shutil.rmtree(cache._global_cache_path())
+		except:
+			print('Error while trying to delete global cache')
+			traceback.print_exc()
+			try:
+				shutil.rmtree(cache._local_cache_path())
+			except:
+				print('Error while trying to delete local cache')
+				traceback.print_exc()
+		window = self.window
+		if window.active_view().score_selector(0, "text.tex.latex"):
+			window.run_command("clear_local_latex_cache")
+			window.run_command("clear_bibliography_cache")
+
+
 class ClearLocalLatexCacheCommand(sublime_plugin.WindowCommand):
 
 	def is_visible(self, *args):

--- a/latextools_utils/cache.py
+++ b/latextools_utils/cache.py
@@ -33,9 +33,8 @@ else:
 
 # the folder, if the local cache is not hidden, i.e. folder in the same
 # folder as the tex root
-LOCAL_CACHE_FOLDER = ".st_lt_cache"
 # folder to store all hidden local caches in the cache path
-HIDDEN_LOCAL_CACHE_FOLDER = "local_cache"
+LOCAL_CACHE_FOLDER = "local_cache"
 # global cache folder for ST2, this folder will be created inside the User
 # folder to store the global and the local cache
 ST2_GLOBAL_CACHE_FOLDER = ".lt_cache"
@@ -184,7 +183,7 @@ read = read_local
 if _ST3:
     def _global_cache_path():
         return os.path.normpath(os.path.join(
-            sublime.cache_path(), "LaTeXTools"))
+            sublime.cache_path(), "LaTeXTools", "internal"))
 else:
     def _global_cache_path():
         return os.path.normpath(os.path.join(
@@ -672,9 +671,6 @@ class LocalCache(ValidatingCache, InstanceTrackingCache):
 
     def __init__(self, tex_root):
         self.tex_root = tex_root
-        # although this could change, currently only the value when the
-        # cache is created is relevant
-        self.hide_cache = get_setting('hide_local_cache', True)
         super(LocalCache, self).__init__()
 
     def validate_on_get(self, key):
@@ -699,14 +695,9 @@ class LocalCache(ValidatingCache, InstanceTrackingCache):
             return self.tex_root
 
     def _get_cache_path(self):
-        if self.hide_cache:
-            cache_path = super(LocalCache, self)._get_cache_path()
-            root_hash = hash_digest(self.tex_root)
-            return os.path.join(
-                cache_path, HIDDEN_LOCAL_CACHE_FOLDER, root_hash)
-        else:
-            root_folder = os.path.dirname(self.tex_root)
-            return os.path.join(root_folder, LOCAL_CACHE_FOLDER)
+        cache_path = super(LocalCache, self)._get_cache_path()
+        root_hash = hash_digest(self.tex_root)
+        return os.path.join(cache_path, LOCAL_CACHE_FOLDER, root_hash)
 
     def is_up_to_date(self, key, timestamp):
         if timestamp is None:

--- a/st_preview/preview_image.py
+++ b/st_preview/preview_image.py
@@ -48,9 +48,6 @@ def plugin_loaded():
     _lt_settings = sublime.load_settings("LaTeXTools.sublime-settings")
 
     temp_path = os.path.join(cache._global_cache_path(), _name)
-    # validate the temporary file directory is available
-    if not os.path.exists(temp_path):
-        os.makedirs(temp_path)
 
     # init all variables
     _on_setting_change()
@@ -120,6 +117,10 @@ def _append_image_job(image_path, thumbnail_path, width, height, cont):
 
 
 def _run_image_jobs():
+    # validate the temporary file directory is available
+    if not os.path.exists(temp_path):
+        os.makedirs(temp_path)
+
     if not pv_threading.has_function(_name):
         pv_threading.register_function(_name, lambda job: job())
     pv_threading.run_jobs(_name)

--- a/st_preview/preview_math.py
+++ b/st_preview/preview_math.py
@@ -94,9 +94,6 @@ def plugin_loaded():
     _lt_settings = sublime.load_settings("LaTeXTools.sublime-settings")
 
     temp_path = os.path.join(cache._global_cache_path(), _name)
-    # validate the temporary file directory is available
-    if not os.path.exists(temp_path):
-        os.makedirs(temp_path)
 
     # init all variables
     _on_setting_change()
@@ -295,6 +292,10 @@ def _extend_image_jobs(vid, latex_program, jobs):
 
 
 def _run_image_jobs():
+    # validate the temporary file directory is available
+    if not os.path.exists(temp_path):
+        os.makedirs(temp_path)
+
     if not pv_threading.has_function(_name):
         pv_threading.register_function(_name, _execute_job)
     pv_threading.run_jobs(_name)


### PR DESCRIPTION
This moves all cache files into a subfolder `internal`, removes the non-hidden local cache, and creates a command to delete all cache files. As far I understood the invalidate local cache command does not delete all files and this may help to resolve issues.