### PR TITLE
This temporary fixes an error with \cite{

### DIFF
--- a/latex_cite_completions.py
+++ b/latex_cite_completions.py
@@ -268,7 +268,15 @@ def find_bib_files(root):
         return list(set(result))
 
     # since the processing can be a bit intensive, cache the results
-    return cache.LocalCache(root).cache('bib_files', _find_bib_files)
+    result = cache.LocalCache(root).cache('bib_files', _find_bib_files)
+    # TODO temporary workaround to ensure the result is a sequence
+    if not hasattr(type(result), '__iter__'):
+        result = _find_bib_files()
+        try:
+            cache.LocalCache(root).set('bib_files', result)
+        except:
+            pass
+    return result
 
 
 def run_plugin_command(command, *args, **kwargs):


### PR DESCRIPTION
If the cache returns an object instead of a sequence it will rerun the _find_bib_files command.