### PR TITLE
Output better error message if ghostscript was not found

### DIFF
--- a/st_preview/preview_utils.py
+++ b/st_preview/preview_utils.py
@@ -100,13 +100,11 @@ def _update_gs_version():
             m = _GS_VERSION_REGEX.search(raw_version)
             if m:
                 _GS_VERSION = tuple(int(x) for x in m.groups())
-        except OSError:
+        except Exception:
             print('Error finding Ghostscript version for {0}'.format(
                 _GS_COMMAND))
             traceback.print_exc()
-        except Exception:
-            traceback.print_exc()
-
+            
 
 # broken out to be called from system_check
 def __get_gs_command():


### PR DESCRIPTION
I got the following message when Ghostscript was not installed
> Traceback (most recent call last):
  File "C:\Users\Tobi\AppData\Roaming\Sublime Text 3\Packages\LaTeXTools\st_preview\preview_utils.py", line 99, in _update_gs_version
    raw_version = check_output([_GS_COMMAND, '-version'])
  File "C:\Users\Tobi\AppData\Roaming\Sublime Text 3\Packages\LaTeXTools\latextools_utils\external_command.py", line 348, in check_output
    show_window=show_window
  File "C:\Users\Tobi\AppData\Roaming\Sublime Text 3\Packages\LaTeXTools\latextools_utils\external_command.py", line 268, in execute_command
    show_window=show_window
  File "C:\Users\Tobi\AppData\Roaming\Sublime Text 3\Packages\LaTeXTools\latextools_utils\external_command.py", line 181, in external_command
    if not os.path.isabs(command[0]):
  File "./python3.3/ntpath.py", line 102, in isabs
  File "./python3.3/ntpath.py", line 162, in splitdrive
TypeError: object of type 'NoneType' has no len()

Since there was no real reference to ghostscript (except the pointer to `GS_COMMAND`) troubleshooting was harder then it should be. With the proposed change a proper error message is displayed.