### PR TITLE
Fix conversation problem when using preview

### DIFF
--- a/st_preview/preview_utils.py
+++ b/st_preview/preview_utils.py
@@ -170,7 +170,7 @@ def _get_gs_exe_from_registry():
                 for i in range(winreg.QueryInfoKey(hndl)[0]):
                     version = winreg.EnumKey(hndl, i)
                     try:
-                        major, minor = version.split('.')
+                        major, minor = map(int, version.split('.'))
                         if (
                             major > major_version or
                             (


### PR DESCRIPTION
With Ghostscript 9.21 installed, I got the following error 
> Traceback (most recent call last):
  File "C:\Users\Tobi\AppData\Roaming\Sublime Text 3\Packages\LaTeXTools\st_preview\preview_math.py", line 559, in on_after_selection_modified_async
    self.update_phantoms()
  File "C:\Users\Tobi\AppData\Roaming\Sublime Text 3\Packages\LaTeXTools\st_preview\preview_math.py", line 619, in update_phantoms
    self._update_phantoms()
  File "C:\Users\Tobi\AppData\Roaming\Sublime Text 3\Packages\LaTeXTools\st_preview\preview_math.py", line 627, in _update_phantoms
    if not ghostscript_installed():
  File "C:\Users\Tobi\AppData\Roaming\Sublime Text 3\Packages\LaTeXTools\st_preview\preview_utils.py", line 220, in ghostscript_installed
    return _get_gs_command() is not None
  File "C:\Users\Tobi\AppData\Roaming\Sublime Text 3\Packages\LaTeXTools\st_preview\preview_utils.py", line 82, in _get_gs_command
    _GS_COMMAND = __get_gs_command()
  File "C:\Users\Tobi\AppData\Roaming\Sublime Text 3\Packages\LaTeXTools\st_preview\preview_utils.py", line 128, in __get_gs_command
    result = _get_gs_exe_from_registry()
  File "C:\Users\Tobi\AppData\Roaming\Sublime Text 3\Packages\LaTeXTools\st_preview\preview_utils.py", line 175, in _get_gs_exe_from_registry
    major > major_version or
TypeError: unorderable types: str() > int()

and this PR provides a fix for this.