### PR TITLE
Created the parameter single_selection for latex_fill_all

### DIFF
--- a/latex_fill_all.py
+++ b/latex_fill_all.py
@@ -876,11 +876,15 @@ class LatexFillAllCommand(
         is disabled
 
     :param single_selection:
-        boolean indicating whether or not to ignore multiple cursors/carets on
-        the text. This is useful when creating a snippet which defaults to
-        creating multiple carets/cursors and want to force the completion for
-        some specific scope as `input` or `cite`. Therefore we must to ignore
-        the multi selection, otherwise it will ignore the input scope specified
+        positive integer indicating to ignore multiple cursors/carets on the
+        text and use one specific selection point. This is useful when creating
+        a snippet which defaults to creating multiple carets/cursors and want to
+        force the completion for some specific scope as `input` or `cite`.
+        Therefore we must to ignore the multi selection, otherwise it will
+        ignore the input scope specified
+        the accepted values start on 0 for the first selection, 1 for the second
+        and etc. They must to be lower then the maximum selections, otherwise
+        this setting will be ignored.
     '''
 
     def is_visible(self, *args):
@@ -888,21 +892,25 @@ class LatexFillAllCommand(
 
     def run(
         self, edit, completion_type=None, insert_char="", overwrite=False,
-        force=False, single_selection=False
+        force=False, single_selection=-1
     ):
         view = self.view
         selections = view.sel()
+        selections_len = len(selections)
 
         # initialize the `point` variable to a proper value, to be used later
-        if len( selections ):
-            for sel in selections:
-                point = sel.b
+        if selections_len:
+            if single_selection > -1 and single_selection < selections_len:
+                point = selections[single_selection].b
                 if not view.score_selector(point, "text.tex.latex"):
                     self.complete_brackets(view, edit, insert_char)
                     return
-
-                if single_selection:
-                    break
+            else:
+                for sel in selections:
+                    point = sel.b
+                    if not view.score_selector(point, "text.tex.latex"):
+                        self.complete_brackets(view, edit, insert_char)
+                        return
         else:
             # No selections? What?
             return

--- a/latex_fill_all.py
+++ b/latex_fill_all.py
@@ -882,8 +882,8 @@ class LatexFillAllCommand(
         force the completion for some specific scope as `input` or `cite`.
         Therefore we must to ignore the multi selection, otherwise it will
         ignore the input scope specified
-        the accepted values start on 0 for the first selection, 1 for the second
-        and etc. They must to be lower then the maximum selections, otherwise
+        the accepted values start on 1 for the first selection, 2 for the second
+        and etc. They must to be lower then the maximum selections + 1, otherwise
         this setting will be ignored.
     '''
 
@@ -903,11 +903,13 @@ class LatexFillAllCommand(
             return
 
         # initialize the `point` variable to a proper value, to be used later
-        if single_selection and single_selection > -1 and single_selection < selections_len:
-            point = selections[single_selection].b
-            if not view.score_selector(point, "text.tex.latex"):
-                self.complete_brackets(view, edit, insert_char)
-                return
+        if single_selection:
+            single_selection -= 1
+            if single_selection > -1 and single_selection < selections_len:
+                point = selections[single_selection].b
+                if not view.score_selector(point, "text.tex.latex"):
+                    self.complete_brackets(view, edit, insert_char)
+                    return
         else:
             for sel in selections:
                 point = sel.b

--- a/latex_fill_all.py
+++ b/latex_fill_all.py
@@ -892,28 +892,28 @@ class LatexFillAllCommand(
 
     def run(
         self, edit, completion_type=None, insert_char="", overwrite=False,
-        force=False, single_selection=-1
+        force=False, single_selection=None
     ):
         view = self.view
         selections = view.sel()
         selections_len = len(selections)
 
+        # No selections? What?
+        if not selections_len:
+            return
+
         # initialize the `point` variable to a proper value, to be used later
-        if selections_len:
-            if single_selection > -1 and single_selection < selections_len:
-                point = selections[single_selection].b
+        if single_selection and single_selection > -1 and single_selection < selections_len:
+            point = selections[single_selection].b
+            if not view.score_selector(point, "text.tex.latex"):
+                self.complete_brackets(view, edit, insert_char)
+                return
+        else:
+            for sel in selections:
+                point = sel.b
                 if not view.score_selector(point, "text.tex.latex"):
                     self.complete_brackets(view, edit, insert_char)
                     return
-            else:
-                for sel in selections:
-                    point = sel.b
-                    if not view.score_selector(point, "text.tex.latex"):
-                        self.complete_brackets(view, edit, insert_char)
-                        return
-        else:
-            # No selections? What?
-            return
 
         # if completion_type is a simple string, try to load it
         if isinstance(completion_type, str):


### PR DESCRIPTION
command. It is a boolean indicating whether or not to ignore
multiple cursors/carets on the text. This is useful when creating
a snippet which defaults to creating multiple carets/cursors and
want to force the completion for some specific scope as `input`
or `cite`. Therefore we must to ignore the multi selection,
otherwise it will ignore the input scope specified.

Solves the issue:
1. https://github.com/SublimeText/LaTeXTools/issues/1161 Cannot determine completion type for current selection, for multi cursors

For that solution, you just need to use this command on the
command palette, adding the `single_selection` and `force` arguments:
```latex
[
	{
		"caption": "LaTeXTools: Insert Image",
		"command": "chain",
		"args": {
		    "commands": [
		        ["insert_snippet", {"contents": "\\begin{figure}\n\\centering\n\\includegraphics[scale=1.0]{$TM_SELECTED_TEXT$1}\n\\caption{$1}\n\\label{fig:$1}\n\\end{figure}"}],
		        ["latex_fill_all", {"completion_type": "input", "force": true, "single_selection" : 0} ]
		    ]
		},
	},
]
```