### PR TITLE
Auto-pair escaped braces, brackets, and parens

### DIFF
--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -10,6 +10,15 @@
     },
 
     // Auto-pair escaped curly braces/brackets/parens
+    // improve enter key behavior
+    {
+        "keys": ["enter"], "command": "insert_snippet", "args": {"contents": "\n\t$0\n"},
+        "context": [
+            { "key": "selector", "operator": "equal", "operand": "text.tex.latex" },
+            { "key": "preceding_text", "operator": "regex_contains", "operand": "(?:\\\\left)?(?:\\\\)?(\\(|\\[|{)$", "match_all": true },
+            { "key": "following_text", "operator": "regex_contains", "operand": "^(?:\\\\right)?(?:\\\\)?(\\)|\\]|})", "match_all": true },
+        ]
+    },
     {
         "keys": ["{"],
         "command": "insert_snippet",
@@ -19,8 +28,8 @@
             { "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
             { "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
             { "key": "preceding_text", "operator": "regex_contains", "operand": "\\\\$", "match_all": true },
-            { "key": "following_text", "operator": "regex_contains", "operand": "^(\\s|\\)|]|\\}|\\\\|$)", "match_all": true },
-            { "key": "selector", "operand": "text.tex", "match_all": true }
+            { "key": "following_text", "operator": "regex_contains", "operand": "^(\\s|\\)|]|\\}|\\\\|\\$|$)", "match_all": true },
+            { "key": "selector", "operand": "text.tex.latex", "match_all": true }
         ]
     },
     {
@@ -32,8 +41,8 @@
             { "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
             { "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
             { "key": "preceding_text", "operator": "regex_contains", "operand": "\\\\$", "match_all": true },
-            { "key": "following_text", "operator": "regex_contains", "operand": "^(\\s|\\)|]|\\}|\\\\|$)", "match_all": true },
-            { "key": "selector", "operand": "text.tex", "match_all": true }
+            { "key": "following_text", "operator": "regex_contains", "operand": "^(\\s|\\)|]|\\}|\\\\|\\$|$)", "match_all": true },
+            { "key": "selector", "operand": "text.tex.latex", "match_all": true }
         ]
     },
     {
@@ -45,8 +54,47 @@
             { "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
             { "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
             { "key": "preceding_text", "operator": "regex_contains", "operand": "\\\\$", "match_all": true },
-            { "key": "following_text", "operator": "regex_contains", "operand": "^(\\s|\\)|]|\\}|\\\\|$)", "match_all": true },
-            { "key": "selector", "operand": "text.tex", "match_all": true }
+            { "key": "following_text", "operator": "regex_contains", "operand": "^(\\s|\\)|]|\\}|\\\\|\\$|$)", "match_all": true },
+            { "key": "selector", "operand": "text.tex.latex", "match_all": true }
+        ]
+    },
+    {
+        "keys": ["{"],
+        "command": "insert_snippet",
+        "args": {"contents": "{$0\\\\right\\\\}"},
+        "context":
+        [
+            { "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
+            { "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
+            { "key": "preceding_text", "operator": "regex_contains", "operand": "\\\\left\\\\$", "match_all": true },
+            { "key": "following_text", "operator": "regex_contains", "operand": "^(\\s|\\)|]|\\}|\\\\|\\$|$)", "match_all": true },
+            { "key": "selector", "operand": "text.tex.latex meta.environment.math", "match_all": true }
+        ]
+    },
+    {
+        "keys": ["["],
+        "command": "insert_snippet",
+        "args": {"contents": "[$0\\\\right]"},
+        "context":
+        [
+            { "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
+            { "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
+            { "key": "preceding_text", "operator": "regex_contains", "operand": "\\\\left$", "match_all": true },
+            { "key": "following_text", "operator": "regex_contains", "operand": "^(\\s|\\)|]|\\}|\\\\|\\$|$)", "match_all": true },
+            { "key": "selector", "operand": "text.tex.latex meta.environment.math", "match_all": true }
+        ]
+    },
+    {
+        "keys": ["("],
+        "command": "insert_snippet",
+        "args": {"contents": "($0\\\\right)"},
+        "context":
+        [
+            { "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
+            { "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
+            { "key": "preceding_text", "operator": "regex_contains", "operand": "\\\\left$", "match_all": true },
+            { "key": "following_text", "operator": "regex_contains", "operand": "^(\\s|\\)|]|\\}|\\\\|\\$|$)", "match_all": true },
+            { "key": "selector", "operand": "text.tex.latex meta.environment.math", "match_all": true }
         ]
     },
     {
@@ -58,7 +106,20 @@
             { "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
             { "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
             { "key": "preceding_text", "operator": "regex_contains", "operand": "\\\\(?:\\{|\\}|\\[|\\]|\\(|\\))$", "match_all": true },
-            { "key": "selector", "operand": "text.tex", "match_all": true }
+            { "key": "selector", "operand": "text.tex.latex", "match_all": true }
+        ]
+    },
+    {
+        "keys": ["backspace"],
+        "command": "run_macro_file",
+        "args": {"file": "res://Packages/LaTeXTools/Delete Left Right Twice.sublime-macro"},
+        "context":
+        [
+            { "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
+            { "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
+            { "key": "preceding_text", "operator": "regex_contains", "operand": "\\\\\\($", "match_all": true },
+            { "key": "following_text", "operator": "regex_contains", "operand": "^\\\\\\)", "match_all": true },
+            { "key": "selector", "operand": "text.tex.latex", "match_all": true }
         ]
     },
     {
@@ -71,7 +132,7 @@
             { "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
             { "key": "preceding_text", "operator": "regex_contains", "operand": "\\\\\\{$", "match_all": true },
             { "key": "following_text", "operator": "regex_contains", "operand": "^\\\\\\}", "match_all": true },
-            { "key": "selector", "operand": "text.tex", "match_all": true }
+            { "key": "selector", "operand": "text.tex.latex", "match_all": true }
         ]
     },
     {
@@ -84,7 +145,59 @@
             { "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
             { "key": "preceding_text", "operator": "regex_contains", "operand": "\\\\\\[$", "match_all": true },
             { "key": "following_text", "operator": "regex_contains", "operand": "^\\\\\\]", "match_all": true },
-            { "key": "selector", "operand": "text.tex", "match_all": true }
+            { "key": "selector", "operand": "text.tex.latex", "match_all": true }
+        ]
+    },
+    {
+        "keys": ["backspace"],
+        "command": "run_macro_file",
+        "args": {"file": "res://Packages/LaTeXTools/Delete Left Right Bracket 1.sublime-macro"},
+        "context":
+        [
+            { "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
+            { "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
+            { "key": "preceding_text", "operator": "regex_contains", "operand": "\\\\left.$", "match_all": true },
+            { "key": "following_text", "operator": "regex_contains", "operand": "^\\\\right.", "match_all": true },
+            { "key": "selector", "operand": "text.tex.latex", "match_all": true }
+        ]
+    },
+    {
+        "keys": ["backspace"],
+        "command": "run_macro_file",
+        "args": {"file": "res://Packages/LaTeXTools/Delete Left Right Bracket 2 1.sublime-macro"},
+        "context":
+        [
+            { "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
+            { "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
+            { "key": "preceding_text", "operator": "regex_contains", "operand": "\\\\left\\\\.$", "match_all": true },
+            { "key": "following_text", "operator": "regex_contains", "operand": "^\\\\right.", "match_all": true },
+            { "key": "selector", "operand": "text.tex.latex", "match_all": true }
+        ]
+    },
+    {
+        "keys": ["backspace"],
+        "command": "run_macro_file",
+        "args": {"file": "res://Packages/LaTeXTools/Delete Left Right Bracket 1 2.sublime-macro"},
+        "context":
+        [
+            { "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
+            { "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
+            { "key": "preceding_text", "operator": "regex_contains", "operand": "\\\\left.$", "match_all": true },
+            { "key": "following_text", "operator": "regex_contains", "operand": "^\\\\right\\\\.", "match_all": true },
+            { "key": "selector", "operand": "text.tex.latex", "match_all": true }
+        ]
+    },
+    {
+        "keys": ["backspace"],
+        "command": "run_macro_file",
+        "args": {"file": "res://Packages/LaTeXTools/Delete Left Right Bracket 2.sublime-macro"},
+        "context":
+        [
+            { "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
+            { "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
+            { "key": "preceding_text", "operator": "regex_contains", "operand": "\\\\left\\\\.$", "match_all": true },
+            { "key": "following_text", "operator": "regex_contains", "operand": "^\\\\right\\\\.", "match_all": true },
+            { "key": "selector", "operand": "text.tex.latex", "match_all": true }
         ]
     },
 ]

--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -8,4 +8,83 @@
             { "key": "latextools.input_overlay_visible" },
         ],
     },
+
+    // Auto-pair escaped curly braces/brackets/parens
+    {
+        "keys": ["{"],
+        "command": "insert_snippet",
+        "args": {"contents": "{$0\\\\}"},
+        "context":
+        [
+            { "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
+            { "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
+            { "key": "preceding_text", "operator": "regex_contains", "operand": "\\\\$", "match_all": true },
+            { "key": "following_text", "operator": "regex_contains", "operand": "^(\\s|\\)|]|\\}|\\\\|$)", "match_all": true },
+            { "key": "selector", "operand": "text.tex", "match_all": true }
+        ]
+    },
+    {
+        "keys": ["["],
+        "command": "insert_snippet",
+        "args": {"contents": "[$0\\\\]"},
+        "context":
+        [
+            { "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
+            { "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
+            { "key": "preceding_text", "operator": "regex_contains", "operand": "\\\\$", "match_all": true },
+            { "key": "following_text", "operator": "regex_contains", "operand": "^(\\s|\\)|]|\\}|\\\\|$)", "match_all": true },
+            { "key": "selector", "operand": "text.tex", "match_all": true }
+        ]
+    },
+    {
+        "keys": ["("],
+        "command": "insert_snippet",
+        "args": {"contents": "($0\\\\)"},
+        "context":
+        [
+            { "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
+            { "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
+            { "key": "preceding_text", "operator": "regex_contains", "operand": "\\\\$", "match_all": true },
+            { "key": "following_text", "operator": "regex_contains", "operand": "^(\\s|\\)|]|\\}|\\\\|$)", "match_all": true },
+            { "key": "selector", "operand": "text.tex", "match_all": true }
+        ]
+    },
+    {
+        "keys": ["backspace"],
+        "command": "run_macro_file",
+        "args": {"file": "res://Packages/LaTeXTools/Delete Left Twice.sublime-macro"},
+        "context":
+        [
+            { "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
+            { "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
+            { "key": "preceding_text", "operator": "regex_contains", "operand": "\\\\(?:\\{|\\}|\\[|\\]|\\(|\\))$", "match_all": true },
+            { "key": "selector", "operand": "text.tex", "match_all": true }
+        ]
+    },
+    {
+        "keys": ["backspace"],
+        "command": "run_macro_file",
+        "args": {"file": "res://Packages/LaTeXTools/Delete Left Right Twice.sublime-macro"},
+        "context":
+        [
+            { "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
+            { "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
+            { "key": "preceding_text", "operator": "regex_contains", "operand": "\\\\\\{$", "match_all": true },
+            { "key": "following_text", "operator": "regex_contains", "operand": "^\\\\\\}", "match_all": true },
+            { "key": "selector", "operand": "text.tex", "match_all": true }
+        ]
+    },
+    {
+        "keys": ["backspace"],
+        "command": "run_macro_file",
+        "args": {"file": "res://Packages/LaTeXTools/Delete Left Right Twice.sublime-macro"},
+        "context":
+        [
+            { "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
+            { "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
+            { "key": "preceding_text", "operator": "regex_contains", "operand": "\\\\\\[$", "match_all": true },
+            { "key": "following_text", "operator": "regex_contains", "operand": "^\\\\\\]", "match_all": true },
+            { "key": "selector", "operand": "text.tex", "match_all": true }
+        ]
+    },
 ]

--- a/Delete Left Right Bracket 1 2.sublime-macro
+++ b/Delete Left Right Bracket 1 2.sublime-macro
@@ -1,0 +1,21 @@
+[
+    // extra char
+    { "command": "left_delete" },
+    // the word \left
+    { "command": "left_delete" },
+    { "command": "left_delete" },
+    { "command": "left_delete" },
+    { "command": "left_delete" },
+    { "command": "left_delete" },
+
+    // the word \right
+    { "command": "right_delete" },
+    { "command": "right_delete" },
+    { "command": "right_delete" },
+    { "command": "right_delete" },
+    { "command": "right_delete" },
+    { "command": "right_delete" },
+    // extra char
+    { "command": "right_delete" },
+    { "command": "right_delete" },
+]

--- a/Delete Left Right Bracket 1.sublime-macro
+++ b/Delete Left Right Bracket 1.sublime-macro
@@ -1,0 +1,20 @@
+[
+    // extra char
+    { "command": "left_delete" },
+    // the word \left
+    { "command": "left_delete" },
+    { "command": "left_delete" },
+    { "command": "left_delete" },
+    { "command": "left_delete" },
+    { "command": "left_delete" },
+
+    // the word \right
+    { "command": "right_delete" },
+    { "command": "right_delete" },
+    { "command": "right_delete" },
+    { "command": "right_delete" },
+    { "command": "right_delete" },
+    { "command": "right_delete" },
+    // extra char
+    { "command": "right_delete" },
+]

--- a/Delete Left Right Bracket 2 1.sublime-macro
+++ b/Delete Left Right Bracket 2 1.sublime-macro
@@ -1,0 +1,21 @@
+[
+    // extra char
+    { "command": "left_delete" },
+    { "command": "left_delete" },
+    // the word \left
+    { "command": "left_delete" },
+    { "command": "left_delete" },
+    { "command": "left_delete" },
+    { "command": "left_delete" },
+    { "command": "left_delete" },
+
+    // the word \right
+    { "command": "right_delete" },
+    { "command": "right_delete" },
+    { "command": "right_delete" },
+    { "command": "right_delete" },
+    { "command": "right_delete" },
+    { "command": "right_delete" },
+    // extra char
+    { "command": "right_delete" },
+]

--- a/Delete Left Right Bracket 2.sublime-macro
+++ b/Delete Left Right Bracket 2.sublime-macro
@@ -1,0 +1,22 @@
+[
+    // extra char
+    { "command": "left_delete" },
+    // the word \left
+    { "command": "left_delete" },
+    { "command": "left_delete" },
+    { "command": "left_delete" },
+    { "command": "left_delete" },
+    { "command": "left_delete" },
+    { "command": "left_delete" },
+
+    // the word \right
+    { "command": "right_delete" },
+    { "command": "right_delete" },
+    { "command": "right_delete" },
+    { "command": "right_delete" },
+    { "command": "right_delete" },
+    { "command": "right_delete" },
+    // extra char
+    { "command": "right_delete" },
+    { "command": "right_delete" },
+]

--- a/Delete Left Right Twice.sublime-macro
+++ b/Delete Left Right Twice.sublime-macro
@@ -1,0 +1,6 @@
+[
+    { "command": "left_delete" },
+    { "command": "right_delete" },
+    { "command": "left_delete" },
+    { "command": "right_delete" }
+]

--- a/Delete Left Twice.sublime-macro
+++ b/Delete Left Twice.sublime-macro
@@ -1,0 +1,4 @@
+[
+    { "command": "left_delete" },
+    { "command": "left_delete" }
+]


### PR DESCRIPTION
This has been suggested by @Romeoly in #1193, by @skulumani in #917, and by @FichteFoll in #963.

It currently does:
(&#124; is the caret position)

insert | get
--- | ---
`\{` | `\{`&#124;`\}`
`\[` | `\[`&#124;`\]`
`\(` | `\(`&#124;`\)`
`\left(` | `\left(`&#124;`\right)`

It also changes the backpace behavior (same for parens and braces):

before pressing | after pressing
--- | ---
`\[`&#124;`\]` | &#124;
`\[\]`&#124; | `\[`&#124;
`\[`&#124; | &#124;
`\left(`&#124;`\right)` | &#124;

I am open to discussion for more worthy additions.