### PR TITLE
Add command for toggling starred version of surrounding environment

### DIFF
--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -248,6 +248,11 @@ LaTeX Package keymap for Linux
 		"context":  [
 			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"}],
 		"command": "latex_change_environment"},
+	// Toggle the starred version of environment
+	{ "keys": ["ctrl+l", "ctrl+shift+8"],
+		"context":  [
+			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"}],
+		"command": "latex_toggle_environment_star"},
 
 	// Wrap selected text in emph, bold or underline
 	{ "keys": ["ctrl+l","ctrl+e"],  

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -248,6 +248,11 @@ LaTeX Package keymap for OS X
 		"context":  [
 			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"}],
 		"command": "latex_change_environment"},
+	// Toggle the starred version of environment
+	{ "keys": ["super+l", "shift+super+8"],
+		"context":  [
+			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"}],
+		"command": "latex_toggle_environment_star"},
 
 	// Wrap selected text in emph, bold or underline
 	{ "keys": ["super+l","super+e"],  

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -248,6 +248,11 @@ LaTeX Package keymap for Windows
 		"context":  [
 			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"}],
 		"command": "latex_change_environment"},
+	// Toggle the starred version of environment
+	{ "keys": ["ctrl+l", "ctrl+shift+8"],
+		"context":  [
+			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"}],
+		"command": "latex_toggle_environment_star"},
 
 	// Wrap selected text in emph, bold or underline
 	{ "keys": ["ctrl+l","ctrl+e"],  

--- a/change_environment.py
+++ b/change_environment.py
@@ -7,6 +7,9 @@ class LatexChangeEnvironmentCommand(sublime_plugin.TextCommand):
     def run(self, edit):
         view = self.view
         new_regions = _find_env_regions(view)
+        if not new_regions:
+            return
+
         view.sel().clear()
         for r in new_regions:
             view.sel().add(r)
@@ -15,12 +18,14 @@ class LatexToggleEnvironmentStarCommand(sublime_plugin.TextCommand):
     def run(self, edit):
         view = self.view
         new_regions = _find_env_regions(view)
-        # 
-        if view.substr(new_regions[0])[-1] == '*':
-            for r in reversed(new_regions):
+        if not new_regions:
+            return
+
+        # replace '*' with '' or vice versa for each region
+        for r in reversed(new_regions):
+            if view.substr(r).endswith('*'):
                 view.replace(edit, r, view.substr(r)[:-1])
-        else:
-            for r in reversed(new_regions):
+            else:
                 view.replace(edit, r, view.substr(r) + "*")
 
 def _find_env_regions(view):
@@ -91,7 +96,7 @@ def _find_env_regions(view):
             )
     if not new_regions:
         sublime.status_message("Environment detection failed")
-        return []
+
     return new_regions
 
 

--- a/change_environment.py
+++ b/change_environment.py
@@ -6,77 +6,93 @@ import re
 class LatexChangeEnvironmentCommand(sublime_plugin.TextCommand):
     def run(self, edit):
         view = self.view
-        begin_re = r"\\begin(?:\[[^\]]*\])?\{([^\}]*)\}"
-        end_re = r"\\end\{([^\}]*)\}"
-        begins = view.find_all(begin_re, sublime.IGNORECASE)
-        ends = view.find_all(end_re, sublime.IGNORECASE)
-        # compile the begin_re (findall does not work if its compiled)
-        begin_re = re.compile(begin_re)
-
-        comment_line_re = re.compile(r"\s*%.*")
-
-        def is_comment(reg):
-            line_str = view.substr(view.line(reg))
-            return comment_line_re.match(line_str) is not None
-        begins = [b for b in begins if not is_comment(b)]
-        ends = [e for e in ends if not is_comment(e)]
-
-        def extract_begin_region(region):
-            """creates a sublime.Region: \\begin{|text|}"""
-            s = view.substr(region)
-            boffset = len("\\begin{")
-            m = begin_re.search(s)
-            if m:
-                boffset = m.regs[1][0]
-            return sublime.Region(region.begin() + boffset, region.end() - 1)
-
-        def extract_end_region(region):
-            """creates a sublime.Region: \\end{|text|}"""
-            boffset = len("\\end{")
-            return sublime.Region(region.begin() + boffset, region.end() - 1)
-
-        new_regions = []
-        one_sel = len(view.sel()) == 1
-
-        for sel in view.sel():
-            # partition the open and closed environments
-            begin_before, begin_after =\
-                _partition(begins, lambda b: b.begin() <= sel.begin())
-            end_before, end_after =\
-                _partition(ends, lambda e: e.end() < sel.begin())
-
-            # get the nearest open environments
-            try:
-                begin = _get_closest_begin(begin_before, end_before)
-                end = _get_closest_end(end_after, begin_after)
-            except NoEnvError as e:
-                if one_sel:
-                    sublime.status_message(e.args[0])
-                    return
-                else:
-                    continue
-
-            # extract the regions for the environments
-            begin_region = extract_begin_region(begin)
-            end_region = extract_end_region(end)
-
-            # validity check: matching env name
-            if view.substr(begin_region) == view.substr(end_region):
-                new_regions.append(begin_region)
-                new_regions.append(end_region)
-            elif one_sel:
-                sublime.status_message(
-                    "The environment begin and end does not match:"
-                    "'{0}' and '{1}'"
-                    .format(view.substr(begin_region), view.substr(end_region))
-                )
-        if not new_regions:
-            sublime.status_message("Environment detection failed")
-            return
-
+        new_regions = _find_env_regions(view)
         view.sel().clear()
         for r in new_regions:
             view.sel().add(r)
+
+class LatexToggleEnvironmentStarCommand(sublime_plugin.TextCommand):
+    def run(self, edit):
+        view = self.view
+        new_regions = _find_env_regions(view)
+        # 
+        if view.substr(new_regions[0])[-1] == '*':
+            for r in reversed(new_regions):
+                view.replace(edit, r, view.substr(r)[:-1])
+        else:
+            for r in reversed(new_regions):
+                view.replace(edit, r, view.substr(r) + "*")
+
+def _find_env_regions(view):
+    """returns the regions corresponding to nearest matching environments"""
+    begin_re = r"\\begin(?:\[[^\]]*\])?\{([^\}]*)\}"
+    end_re = r"\\end\{([^\}]*)\}"
+    begins = view.find_all(begin_re, sublime.IGNORECASE)
+    ends = view.find_all(end_re, sublime.IGNORECASE)
+    # compile the begin_re (findall does not work if its compiled)
+    begin_re = re.compile(begin_re)
+
+    comment_line_re = re.compile(r"\s*%.*")
+
+    def is_comment(reg):
+        line_str = view.substr(view.line(reg))
+        return comment_line_re.match(line_str) is not None
+    begins = [b for b in begins if not is_comment(b)]
+    ends = [e for e in ends if not is_comment(e)]
+
+    def extract_begin_region(region):
+        """creates a sublime.Region: \\begin{|text|}"""
+        s = view.substr(region)
+        boffset = len("\\begin{")
+        m = begin_re.search(s)
+        if m:
+            boffset = m.regs[1][0]
+        return sublime.Region(region.begin() + boffset, region.end() - 1)
+
+    def extract_end_region(region):
+        """creates a sublime.Region: \\end{|text|}"""
+        boffset = len("\\end{")
+        return sublime.Region(region.begin() + boffset, region.end() - 1)
+
+    new_regions = []
+    one_sel = len(view.sel()) == 1
+
+    for sel in view.sel():
+        # partition the open and closed environments
+        begin_before, begin_after =\
+            _partition(begins, lambda b: b.begin() <= sel.begin())
+        end_before, end_after =\
+            _partition(ends, lambda e: e.end() < sel.begin())
+
+        # get the nearest open environments
+        try:
+            begin = _get_closest_begin(begin_before, end_before)
+            end = _get_closest_end(end_after, begin_after)
+        except NoEnvError as e:
+            if one_sel:
+                sublime.status_message(e.args[0])
+                return []
+            else:
+                continue
+
+        # extract the regions for the environments
+        begin_region = extract_begin_region(begin)
+        end_region = extract_end_region(end)
+
+        # validity check: matching env name
+        if view.substr(begin_region) == view.substr(end_region):
+            new_regions.append(begin_region)
+            new_regions.append(end_region)
+        elif one_sel:
+            sublime.status_message(
+                "The environment begin and end does not match:"
+                "'{0}' and '{1}'"
+                .format(view.substr(begin_region), view.substr(end_region))
+            )
+    if not new_regions:
+        sublime.status_message("Environment detection failed")
+        return []
+    return new_regions
 
 
 def _partition(env_list, is_before):


### PR DESCRIPTION
Builds on https://github.com/SublimeText/LaTeXTools/pull/585 by @r-stein to add a command for toggling the starred version of a surrounding environment with keybinding `C-l,C-*`.  This is useful for enabling/disabling numbering of math environments such as `equation` and `align`.  The implementation reuses existing logic in `latex_change_environment` for detecting environment regions so it should work with nested environments and multiple cursors.

Demo
![toggle_starred_environments](https://user-images.githubusercontent.com/867637/29696871-8d57baca-8919-11e7-9267-a1a3d7d89ce4.gif)
