### PR TITLE
Added hover html-documentation viewer for commands end environments

### DIFF
--- a/dependencies.json
+++ b/dependencies.json
@@ -4,6 +4,7 @@
             "regex"
         ],
         ">=3118": [
+            "bs4",
             "pygments",
             "python-markdown",
             "mdpopups",

--- a/html_documentation_viewer.py
+++ b/html_documentation_viewer.py
@@ -1,0 +1,158 @@
+# -*- coding: utf-8 -*-
+import functools
+import html
+import re
+import webbrowser
+
+import sublime
+import sublime_plugin
+
+import mdpopups
+from Default.open_context_url import rex as RE_URL
+
+from .latextools_utils import latex2e_html
+import imp
+# imp.reload(latex2e_html)
+
+
+class _show_documentation_popup():
+    def __init__(self, view, doc, pos):
+        self.view = view
+        self.doc = doc
+        self.pos = pos
+        self.history = ([], [])
+        self._show_popup(on_hover=True)
+
+    def _command_close(self):
+        self.view.hide_popup()
+
+    def _command_go_backward(self):
+        doc = self.doc
+        try:
+            self.doc = self.history[0].pop()
+        except IndexError:
+            return
+        self.history[1].append(doc)
+        self._show_popup()
+
+    def _command_go_forward(self):
+        doc = self.doc
+        try:
+            self.doc = self.history[1].pop()
+        except IndexError:
+            return
+        self.history[0].append(doc)
+        self._show_popup()
+
+    def _follow_doc_href(self, href):
+        # save the previous document in the history
+        self.history[0].append(self.doc)
+        # clear the go-forward history
+        self.history[1].clear()
+        self.doc = latex2e_html.read_href_section(href)
+        self._show_popup()
+
+    def _open_url_in_browser(self, href):
+        pass
+        answer = sublime.ok_cancel_dialog(
+            "Do you want to open '{href}' in your browser?".format(href=href))
+        if answer == sublime.DIALOG_YES:
+            webbrowser.open(href)
+
+    def _open_href(self, href):
+        print("href:", href)
+        if href.startswith("command-"):
+            try:
+                func = getattr(self, "_command_" + href[len("command-"):])
+            except AttributeError:
+                print("Error calling {}".format(href))
+                return
+            func()
+        elif RE_URL.match(href):
+            self._open_url_in_browser(href)
+        else:
+            self._follow_doc_href(href)
+
+    def _show_popup(self, on_hover=False):
+        symbols = {
+            "cancel_char": "×",
+            "backward_char": "←",
+            "forward_char": "→",
+        }
+        html_head = "".join([
+            '<p>',
+            '<a href="command-close">{cancel_char}</a> '.format(**symbols),
+            (
+                '<a href="command-go_backward">{backward_char}</a> '
+                .format(**symbols)
+                if self.history[0] else
+                '{backward_char} '.format(**symbols)
+            ),
+            (
+                '<a href="command-go_forward">{forward_char}</a> '
+                .format(**symbols)
+                if self.history[1] else
+                '{forward_char} '.format(**symbols)
+            ),
+            '</p>',
+        ])
+        html_content = html_head + (self.doc or "No documentation found.")
+        mdpopups.show_popup(
+            self.view, html_content, md=False, location=self.pos,
+            flags=sublime.HIDE_ON_MOUSE_MOVE_AWAY if on_hover else 0,
+            on_navigate=self._open_href
+        )
+
+
+class LatexEnvHtmlDocumentationHoverListener(sublime_plugin.EventListener):
+    def on_hover(self, view, point, hover_zone):
+        if hover_zone != sublime.HOVER_TEXT:
+            return
+        if not view.score_selector(
+                point,
+                "text.tex.latex variable.parameter.function.latex"):
+            return
+
+        word_reg = view.word(point)
+
+        line_before = view.substr(
+            sublime.Region(view.line(word_reg.a).a, word_reg.a))[::-1]
+
+        # check that it inside a begin/end environment
+        if not re.match(r"\w*{(?:nigeb|dne)\\", line_before):
+            return
+
+        env_name = view.substr(word_reg)
+
+        doc = latex2e_html.read_env_documentation(env_name)
+
+        pos = word_reg.a
+        _show_documentation_popup(view, doc, pos)
+
+
+class LatexCommandHtmlDocumentationHoverListener(sublime_plugin.EventListener):
+    def on_hover(self, view, point, hover_zone):
+        if hover_zone != sublime.HOVER_TEXT:
+            return
+        if not view.score_selector(
+                point,
+                "text.tex.latex & ("
+                "    support.function"
+                "  | keyword.other"
+                "  | constant.character.escape"
+                ")"):
+            return
+        word_reg = view.word(point)
+        command = view.substr(word_reg)
+        char_before = sublime.Region(word_reg.a - 1, word_reg.a)
+        if command.startswith("\\"):
+            pass
+        elif not view.substr(char_before) == "\\":
+            return
+        else:
+            command = "\\" + command
+        print("command:", command)
+        doc = latex2e_html.read_command_documentation(command)
+
+        pos = word_reg.a
+        _show_documentation_popup(view, doc, pos)

--- a/latextools_utils/latex2e_html.py
+++ b/latextools_utils/latex2e_html.py
@@ -1,0 +1,200 @@
+import bs4
+import functools
+import re
+
+from . import external_command
+from .distro_utils import using_miktex
+
+
+@functools.lru_cache()
+def get_doc_path():
+    if using_miktex():
+        command = ["mthelp", "--list-only", "latex2e.html"]
+    else:
+        command = ["texdoc", "-l", "-M", "latex2e.html"]
+
+    return_code, stdout, _ = external_command.execute_command(command)
+
+    if return_code != 0:
+        print("Error on retrieving the documentation path.")
+        return ""
+
+    doc_path = stdout.strip()
+
+    return doc_path
+
+
+# from https://stackoverflow.com/a/23243553/5963435
+def bs_preprocess(html):
+    """remove distracting whitespaces and newline characters"""
+    pat = re.compile('(^[\s]+)|([\s]+$)', re.MULTILINE)
+    html = re.sub(pat, '', html)
+    html = re.sub('\n', ' ', html)
+    html = re.sub('[\s]+<', '<', html)
+    html = re.sub('>[\s]+', '>', html)
+    return html
+
+
+@functools.lru_cache()
+def get_doc_content(doc_path):
+    with open(doc_path) as fh:
+        content = fh.read()
+    return content
+
+
+@functools.lru_cache()
+def get_doc_soup_handler():
+    doc_path = get_doc_path()
+    content = get_doc_content(doc_path)
+    soup = bs4.BeautifulSoup(content, 'html.parser')
+    return soup
+
+
+@functools.lru_cache()
+def _get_command_href_map():
+    soup = get_doc_soup_handler()
+
+    command_index = soup.find("a", {"name": "Command-Index_fn_symbol-7"})
+
+    first_row = command_index.parent.parent
+    first_row = first_row.next_sibling.next_sibling
+    first_row = first_row.next_sibling.next_sibling
+
+    command_href_map = {}
+
+    i = 0
+    row = first_row
+    while i < 1000 and row.name != "hr":
+        i += 1
+        # the section ends at a hr line
+        if row.name == "hr" or row.hr is not None:
+            break
+        try:
+            children = list(row.children)
+        except AttributeError:
+            row = row.next_sibling
+            continue
+        try:
+            code = children[1].code
+            href = children[3].a["href"]
+        except IndexError:
+            print("IndexError at parsing {}".format(row))
+            break
+        except KeyError:
+            print("KeyError at parsing href from {}".format(row))
+            break
+
+        command = str(next(code.children)).strip()
+
+        command_href_map[command] = href
+
+        row = row.next_sibling.next_sibling
+
+    return command_href_map
+
+
+@functools.lru_cache()
+def _get_env_href_map():
+    soup = get_doc_soup_handler()
+
+    command_index = soup.find("a", {"name": "Command-Index_fn_letter-A"})
+
+    first_row = command_index.parent.parent
+    first_row = first_row.next_sibling.next_sibling
+    first_row = first_row.next_sibling.next_sibling
+
+    env_href_map = {}
+
+    i = 0
+    row = first_row
+    while i < 1000 and row:
+        i += 1
+        # the section ends at a hr line
+        try:
+            children = list(row.children)
+        except AttributeError:
+            row = row.next_sibling
+            continue
+
+        try:
+            is_env = children[1].span.text == "environment"
+        except Exception:
+            is_env = False
+
+        if is_env:
+            try:
+                code = children[1].code
+                href = children[3].a["href"]
+            except IndexError:
+                print("IndexError at parsing {}".format(row))
+                break
+            except KeyError:
+                print("KeyError at parsing href from {}".format(row))
+                break
+
+            env = str(next(code.children)).strip()
+
+            env_href_map[env] = href
+
+        try:
+            row = row.next_sibling.next_sibling
+        except AttributeError:
+            break
+
+    return env_href_map
+
+
+def read_command_documentation(command):
+    command_href_map = _get_command_href_map()
+
+    try:
+        href = command_href_map[command]
+    except KeyError:
+        return
+
+    return read_href_section(href)
+
+
+def read_env_documentation(env):
+    env_href_map = _get_env_href_map()
+
+    try:
+        href = env_href_map[env]
+    except KeyError:
+        return
+
+    return read_href_section(href)
+
+
+@functools.lru_cache(maxsize=1024)
+def read_href_section(href):
+    return _read_section(_follow_href(href))
+
+
+def _follow_href(href):
+    soup = get_doc_soup_handler()
+    target = soup.find("a", {"name": href.lstrip("#")})
+    start = target
+    return start
+
+
+def _has_class(node, css_class):
+    try:
+        return css_class in node["class"]
+    except AttributeError:
+        return False
+
+
+def _read_section(start_node):
+    content = []
+    current = start_node
+    while current is not None:
+        if current.name == "div" and _has_class(current, "header"):
+            pass
+        else:
+            content.append(current)
+        current = current.next_sibling
+        if current.name in ("hr",):
+            break
+
+    return "\n".join(str(c) for c in content)


### PR DESCRIPTION
This implements the suggestion of @faridcher in #1219 and adds a hover preview for the documentation.

I am still looking forward to add features/buttons to integrate it with other features (like goto-anywhere and the image preview).

- [ ] Add a call to jump-to-anywhere (if possible)
- [ ] Add a command to open the package documentation (if possible) via the information from the cwl file
- [ ] Integrate `\includegraphics` with the image preview

Please test this on other systems and I am open to additional suggestions.