### PR TITLE
Auto-pair \( .. \) math environments

### DIFF
--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -305,8 +305,8 @@ LaTeX Package keymap for Windows
 			{"key": "panel_visible", "operator": "equal", "operand": false }],
 		"command": "show_panel", "args": {"panel": "output.latextools"}},
 
-		// Auto-pair ``$''
-		// Lifted from default file
+	// Auto-pair ``$''
+	// Lifted from default file
 	// insert matching $
 	// note the "key": "selector" line!
 	{ "keys": ["$"], "command": "insert_snippet", "args": {"contents": "\\$$0\\$"}, 
@@ -367,8 +367,18 @@ LaTeX Package keymap for Windows
 			{ "key": "following_text", "operator": "regex_contains", "operand": "^\\$", "match_all": true }
 		]
 	},
+	
+	// auto-pair \( .. \)
+	{ "keys": ["("], "command": "insert_snippet", "args": {"contents": "( $0 \\\\)"},
+        	"context":
+        	[
+            		{"key": "selector", "operator": "equal", "operand": "text.tex.latex"},
+            		{ "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
+            		{ "key": "preceding_text", "operator": "regex_contains", "operand": "\\\\", "match_all": true },
+        	]
+    	},
 
-		// overlay specifications (Tobias Schmidt)
+	// overlay specifications (Tobias Schmidt)
 	// FIXME: the scope for the four following should actually be text.tex.latex.beamer, but for some reason this does not seem to work
 	{ "keys": ["<"], "command": "insert_snippet", "args": {"contents": "<${1:+-}>$0"}, 
 	"context":  


### PR DESCRIPTION
In order to say thank you for all the help and the superb software, I would like to give something small back. This PR adds auto-pairing of new-style `\( .. \)` math environments.
