### PR TITLE
Fix bug where unfinished lines were not being detected

### DIFF
--- a/parseTeXlog.py
+++ b/parseTeXlog.py
@@ -282,15 +282,18 @@ def parse_tex_log(data, root_dir):
 			if file_match:
 				debug("MATCHED (long line)")
 				file_name = file_match.group(1)
-				file_name = os.path.normpath(file_name.strip('"'))
 
+				# remove quotes if necessary, but first save the count for a later check
+				quotecount = file_name.count("\"")
+				file_name = file_name.replace("\"", "")
+
+				# Normalize the file path
+				file_name = os.path.normpath(file_name)
 				if not os.path.isabs(file_name):
 					file_name = os.path.normpath(os.path.join(root_dir, file_name))
 
 				file_extra = file_match.group(2) + file_match.group(3) # don't call it "extra"
-				# remove quotes if necessary, but first save the count for a later check
-				quotecount = file_name.count("\"")
-				file_name = file_name.replace("\"", "")
+				
 				# NOTE: on TL201X pdftex sometimes writes "pdfTeX warning" right after file name
 				# This may or may not be a stand-alone long line, but in any case if we
 				# extend, the file regex will fire regularly


### PR DESCRIPTION
The unfinished line detection code was never triggering, causing `(Log parsing issues. Disregard unless something else is wrong.)` errors. 

For an MWE, try compiling this on Windows:

```
\documentclass{article}

\usepackage{pgfcore}

\begin{document}

If run on Windows, the log file will now contain several lines (e.g. l.150, l.160) that have only a single quote mark. Try searching for 
\verb¬^[^\n"]*"[^\n"]*$¬ to find them. 

\end{document}
```