### PR TITLE
strip doublequotes from filename in _jumpto_tex_file

### DIFF
--- a/jumpto_tex_file.py
+++ b/jumpto_tex_file.py
@@ -50,6 +50,8 @@ IMAGE_REG = re.compile(
 
 def _jumpto_tex_file(view, window, tex_root, file_name,
                      auto_create_missing_folders, auto_insert_root):
+    file_name = file_name.strip('"')
+    
     root_base_path, root_base_name = os.path.split(tex_root)
 
     ana = analysis.get_analysis(tex_root)


### PR DESCRIPTION
Allows `\input{"../my folder/my file.tex"}` to be read as `\input{../my folder/my file.tex}`.  The former is necessary to have filenames with spaces to be typeset by LaTeX, but without this change, the command _jumpto_tex_file ends up creating a folder called `"..` (that's doublequote then dot dot) in the home folder.