### PR TITLE
Add sec, fig, app, tab, alg to triggers for ref

### DIFF
--- a/latex_ref_completions.py
+++ b/latex_ref_completions.py
@@ -19,7 +19,7 @@ _ref_special_commands = "|".join([
     "", "eq", "page", "v", "V", "auto", "autopage", "name",
     "c", "C", "cpage", "Cpage", "namec", "nameC", "lcnamec", "labelc",
     "labelcpage", "sub", "f", "F", "vpage", "t", "p", "A", "B", "P", "S",
-    "title", "headname", "tocname"
+    "title", "headname", "tocname", "sec", "fig", "app", "tab", "alg"
 ])[::-1]
 
 OLD_STYLE_REF_REGEX = re.compile(


### PR DESCRIPTION
We use the following snippet in out Latex documents: 
```latex
\newcommand{\secref}[1]{Section~\ref{#1}}
\newcommand{\figref}[1]{Figure~\ref{#1}}
\newcommand{\tabref}[1]{Table~\ref{#1}}
\newcommand{\appref}[1]{Appendix~\ref{#1}}
\renewcommand{\eqref}[1]{Equation~(\ref{#1})}
\renewcommand{\algref}[1]{Algorithm~\ref{#1}}
```

This PR extends the list of valid prefixes before `\ref` to the ones mentioned above. Close #1323 