### PR TITLE
Add stdin=subprocess.PIPE to prevent fail on win

### DIFF
--- a/makePDF.py
+++ b/makePDF.py
@@ -311,6 +311,7 @@ class CmdThread ( threading.Thread ):
 							cmd,
 							env=env,
 							use_texpath=False,
+							stdin=subprocess.PIPE,
 							stdout=subprocess.PIPE,
 							stderr=subprocess.STDOUT,
 							preexec_fn=os.setsid if self.caller.plat != 'windows' else None,


### PR DESCRIPTION
I modified makePDF.py adding a stdin=subprocess.PIPE argument to external_command(); without this building fails on Windows 7