### PR TITLE
Fixed a reference to set_async_timeout (should be set_timeout_async).

### DIFF
--- a/latextools_utils/sublime_utils.py
+++ b/latextools_utils/sublime_utils.py
@@ -79,8 +79,8 @@ def focus_st():
             def keep_focus():
                 external_command([sublime_command], use_texpath=False)
 
-        if hasattr(sublime, 'set_async_timeout'):
-            sublime.set_async_timeout(keep_focus, int(wait_time * 1000))
+        if hasattr(sublime, 'set_timeout_async'):
+            sublime.set_timeout_async(keep_focus, int(wait_time * 1000))
         else:
             sublime.set_timeout(keep_focus, int(wait_time * 1000))
 


### PR DESCRIPTION
A reference to `set_async_timeout` should be `set_timeout_async`. I only found this typo in `latextools_utils/sublime_utils.py`. For more information see these:

- https://github.com/SublimeTextIssues/Core/issues/825
- https://www.sublimetext.com/docs/3/api_reference.html

All other uses of the timeout are correct as far as I can tell.