### PR TITLE
Add support for \textsl{} snippet

### DIFF
--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -263,6 +263,10 @@ LaTeX Package keymap for Linux
 		"context":  [
 			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"}],
 		"command": "insert_snippet", "args": {"name":"Packages/LaTeXTools/Text boldface.sublime-snippet"}},
+	{ "keys": ["ctrl+l","ctrl+s"],  
+		"context":  [
+			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"}],
+		"command": "insert_snippet", "args": {"name":"Packages/LaTeXTools/Text slanted.sublime-snippet"}},
 	{ "keys": ["ctrl+l","ctrl+u"],  
 		"context":  [
 			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"}],

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -263,6 +263,10 @@ LaTeX Package keymap for OS X
 		"context":  [
 			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"}],
 		"command": "insert_snippet", "args": {"name":"Packages/LaTeXTools/Text boldface.sublime-snippet"}},
+	{ "keys": ["ctrl+l","ctrl+s"],  
+		"context":  [
+			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"}],
+		"command": "insert_snippet", "args": {"name":"Packages/LaTeXTools/Text slanted.sublime-snippet"}},
 	{ "keys": ["super+l","super+u"],  
 		"context":  [
 			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"}],

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -263,6 +263,10 @@ LaTeX Package keymap for Windows
 		"context":  [
 			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"}],
 		"command": "insert_snippet", "args": {"name":"Packages/LaTeXTools/Text boldface.sublime-snippet"}},
+	{ "keys": ["ctrl+l","ctrl+s"],  
+		"context":  [
+			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"}],
+		"command": "insert_snippet", "args": {"name":"Packages/LaTeXTools/Text slanted.sublime-snippet"}},
 	{ "keys": ["ctrl+l","ctrl+u"],  
 		"context":  [
 			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"}],

--- a/Text slanted.sublime-snippet
+++ b/Text slanted.sublime-snippet
@@ -1,0 +1,9 @@
+<snippet>
+	<description>Boldface text</description>
+	<content><![CDATA[
+\\textsl{${1:$SELECTION}}
+]]></content>
+	<!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
+	<!-- <tabTrigger>hello</tabTrigger> -->
+	<scope>text.tex.latex</scope>
+</snippet>


### PR DESCRIPTION
As per title, this pr adds support for the `\textsl{}` snipped, which converts the text to slanted. Please let me know if you'd like anything to be changed! 