### PR TITLE
Bug fix for no pkg cache

### DIFF
--- a/latex_installed_packages.py
+++ b/latex_installed_packages.py
@@ -114,9 +114,9 @@ def _generate_package_cache():
 
     # create the cache object
     pkg_cache = {
-        'pkg': installed_tex_items['sty'],
-        'bst': installed_bst['bst'],
-        'cls': installed_tex_items['cls']
+        'pkg': installed_tex_items.get('sty', []),
+        'bst': installed_bst.get('bst', []),
+        'cls': installed_tex_items.get('cls', [])
     }
 
     # For ST3, put the cache files in cache dir


### PR DESCRIPTION
Addressing issue https://github.com/SublimeText/LaTeXTools/issues/1425

```LatexTools: Build cache of LaTex packages``` command might fail due to no bst installed. There would be KeyError for 'bst'. Thus, it would be nice if we could use the get method to avoid this error.
