### PR TITLE
Allow use of math preview in embedded latex scopes

### DIFF
--- a/st_preview/preview_math.py
+++ b/st_preview/preview_math.py
@@ -529,7 +529,7 @@ class MathPreviewPhantomListener(sublime_plugin.ViewEventListener,
     def is_applicable(cls, settings):
         try:
             view = inspect.currentframe().f_back.f_locals['view']
-            return view.score_selector(0, 'text.tex.latex') > 0
+            return len(view.find_by_selector('text.tex.latex')) > 0
         except KeyError:
             syntax = settings.get('syntax')
             return syntax == 'Packages/LaTeX/LaTeX.sublime-syntax'


### PR DESCRIPTION
The previous formulation required character 0 of the document to be consider LaTeX. This change allows the preview to apply to any document which contains embedded latex scopes.

An example can be seen in https://github.com/sublimehq/Packages/pull/2145#discussion_r338840922