### PR TITLE
Fix error message when jumping to pdf from non-.tex-file

### DIFF
--- a/jumpToPDF.py
+++ b/jumpToPDF.py
@@ -117,7 +117,7 @@ class JumpToPdf(sublime_plugin.TextCommand):
 		if not is_tex_file(view.file_name()):
 			sublime.error_message(
 				"%s is not a TeX source file: cannot jump." %
-				(os.path.basename(view.fileName()),))
+				(os.path.basename(view.file_name()),))
 			return
 
 		root = getTeXRoot.get_tex_root(view)


### PR DESCRIPTION
There was an ST1-syntax being used (the same as in https://github.com/SublimeText/LaTeXTools/issues/51) that caused a Python error. This PR fixes that, so when you are in a non-`.tex`-file and try to jump to the PDF, it gives a Sublime error.

This still leaves another question for me: I encountered this bug when I tried to recompile from a non-`.tex`-file. In that case, I think there should not be an error message, but instead it should either:
- reload the pdf on the same place if it was already opened
- open the pdf on the first page if it hadn't been open
Should I open an issue for this?