### PR TITLE
Plugin for setting current file as the "TEXroot" of the project

### DIFF
--- a/LaTeX.sublime-commands
+++ b/LaTeX.sublime-commands
@@ -15,5 +15,6 @@
 	{ "caption": "LaTeXTools: View TeX package documentation", "command": "latex_pkg_doc"},
 	{ "caption": "LaTeXTools: Build cache of LaTeX packages", "command": "latex_gen_pkg_cache"},
 	{ "caption": "LaTeXTools: Update document analysis cache", "command": "latextools_analysis_update"},
-	{ "caption": "LaTeXTools: Update bibliography cache", "command": "latextools_bib_update"}
+	{ "caption": "LaTeXTools: Update bibliography cache", "command": "latextools_bib_update"},
+	{ "caption": "LatexTools: Set Current File as \"TEXroot\" of Project", "command": "set_file_as_project_texroot",},
 ]

--- a/set_file_as_project_texroot.py
+++ b/set_file_as_project_texroot.py
@@ -1,0 +1,22 @@
+import sublime
+import sublime_plugin
+
+class SetFileAsProjectTexrootCommand(sublime_plugin.TextCommand):
+	def run(self,edit):
+		variables = self.view.window().extract_variables()
+		current_file_name = sublime.expand_variables("$file_name",variables)
+		current_project_name = sublime.expand_variables("$project_name",variables)
+
+		project_data = self.view.window().project_data()
+
+		#print("current file's name: ", current_file_name)
+		#print("current project's name: ", current_project_name)
+		#print("project data previously:", project_data)
+		
+		project_data.update({'settings': {'TEXroot': current_file_name} })
+		self.view.window().set_project_data(project_data)
+
+		#print("project data currently:", self.view.window().project_data())
+
+# Test in console:
+# view.run_command("set_as_project_texroot")

--- a/set_file_as_project_texroot.py
+++ b/set_file_as_project_texroot.py
@@ -8,12 +8,13 @@ class SetFileAsProjectTexrootCommand(sublime_plugin.TextCommand):
 		current_project_name = sublime.expand_variables("$project_name",variables)
 
 		project_data = self.view.window().project_data()
+		project_settings = project_data["settings"]
 
 		#print("current file's name: ", current_file_name)
 		#print("current project's name: ", current_project_name)
-		#print("project data previously:", project_data)
+		#print("project settings previously:", project_settings)
 		
-		project_data.update({'settings': {'TEXroot': current_file_name} })
+		project_data["settings"].update({'TEXroot': current_file_name})
 		self.view.window().set_project_data(project_data)
 
 		#print("project data currently:", self.view.window().project_data())


### PR DESCRIPTION
Addition of a little plugin (ViewCommand) to make the current file open in view the project's  "TEXroot".

{
	"caption": "LatexTools: Set Current File as \"TEXroot\" of Project",
	"command": "set_file_as_project_texroot",
},