### PR TITLE
Fix an encoding issue when looking for ImageMagick

### DIFF
--- a/system_check.py
+++ b/system_check.py
@@ -208,7 +208,7 @@ def get_version_info(executable, env=None):
             return None
 
         return re.split(
-            r'\r?\n', stdout.decode('utf-8').strip(), 1
+            r'\r?\n', stdout.decode(encoding='utf-8', errors='ignore').strip(), 1
         )[0].lstrip('Version: ')
     except:
         return None


### PR DESCRIPTION
fix byte to string decoding error  when checking version of `ImageMagick` missing or available.


![image](https://user-images.githubusercontent.com/10379684/105043580-0aacc600-5aa9-11eb-909a-2e69be81eed7.png)
