### PR TITLE
Fix critical mistake in parseTeXlog.py

### DIFF
--- a/parseTeXlog.py
+++ b/parseTeXlog.py
@@ -501,7 +501,7 @@ def parse_tex_log(data, root_dir):
 				# Sometimes it's " []" and sometimes it's "[]"...
 #				if len(line)>0 and line[:3] == " []" or line[:2] == "[]":
 				# NO, it really should be just " []"
-				if len(line)>0 and line == " []":
+				if len(line)>0 and line[-3:] == " []":
 					ou_processing = False
 				else:
 					current_badbox += line


### PR DESCRIPTION
For parsing over/underfull messages, there is a line (504) that tests `line == " []"` — which is clearly meant to read `line[-3:] == " []"`, since `line` is a string containing the _entire_ line. (There are four other occurrences of `line[-X:] == "…"` in this file.)

Please accept this PR! It was impossible for me to continue working with LaTeXTools when log parsing was broken, but luckily the fix was trivial! :)