### PR TITLE
typo fix for subscript snippet

### DIFF
--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -460,7 +460,7 @@ LaTeX Package keymap for Linux
 	{ "keys": ["shift+super+down"], "command": "insert_snippet", "args": {"contents": "_{$1}$0"}, 
 	"context":  
 		[
-			{"key": "selector", "operator": "equal", "operand": "ttext.tex.latex meta.environment.math"},
+			{"key": "selector", "operator": "equal", "operand": "text.tex.latex meta.environment.math"},
 			{ "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
 			{ "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true }
 		]


### PR DESCRIPTION
The environment was misspelled, implying a non functional keybinding for subscreipting