### PR TITLE
Create pull_request_template.md requiring the license approval

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,4 +5,4 @@ https://github.com/SublimeText/LaTeXTools/pull/1570 - Created the LICENSE as rep
 To approve the license on pull-request #1570,
 click on the `review now` button at the pull-request sidebar, as shown in the following image,
 and type `I agree with the MIT license proposed.` as the review message:
-![pull-request sidebar `review now` button](https://i.imgur.com/zEqlHae.png)
+![image](https://user-images.githubusercontent.com/5332158/210024625-dbfb5ff1-c9a1-41b9-b880-2691dbd7a050.png)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,8 @@
+Before your pull-request is merged,
+it is required to approve an open-source MIT LICENSE being discussed on the pull-request:
+https://github.com/SublimeText/LaTeXTools/pull/1570 - Created the LICENSE as represented on the github issue #1175
+
+To approve the license on pull-request #1570,
+click on the `review now` button at the pull-request sidebar, as shown in the following image,
+and type `I agree with the MIT license proposed.` as the review message:
+![pull-request sidebar `review now` button](https://i.imgur.com/zEqlHae.png)


### PR DESCRIPTION
All new pull-requests, before being merged, should already have approved the open-source license being discussed on:
1. https://github.com/SublimeText/LaTeXTools/pull/1570 - Created the LICENSE as represented on the github issue https://github.com/SublimeText/LaTeXTools/issues/1175

To approve the open-source license, hit the `review now` button at the sidebar, as shown in the following image, and type `I agree with this license for my code.` as the pull-request view message:
1. ![image](https://user-images.githubusercontent.com/5332158/210024625-dbfb5ff1-c9a1-41b9-b880-2691dbd7a050.png)
1. ![image](https://user-images.githubusercontent.com/5332158/210025232-b963c851-9cff-4795-8cfa-a71167828773.png)
