### PR TITLE
Improve auto-pairing of brackets

### DIFF
--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -446,19 +446,6 @@ LaTeX Package keymap for Linux
 	// Auto-pair braces/brackets/parentheses
 	// ------------------------------------------------------------------
 
-	// Override default "wrap_block" binding
-	{
-		"keys": ["{"],
-		"command": "insert_snippet", "args": { "contents": "{$0}" },
-		"context": [
-			{ "key": "indented_block", "match_all": true },
-			{ "key": "setting.auto_match_enabled" },
-			{ "key": "selection_empty", "match_all": true },
-			{ "key": "selector", "operand": "text.tex.latex" },
-			{ "key": "following_text", "operator": "regex_match", "operand": "^$", "match_all": true }
-		]
-	},
-
 	// Auto-pair curly brackets (also in front of $)
 	{
 		"keys": ["{"],
@@ -466,8 +453,8 @@ LaTeX Package keymap for Linux
 		"context": [
 			{ "key": "setting.auto_match_enabled" },
 			{ "key": "selection_empty", "match_all": true },
-			{ "key": "selector", "operand": "text.tex.latex meta.environment.math" },
-			{ "key": "preceding_text", "operator": "not_regex_contains", "operand": "\\\\$", "match_all": true },
+			{ "key": "selector", "operand": "text.tex.latex" },
+			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*$", "match_all": true },
 			{ "key": "following_text", "operator": "regex_contains", "operand": "^(?:\\s|\\)|\\]|\\}|\\$|$)", "match_all": true }
 		]
 	},
@@ -479,8 +466,8 @@ LaTeX Package keymap for Linux
 		"context": [
 			{ "key": "setting.auto_match_enabled" },
 			{ "key": "selection_empty", "match_all": true },
-			{ "key": "selector", "operand": "text.tex.latex meta.environment.math" },
-			{ "key": "preceding_text", "operator": "not_regex_contains", "operand": "\\\\$", "match_all": true },
+			{ "key": "selector", "operand": "text.tex.latex" },
+			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*$", "match_all": true },
 			{ "key": "following_text", "operator": "regex_contains", "operand": "^(?:\\s|\\)|\\]|\\}|\\$|$)", "match_all": true }
 		]
 	},
@@ -492,8 +479,8 @@ LaTeX Package keymap for Linux
 		"context": [
 			{ "key": "setting.auto_match_enabled" },
 			{ "key": "selection_empty", "match_all": true },
-			{ "key": "selector", "operand": "text.tex.latex meta.environment.math" },
-			{ "key": "preceding_text", "operator": "not_regex_contains", "operand": "\\\\$", "match_all": true },
+			{ "key": "selector", "operand": "text.tex.latex" },
+			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*$", "match_all": true },
 			{ "key": "following_text", "operator": "regex_contains", "operand": "^(?:\\s|\\)|\\]|\\}|\\$|$)", "match_all": true }
 		]
 	},
@@ -506,7 +493,7 @@ LaTeX Package keymap for Linux
 			{ "key": "setting.auto_match_enabled" },
 			{ "key": "selection_empty", "match_all": true },
 			{ "key": "selector", "operand": "text.tex.latex", "match_all": true },
-			{ "key": "preceding_text", "operator": "regex_contains", "operand": "\\\\$", "match_all": true },
+			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\\\$", "match_all": true },
 			{ "key": "following_text", "operator": "regex_contains", "operand": "^(?:\\s|\\)|\\]|\\}|\\\\|\\$|$)", "match_all": true },
 		]
 	},
@@ -517,7 +504,7 @@ LaTeX Package keymap for Linux
 			{ "key": "setting.auto_match_enabled" },
 			{ "key": "selection_empty", "match_all": true },
 			{ "key": "selector", "operand": "text.tex.latex", "match_all": true },
-			{ "key": "preceding_text", "operator": "regex_contains", "operand": "\\\\\\{$", "match_all": true },
+			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\\\\\{$", "match_all": true },
 			{ "key": "following_text", "operator": "regex_contains", "operand": "^\\\\\\}", "match_all": true },
 		]
 	},
@@ -530,7 +517,7 @@ LaTeX Package keymap for Linux
 			{ "key": "setting.auto_match_enabled" },
 			{ "key": "selection_empty", "match_all": true },
 			{ "key": "selector", "operand": "text.tex.latex", "match_all": true },
-			{ "key": "preceding_text", "operator": "regex_contains", "operand": "\\\\$", "match_all": true },
+			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\\\$", "match_all": true },
 			{ "key": "following_text", "operator": "regex_contains", "operand": "^(?:\\s|\\)|\\]|\\}|\\\\|\\$|$)", "match_all": true },
 		]
 	},
@@ -541,7 +528,7 @@ LaTeX Package keymap for Linux
 			{ "key": "setting.auto_match_enabled" },
 			{ "key": "selection_empty", "match_all": true },
 			{ "key": "selector", "operand": "text.tex.latex", "match_all": true },
-			{ "key": "preceding_text", "operator": "regex_contains", "operand": "\\\\\\[$", "match_all": true },
+			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\\\\\[$", "match_all": true },
 			{ "key": "following_text", "operator": "regex_contains", "operand": "^\\\\\\]", "match_all": true },
 		]
 	},
@@ -554,7 +541,7 @@ LaTeX Package keymap for Linux
 			{ "key": "setting.auto_match_enabled" },
 			{ "key": "selection_empty", "match_all": true },
 			{ "key": "selector", "operand": "text.tex.latex", "match_all": true },
-			{ "key": "preceding_text", "operator": "regex_contains", "operand": "\\\\$", "match_all": true },
+			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\\\$", "match_all": true },
 			{ "key": "following_text", "operator": "regex_contains", "operand": "^(?:\\s|\\)|\\]|\\}|\\\\|\\$|$)", "match_all": true },
 		]
 	},
@@ -565,7 +552,7 @@ LaTeX Package keymap for Linux
 			{ "key": "setting.auto_match_enabled" },
 			{ "key": "selection_empty", "match_all": true },
 			{ "key": "selector", "operand": "text.tex.latex", "match_all": true },
-			{ "key": "preceding_text", "operator": "regex_contains", "operand": "\\\\\\($", "match_all": true },
+			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\\\\\($", "match_all": true },
 			{ "key": "following_text", "operator": "regex_contains", "operand": "^\\\\\\)", "match_all": true },
 		]
 	},
@@ -578,8 +565,19 @@ LaTeX Package keymap for Linux
 			{ "key": "setting.auto_match_enabled" },
 			{ "key": "selection_empty", "match_all": true },
 			{ "key": "selector", "operand": "text.tex.latex meta.environment.math", "match_all": true },
-			{ "key": "preceding_text", "operator": "regex_contains", "operand": "\\\\left\\\\$", "match_all": true },
+			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\\\left\\\\$", "match_all": true },
 			{ "key": "following_text", "operator": "regex_contains", "operand": "^(?:\\s|\\)|\\]|\\}|\\\\|\\$|$)", "match_all": true },
+		]
+	},
+	{
+		"keys": ["backspace"],
+		"command": "run_macro_file", "args": {"file": "res://Packages/LaTeXTools/Delete Left Right Bracket 2.sublime-macro"},
+		"context": [
+			{ "key": "setting.auto_match_enabled" },
+			{ "key": "selection_empty", "match_all": true },
+			{ "key": "selector", "operand": "text.tex.latex meta.environment.math", "match_all": true },
+			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\\\left\\\\\\{$", "match_all": true },
+			{ "key": "following_text", "operator": "regex_contains", "operand": "^\\\\right\\\\\\}", "match_all": true },
 		]
 	},
 
@@ -591,8 +589,19 @@ LaTeX Package keymap for Linux
 			{ "key": "setting.auto_match_enabled" },
 			{ "key": "selection_empty", "match_all": true },
 			{ "key": "selector", "operand": "text.tex.latex meta.environment.math", "match_all": true },
-			{ "key": "preceding_text", "operator": "regex_contains", "operand": "\\\\left$", "match_all": true },
+			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\\\left$", "match_all": true },
 			{ "key": "following_text", "operator": "regex_contains", "operand": "^(?:\\s|\\)|\\]|\\}|\\\\|\\$|$)", "match_all": true },
+		]
+	},
+	{
+		"keys": ["backspace"],
+		"command": "run_macro_file", "args": {"file": "res://Packages/LaTeXTools/Delete Left Right Bracket 1.sublime-macro"},
+		"context": [
+			{ "key": "setting.auto_match_enabled" },
+			{ "key": "selection_empty", "match_all": true },
+			{ "key": "selector", "operand": "text.tex.latex meta.environment.math", "match_all": true },
+			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\\\left\\[$", "match_all": true },
+			{ "key": "following_text", "operator": "regex_contains", "operand": "^\\\\right\\]", "match_all": true },
 		]
 	},
 
@@ -604,54 +613,19 @@ LaTeX Package keymap for Linux
 			{ "key": "setting.auto_match_enabled" },
 			{ "key": "selection_empty", "match_all": true },
 			{ "key": "selector", "operand": "text.tex.latex meta.environment.math", "match_all": true },
-			{ "key": "preceding_text", "operator": "regex_contains", "operand": "\\\\left$", "match_all": true },
+			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\\\left$", "match_all": true },
 			{ "key": "following_text", "operator": "regex_contains", "operand": "^(?:\\s|\\)|\\]|\\}|\\\\|\\$|$)", "match_all": true },
 		]
 	},
-
-	// Remove auto-paired escaped brackets in math blocks
 	{
 		"keys": ["backspace"],
 		"command": "run_macro_file", "args": {"file": "res://Packages/LaTeXTools/Delete Left Right Bracket 1.sublime-macro"},
 		"context": [
 			{ "key": "setting.auto_match_enabled" },
 			{ "key": "selection_empty", "match_all": true },
-			{ "key": "selector", "operand": "text.tex.latex", "match_all": true },
-			{ "key": "preceding_text", "operator": "regex_contains", "operand": "\\\\left.$", "match_all": true },
-			{ "key": "following_text", "operator": "regex_contains", "operand": "^\\\\right.", "match_all": true },
-		]
-	},
-	{
-		"keys": ["backspace"],
-		"command": "run_macro_file", "args": {"file": "res://Packages/LaTeXTools/Delete Left Right Bracket 2 1.sublime-macro"},
-		"context": [
-			{ "key": "setting.auto_match_enabled" },
-			{ "key": "selection_empty", "match_all": true },
-			{ "key": "selector", "operand": "text.tex.latex", "match_all": true },
-			{ "key": "preceding_text", "operator": "regex_contains", "operand": "\\\\left\\\\.$", "match_all": true },
-			{ "key": "following_text", "operator": "regex_contains", "operand": "^\\\\right.", "match_all": true },
-		]
-	},
-	{
-		"keys": ["backspace"],
-		"command": "run_macro_file", "args": {"file": "res://Packages/LaTeXTools/Delete Left Right Bracket 1 2.sublime-macro"},
-		"context": [
-			{ "key": "setting.auto_match_enabled" },
-			{ "key": "selection_empty", "match_all": true },
-			{ "key": "selector", "operand": "text.tex.latex", "match_all": true },
-			{ "key": "preceding_text", "operator": "regex_contains", "operand": "\\\\left.$", "match_all": true },
-			{ "key": "following_text", "operator": "regex_contains", "operand": "^\\\\right\\\\.", "match_all": true },
-		]
-	},
-	{
-		"keys": ["backspace"],
-		"command": "run_macro_file", "args": {"file": "res://Packages/LaTeXTools/Delete Left Right Bracket 2.sublime-macro"},
-		"context": [
-			{ "key": "setting.auto_match_enabled" },
-			{ "key": "selection_empty", "match_all": true },
-			{ "key": "selector", "operand": "text.tex.latex", "match_all": true },
-			{ "key": "preceding_text", "operator": "regex_contains", "operand": "\\\\left\\\\.$", "match_all": true },
-			{ "key": "following_text", "operator": "regex_contains", "operand": "^\\\\right\\\\.", "match_all": true },
+			{ "key": "selector", "operand": "text.tex.latex meta.environment.math", "match_all": true },
+			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\\\left\\($", "match_all": true },
+			{ "key": "following_text", "operator": "regex_contains", "operand": "^\\\\right\\)", "match_all": true },
 		]
 	},
 
@@ -659,16 +633,16 @@ LaTeX Package keymap for Linux
 	{
 		"keys": ["enter"], "command": "insert_snippet", "args": {"contents": "\n\t$0\n"},
 		"context": [
-			{ "key": "selector", "operand": "text.tex.latex" },
-			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:\\\\left)?(?:\\\\)?(\\(|\\[|{)$", "match_all": true },
+			{ "key": "selector", "operand": "text.tex.latex meta.environment.math" },
+			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*(?:\\\\left)?(?:\\\\)?(\\(|\\[|{)$", "match_all": true },
 			{ "key": "following_text", "operator": "regex_contains", "operand": "^(?:\\\\right)?(?:\\\\)?(\\)|\\]|})", "match_all": true },
 		]
 	},
 	{
 		"keys": ["keypad_enter"], "command": "insert_snippet", "args": {"contents": "\n\t$0\n"},
 		"context": [
-			{ "key": "selector", "operand": "text.tex.latex" },
-			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:\\\\left)?(?:\\\\)?(\\(|\\[|{)$", "match_all": true },
+			{ "key": "selector", "operand": "text.tex.latex meta.environment.math" },
+			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*(?:\\\\left)?(?:\\\\)?(\\(|\\[|{)$", "match_all": true },
 			{ "key": "following_text", "operator": "regex_contains", "operand": "^(?:\\\\right)?(?:\\\\)?(\\)|\\]|})", "match_all": true },
 		]
 	},
@@ -687,7 +661,7 @@ LaTeX Package keymap for Linux
 			// don't insert, it inside math environments
 			{ "key": "selector", "operand": "text.tex.latex - meta.environment.math - string.other.math", "match_all": true },
 			// do not insert this if it is escaped
-			{ "key": "preceding_text", "operator": "not_regex_contains", "operand": "(?:\\\\\\\\)*(?:\\\\|\\$)$", "match_all": true },
+			{ "key": "preceding_text", "operator": "not_regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*(?:\\\\|\\$)$", "match_all": true },
 			// don't insert, if there is an open dollar math environment at the end of the line
 			{ "key": "eol_selector", "operator": "not_equal",
 			  "operand": "meta.environment.math.inline.dollar - punctuation.definition.string.end, string.other.math - punctuation.definition.string.end",

--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -491,6 +491,7 @@ LaTeX Package keymap for Linux
 		"command": "insert_snippet", "args": {"contents": "{$0\\\\}"},
 		"context": [
 			{ "key": "setting.auto_match_enabled" },
+			{ "key": "latextools.setting.auto_match_escaped_brackets" },
 			{ "key": "selection_empty", "match_all": true },
 			{ "key": "selector", "operand": "text.tex.latex", "match_all": true },
 			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\\\$", "match_all": true },
@@ -502,6 +503,7 @@ LaTeX Package keymap for Linux
 		"command": "run_macro_file", "args": {"file": "res://Packages/LaTeXTools/Delete Left Right Twice.sublime-macro"},
 		"context": [
 			{ "key": "setting.auto_match_enabled" },
+			{ "key": "latextools.setting.auto_match_escaped_brackets" },
 			{ "key": "selection_empty", "match_all": true },
 			{ "key": "selector", "operand": "text.tex.latex", "match_all": true },
 			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\\\\\{$", "match_all": true },
@@ -515,6 +517,7 @@ LaTeX Package keymap for Linux
 		"command": "insert_snippet", "args": {"contents": "[$0\\\\]"},
 		"context": [
 			{ "key": "setting.auto_match_enabled" },
+			{ "key": "latextools.setting.auto_match_escaped_brackets" },
 			{ "key": "selection_empty", "match_all": true },
 			{ "key": "selector", "operand": "text.tex.latex", "match_all": true },
 			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\\\$", "match_all": true },
@@ -526,6 +529,7 @@ LaTeX Package keymap for Linux
 		"command": "run_macro_file", "args": {"file": "res://Packages/LaTeXTools/Delete Left Right Twice.sublime-macro"},
 		"context": [
 			{ "key": "setting.auto_match_enabled" },
+			{ "key": "latextools.setting.auto_match_escaped_brackets" },
 			{ "key": "selection_empty", "match_all": true },
 			{ "key": "selector", "operand": "text.tex.latex", "match_all": true },
 			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\\\\\[$", "match_all": true },
@@ -539,6 +543,7 @@ LaTeX Package keymap for Linux
 		"command": "insert_snippet", "args": {"contents": "($0\\\\)"},
 		"context": [
 			{ "key": "setting.auto_match_enabled" },
+			{ "key": "latextools.setting.auto_match_escaped_brackets" },
 			{ "key": "selection_empty", "match_all": true },
 			{ "key": "selector", "operand": "text.tex.latex", "match_all": true },
 			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\\\$", "match_all": true },
@@ -550,6 +555,7 @@ LaTeX Package keymap for Linux
 		"command": "run_macro_file", "args": {"file": "res://Packages/LaTeXTools/Delete Left Right Twice.sublime-macro"},
 		"context": [
 			{ "key": "setting.auto_match_enabled" },
+			{ "key": "latextools.setting.auto_match_escaped_brackets" },
 			{ "key": "selection_empty", "match_all": true },
 			{ "key": "selector", "operand": "text.tex.latex", "match_all": true },
 			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\\\\\($", "match_all": true },
@@ -563,6 +569,7 @@ LaTeX Package keymap for Linux
 		"command": "insert_snippet", "args": {"contents": "{$0\\\\right\\\\}"},
 		"context": [
 			{ "key": "setting.auto_match_enabled" },
+			{ "key": "latextools.setting.auto_match_math_brackets" },
 			{ "key": "selection_empty", "match_all": true },
 			{ "key": "selector", "operand": "text.tex.latex meta.environment.math", "match_all": true },
 			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\\\left\\\\$", "match_all": true },
@@ -574,6 +581,7 @@ LaTeX Package keymap for Linux
 		"command": "run_macro_file", "args": {"file": "res://Packages/LaTeXTools/Delete Left Right Bracket 2.sublime-macro"},
 		"context": [
 			{ "key": "setting.auto_match_enabled" },
+			{ "key": "latextools.setting.auto_match_math_brackets" },
 			{ "key": "selection_empty", "match_all": true },
 			{ "key": "selector", "operand": "text.tex.latex meta.environment.math", "match_all": true },
 			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\\\left\\\\\\{$", "match_all": true },
@@ -587,6 +595,7 @@ LaTeX Package keymap for Linux
 		"command": "insert_snippet", "args": {"contents": "[$0\\\\right]"},
 		"context": [
 			{ "key": "setting.auto_match_enabled" },
+			{ "key": "latextools.setting.auto_match_math_brackets" },
 			{ "key": "selection_empty", "match_all": true },
 			{ "key": "selector", "operand": "text.tex.latex meta.environment.math", "match_all": true },
 			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\\\left$", "match_all": true },
@@ -598,6 +607,7 @@ LaTeX Package keymap for Linux
 		"command": "run_macro_file", "args": {"file": "res://Packages/LaTeXTools/Delete Left Right Bracket 1.sublime-macro"},
 		"context": [
 			{ "key": "setting.auto_match_enabled" },
+			{ "key": "latextools.setting.auto_match_math_brackets" },
 			{ "key": "selection_empty", "match_all": true },
 			{ "key": "selector", "operand": "text.tex.latex meta.environment.math", "match_all": true },
 			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\\\left\\[$", "match_all": true },
@@ -611,6 +621,7 @@ LaTeX Package keymap for Linux
 		"command": "insert_snippet", "args": {"contents": "($0\\\\right)"},
 		"context": [
 			{ "key": "setting.auto_match_enabled" },
+			{ "key": "latextools.setting.auto_match_math_brackets" },
 			{ "key": "selection_empty", "match_all": true },
 			{ "key": "selector", "operand": "text.tex.latex meta.environment.math", "match_all": true },
 			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\\\left$", "match_all": true },
@@ -622,6 +633,7 @@ LaTeX Package keymap for Linux
 		"command": "run_macro_file", "args": {"file": "res://Packages/LaTeXTools/Delete Left Right Bracket 1.sublime-macro"},
 		"context": [
 			{ "key": "setting.auto_match_enabled" },
+			{ "key": "latextools.setting.auto_match_math_brackets" },
 			{ "key": "selection_empty", "match_all": true },
 			{ "key": "selector", "operand": "text.tex.latex meta.environment.math", "match_all": true },
 			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\\\left\\($", "match_all": true },
@@ -635,6 +647,7 @@ LaTeX Package keymap for Linux
 		"command": "insert_snippet", "args": {"contents": "/$0\\\\right/"},
 		"context": [
 			{ "key": "setting.auto_match_enabled" },
+			{ "key": "latextools.setting.auto_match_math_brackets" },
 			{ "key": "selection_empty", "match_all": true },
 			{ "key": "selector", "operand": "text.tex.latex meta.environment.math", "match_all": true },
 			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\\\left$", "match_all": true },
@@ -646,6 +659,7 @@ LaTeX Package keymap for Linux
 		"command": "run_macro_file", "args": {"file": "res://Packages/LaTeXTools/Delete Left Right Bracket 1.sublime-macro"},
 		"context": [
 			{ "key": "setting.auto_match_enabled" },
+			{ "key": "latextools.setting.auto_match_math_brackets" },
 			{ "key": "selection_empty", "match_all": true },
 			{ "key": "selector", "operand": "text.tex.latex meta.environment.math", "match_all": true },
 			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\\\left/$", "match_all": true },
@@ -659,6 +673,7 @@ LaTeX Package keymap for Linux
 		"command": "insert_snippet", "args": {"contents": "|$0\\\\right|"},
 		"context": [
 			{ "key": "setting.auto_match_enabled" },
+			{ "key": "latextools.setting.auto_match_math_brackets" },
 			{ "key": "selection_empty", "match_all": true },
 			{ "key": "selector", "operand": "text.tex.latex meta.environment.math", "match_all": true },
 			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\\\left$", "match_all": true },
@@ -670,6 +685,7 @@ LaTeX Package keymap for Linux
 		"command": "run_macro_file", "args": {"file": "res://Packages/LaTeXTools/Delete Left Right Bracket 1.sublime-macro"},
 		"context": [
 			{ "key": "setting.auto_match_enabled" },
+			{ "key": "latextools.setting.auto_match_math_brackets" },
 			{ "key": "selection_empty", "match_all": true },
 			{ "key": "selector", "operand": "text.tex.latex meta.environment.math", "match_all": true },
 			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\\\left\\|$", "match_all": true },

--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -557,7 +557,7 @@ LaTeX Package keymap for Linux
 		]
 	},
 
-	// Auto-pair escaped curly braces in math blocks
+	// Auto-pair left/right curly braces in math blocks
 	{
 		"keys": ["{"],
 		"command": "insert_snippet", "args": {"contents": "{$0\\\\right\\\\}"},
@@ -566,7 +566,7 @@ LaTeX Package keymap for Linux
 			{ "key": "selection_empty", "match_all": true },
 			{ "key": "selector", "operand": "text.tex.latex meta.environment.math", "match_all": true },
 			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\\\left\\\\$", "match_all": true },
-			{ "key": "following_text", "operator": "regex_contains", "operand": "^(?:\\s|\\)|\\]|\\}|\\\\|\\$|$)", "match_all": true },
+			{ "key": "following_text", "operator": "regex_contains", "operand": "^(?:\\s|\\)|\\]|\\}|\\\\(?!right\\\\\\})|\\$|$)", "match_all": true },
 		]
 	},
 	{
@@ -590,7 +590,7 @@ LaTeX Package keymap for Linux
 			{ "key": "selection_empty", "match_all": true },
 			{ "key": "selector", "operand": "text.tex.latex meta.environment.math", "match_all": true },
 			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\\\left$", "match_all": true },
-			{ "key": "following_text", "operator": "regex_contains", "operand": "^(?:\\s|\\)|\\]|\\}|\\\\|\\$|$)", "match_all": true },
+			{ "key": "following_text", "operator": "regex_contains", "operand": "^(?:\\s|\\)|\\]|\\}|\\\\(?!right\\])|\\$|$)", "match_all": true },
 		]
 	},
 	{
@@ -614,7 +614,7 @@ LaTeX Package keymap for Linux
 			{ "key": "selection_empty", "match_all": true },
 			{ "key": "selector", "operand": "text.tex.latex meta.environment.math", "match_all": true },
 			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\\\left$", "match_all": true },
-			{ "key": "following_text", "operator": "regex_contains", "operand": "^(?:\\s|\\)|\\]|\\}|\\\\|\\$|$)", "match_all": true },
+			{ "key": "following_text", "operator": "regex_contains", "operand": "^(?:\\s|\\)|\\]|\\}|\\\\(?!right\\))|\\$|$)", "match_all": true },
 		]
 	},
 	{
@@ -629,21 +629,73 @@ LaTeX Package keymap for Linux
 		]
 	},
 
+	// Auto-pair left/right slashes in math blocks
+	{
+		"keys": ["/"],
+		"command": "insert_snippet", "args": {"contents": "/$0\\\\right/"},
+		"context": [
+			{ "key": "setting.auto_match_enabled" },
+			{ "key": "selection_empty", "match_all": true },
+			{ "key": "selector", "operand": "text.tex.latex meta.environment.math", "match_all": true },
+			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\\\left$", "match_all": true },
+			{ "key": "following_text", "operator": "regex_contains", "operand": "^(?:\\s|\\)|\\]|\\}|\\\\(?!right/)|\\$|$)", "match_all": true },
+		]
+	},
+	{
+		"keys": ["backspace"],
+		"command": "run_macro_file", "args": {"file": "res://Packages/LaTeXTools/Delete Left Right Bracket 1.sublime-macro"},
+		"context": [
+			{ "key": "setting.auto_match_enabled" },
+			{ "key": "selection_empty", "match_all": true },
+			{ "key": "selector", "operand": "text.tex.latex meta.environment.math", "match_all": true },
+			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\\\left/$", "match_all": true },
+			{ "key": "following_text", "operator": "regex_contains", "operand": "^\\\\right/", "match_all": true },
+		]
+	},
+
+	// Auto-pair left/right pipes in math blocks
+	{
+		"keys": ["|"],
+		"command": "insert_snippet", "args": {"contents": "|$0\\\\right|"},
+		"context": [
+			{ "key": "setting.auto_match_enabled" },
+			{ "key": "selection_empty", "match_all": true },
+			{ "key": "selector", "operand": "text.tex.latex meta.environment.math", "match_all": true },
+			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\\\left$", "match_all": true },
+			{ "key": "following_text", "operator": "regex_contains", "operand": "^(?:\\s|\\)|\\]|\\}|\\\\(?!right\\|)|\\$|$)", "match_all": true },
+		]
+	},
+	{
+		"keys": ["backspace"],
+		"command": "run_macro_file", "args": {"file": "res://Packages/LaTeXTools/Delete Left Right Bracket 1.sublime-macro"},
+		"context": [
+			{ "key": "setting.auto_match_enabled" },
+			{ "key": "selection_empty", "match_all": true },
+			{ "key": "selector", "operand": "text.tex.latex meta.environment.math", "match_all": true },
+			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\\\left\\|$", "match_all": true },
+			{ "key": "following_text", "operator": "regex_contains", "operand": "^\\\\right\\|", "match_all": true },
+		]
+	},
+
+	// ------------------------------------------------------------------
+	// Indent content between braces/brackets/parentheses
+	// ------------------------------------------------------------------
+
 	// Indent content
 	{
 		"keys": ["enter"], "command": "insert_snippet", "args": {"contents": "\n\t$0\n"},
 		"context": [
 			{ "key": "selector", "operand": "text.tex.latex meta.environment.math" },
-			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*(?:\\\\left)?(?:\\\\)?(\\(|\\[|{)$", "match_all": true },
-			{ "key": "following_text", "operator": "regex_contains", "operand": "^(?:\\\\right)?(?:\\\\)?(\\)|\\]|})", "match_all": true },
+			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*(?:\\\\left)?(?:\\\\)?[(\\[{/|]$", "match_all": true },
+			{ "key": "following_text", "operator": "regex_contains", "operand": "^(?:\\\\right)?(?:\\\\)?[)\\]}/|]", "match_all": true },
 		]
 	},
 	{
 		"keys": ["keypad_enter"], "command": "insert_snippet", "args": {"contents": "\n\t$0\n"},
 		"context": [
 			{ "key": "selector", "operand": "text.tex.latex meta.environment.math" },
-			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*(?:\\\\left)?(?:\\\\)?(\\(|\\[|{)$", "match_all": true },
-			{ "key": "following_text", "operator": "regex_contains", "operand": "^(?:\\\\right)?(?:\\\\)?(\\)|\\]|})", "match_all": true },
+			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*(?:\\\\left)?(?:\\\\)?[(\\[{/|]$", "match_all": true },
+			{ "key": "following_text", "operator": "regex_contains", "operand": "^(?:\\\\right)?(?:\\\\)?[)\\]}/|]", "match_all": true },
 		]
 	},
 

--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -458,6 +458,27 @@ LaTeX Package keymap for Linux
 			{ "key": "following_text", "operator": "regex_contains", "operand": "^(?:\\s|\\)|\\]|\\}|\\$|$)", "match_all": true }
 		]
 	},
+	{
+		"keys": [" "], "command": "insert_snippet", "args": {"contents": " $0 "},
+		"context": [
+			{ "key": "setting.auto_match_enabled" },
+			{ "key": "selection_empty", "match_all": true },
+			{ "key": "selector", "operand": "text.tex.latex", "match_all": true },
+			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\{$", "match_all": true },
+			{ "key": "following_text", "operator": "regex_contains", "operand": "^\\}", "match_all": true },
+		]
+	},
+	{
+		"keys": ["backspace"],
+		"command": "run_macro_file", "args": {"file": "res://Packages/Default/Delete Left Right.sublime-macro"},
+		"context": [
+			{ "key": "setting.auto_match_enabled" },
+			{ "key": "selection_empty", "match_all": true },
+			{ "key": "selector", "operand": "text.tex.latex", "match_all": true },
+			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\{ $", "match_all": true },
+			{ "key": "following_text", "operator": "regex_contains", "operand": "^ \\}", "match_all": true },
+		]
+	},
 
 	// Auto-pair square brackets (also in front of $)
 	{
@@ -471,6 +492,27 @@ LaTeX Package keymap for Linux
 			{ "key": "following_text", "operator": "regex_contains", "operand": "^(?:\\s|\\)|\\]|\\}|\\$|$)", "match_all": true }
 		]
 	},
+	{
+		"keys": [" "], "command": "insert_snippet", "args": {"contents": " $0 "},
+		"context": [
+			{ "key": "setting.auto_match_enabled" },
+			{ "key": "selection_empty", "match_all": true },
+			{ "key": "selector", "operand": "text.tex.latex", "match_all": true },
+			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\[$", "match_all": true },
+			{ "key": "following_text", "operator": "regex_contains", "operand": "^\\]", "match_all": true },
+		]
+	},
+	{
+		"keys": ["backspace"],
+		"command": "run_macro_file", "args": {"file": "res://Packages/Default/Delete Left Right.sublime-macro"},
+		"context": [
+			{ "key": "setting.auto_match_enabled" },
+			{ "key": "selection_empty", "match_all": true },
+			{ "key": "selector", "operand": "text.tex.latex", "match_all": true },
+			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\[ $", "match_all": true },
+			{ "key": "following_text", "operator": "regex_contains", "operand": "^ \\]", "match_all": true },
+		]
+	},
 
 	// Auto-pair parentheses (also in front of $)
 	{
@@ -482,6 +524,27 @@ LaTeX Package keymap for Linux
 			{ "key": "selector", "operand": "text.tex.latex" },
 			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*$", "match_all": true },
 			{ "key": "following_text", "operator": "regex_contains", "operand": "^(?:\\s|\\)|\\]|\\}|\\$|$)", "match_all": true }
+		]
+	},
+	{
+		"keys": [" "], "command": "insert_snippet", "args": {"contents": " $0 "},
+		"context": [
+			{ "key": "setting.auto_match_enabled" },
+			{ "key": "selection_empty", "match_all": true },
+			{ "key": "selector", "operand": "text.tex.latex", "match_all": true },
+			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\($", "match_all": true },
+			{ "key": "following_text", "operator": "regex_contains", "operand": "^\\)", "match_all": true },
+		]
+	},
+	{
+		"keys": ["backspace"],
+		"command": "run_macro_file", "args": {"file": "res://Packages/Default/Delete Left Right.sublime-macro"},
+		"context": [
+			{ "key": "setting.auto_match_enabled" },
+			{ "key": "selection_empty", "match_all": true },
+			{ "key": "selector", "operand": "text.tex.latex", "match_all": true },
+			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\( $", "match_all": true },
+			{ "key": "following_text", "operator": "regex_contains", "operand": "^ \\)", "match_all": true },
 		]
 	},
 
@@ -510,6 +573,29 @@ LaTeX Package keymap for Linux
 			{ "key": "following_text", "operator": "regex_contains", "operand": "^\\\\\\}", "match_all": true },
 		]
 	},
+	{
+		"keys": [" "], "command": "insert_snippet", "args": {"contents": " $0 "},
+		"context": [
+			{ "key": "setting.auto_match_enabled" },
+			{ "key": "latextools.setting.auto_match_escaped_brackets" },
+			{ "key": "selection_empty", "match_all": true },
+			{ "key": "selector", "operand": "text.tex.latex", "match_all": true },
+			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\\\\\{$", "match_all": true },
+			{ "key": "following_text", "operator": "regex_contains", "operand": "^\\\\\\}", "match_all": true },
+		]
+	},
+	{
+		"keys": ["backspace"],
+		"command": "run_macro_file", "args": {"file": "res://Packages/Default/Delete Left Right.sublime-macro"},
+		"context": [
+			{ "key": "setting.auto_match_enabled" },
+			{ "key": "latextools.setting.auto_match_escaped_brackets" },
+			{ "key": "selection_empty", "match_all": true },
+			{ "key": "selector", "operand": "text.tex.latex", "match_all": true },
+			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\\\\\{ $", "match_all": true },
+			{ "key": "following_text", "operator": "regex_contains", "operand": "^ \\\\\\}", "match_all": true },
+		]
+	},
 
 	// Auto-pair escaped square brackets
 	{
@@ -534,6 +620,29 @@ LaTeX Package keymap for Linux
 			{ "key": "selector", "operand": "text.tex.latex", "match_all": true },
 			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\\\\\[$", "match_all": true },
 			{ "key": "following_text", "operator": "regex_contains", "operand": "^\\\\\\]", "match_all": true },
+		]
+	},
+	{
+		"keys": [" "], "command": "insert_snippet", "args": {"contents": " $0 "},
+		"context": [
+			{ "key": "setting.auto_match_enabled" },
+			{ "key": "latextools.setting.auto_match_escaped_brackets" },
+			{ "key": "selection_empty", "match_all": true },
+			{ "key": "selector", "operand": "text.tex.latex", "match_all": true },
+			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\\\\\[$", "match_all": true },
+			{ "key": "following_text", "operator": "regex_contains", "operand": "^\\\\\\]", "match_all": true },
+		]
+	},
+	{
+		"keys": ["backspace"],
+		"command": "run_macro_file", "args": {"file": "res://Packages/Default/Delete Left Right.sublime-macro"},
+		"context": [
+			{ "key": "setting.auto_match_enabled" },
+			{ "key": "latextools.setting.auto_match_escaped_brackets" },
+			{ "key": "selection_empty", "match_all": true },
+			{ "key": "selector", "operand": "text.tex.latex", "match_all": true },
+			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\\\\\[ $", "match_all": true },
+			{ "key": "following_text", "operator": "regex_contains", "operand": "^ \\\\\\]", "match_all": true },
 		]
 	},
 
@@ -562,6 +671,29 @@ LaTeX Package keymap for Linux
 			{ "key": "following_text", "operator": "regex_contains", "operand": "^\\\\\\)", "match_all": true },
 		]
 	},
+	{
+		"keys": [" "], "command": "insert_snippet", "args": {"contents": " $0 "},
+		"context": [
+			{ "key": "setting.auto_match_enabled" },
+			{ "key": "latextools.setting.auto_match_escaped_brackets" },
+			{ "key": "selection_empty", "match_all": true },
+			{ "key": "selector", "operand": "text.tex.latex", "match_all": true },
+			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\\\\\($", "match_all": true },
+			{ "key": "following_text", "operator": "regex_contains", "operand": "^\\\\\\)", "match_all": true },
+		]
+	},
+	{
+		"keys": ["backspace"],
+		"command": "run_macro_file", "args": {"file": "res://Packages/Default/Delete Left Right.sublime-macro"},
+		"context": [
+			{ "key": "setting.auto_match_enabled" },
+			{ "key": "latextools.setting.auto_match_escaped_brackets" },
+			{ "key": "selection_empty", "match_all": true },
+			{ "key": "selector", "operand": "text.tex.latex", "match_all": true },
+			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\\\\\( $", "match_all": true },
+			{ "key": "following_text", "operator": "regex_contains", "operand": "^ \\\\\\)", "match_all": true },
+		]
+	},
 
 	// Auto-pair left/right curly braces in math blocks
 	{
@@ -586,6 +718,29 @@ LaTeX Package keymap for Linux
 			{ "key": "selector", "operand": "text.tex.latex meta.environment.math", "match_all": true },
 			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\\\left\\\\\\{$", "match_all": true },
 			{ "key": "following_text", "operator": "regex_contains", "operand": "^\\\\right\\\\\\}", "match_all": true },
+		]
+	},
+	{
+		"keys": [" "], "command": "insert_snippet", "args": {"contents": " $0 "},
+		"context": [
+			{ "key": "setting.auto_match_enabled" },
+			{ "key": "latextools.setting.auto_match_math_brackets" },
+			{ "key": "selection_empty", "match_all": true },
+			{ "key": "selector", "operand": "text.tex.latex meta.environment.math", "match_all": true },
+			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\\\left\\\\\\{$", "match_all": true },
+			{ "key": "following_text", "operator": "regex_contains", "operand": "^\\\\right\\\\\\}", "match_all": true },
+		]
+	},
+	{
+		"keys": ["backspace"],
+		"command": "run_macro_file", "args": {"file": "res://Packages/Default/Delete Left Right.sublime-macro"},
+		"context": [
+			{ "key": "setting.auto_match_enabled" },
+			{ "key": "latextools.setting.auto_match_math_brackets" },
+			{ "key": "selection_empty", "match_all": true },
+			{ "key": "selector", "operand": "text.tex.latex meta.environment.math", "match_all": true },
+			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\\\left\\\\\\{ $", "match_all": true },
+			{ "key": "following_text", "operator": "regex_contains", "operand": "^ \\\\right\\\\\\}", "match_all": true },
 		]
 	},
 
@@ -614,6 +769,29 @@ LaTeX Package keymap for Linux
 			{ "key": "following_text", "operator": "regex_contains", "operand": "^\\\\right\\]", "match_all": true },
 		]
 	},
+	{
+		"keys": [" "], "command": "insert_snippet", "args": {"contents": " $0 "},
+		"context": [
+			{ "key": "setting.auto_match_enabled" },
+			{ "key": "latextools.setting.auto_match_math_brackets" },
+			{ "key": "selection_empty", "match_all": true },
+			{ "key": "selector", "operand": "text.tex.latex meta.environment.math", "match_all": true },
+			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\\\left\\[$", "match_all": true },
+			{ "key": "following_text", "operator": "regex_contains", "operand": "^\\\\right\\]", "match_all": true },
+		]
+	},
+	{
+		"keys": ["backspace"],
+		"command": "run_macro_file", "args": {"file": "res://Packages/Default/Delete Left Right.sublime-macro"},
+		"context": [
+			{ "key": "setting.auto_match_enabled" },
+			{ "key": "latextools.setting.auto_match_math_brackets" },
+			{ "key": "selection_empty", "match_all": true },
+			{ "key": "selector", "operand": "text.tex.latex meta.environment.math", "match_all": true },
+			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\\\left\\[ $", "match_all": true },
+			{ "key": "following_text", "operator": "regex_contains", "operand": "^ \\\\right\\]", "match_all": true },
+		]
+	},
 
 	// Auto-pair escpaed parentheses in math blocks
 	{
@@ -638,6 +816,29 @@ LaTeX Package keymap for Linux
 			{ "key": "selector", "operand": "text.tex.latex meta.environment.math", "match_all": true },
 			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\\\left\\($", "match_all": true },
 			{ "key": "following_text", "operator": "regex_contains", "operand": "^\\\\right\\)", "match_all": true },
+		]
+	},
+	{
+		"keys": [" "], "command": "insert_snippet", "args": {"contents": " $0 "},
+		"context": [
+			{ "key": "setting.auto_match_enabled" },
+			{ "key": "latextools.setting.auto_match_math_brackets" },
+			{ "key": "selection_empty", "match_all": true },
+			{ "key": "selector", "operand": "text.tex.latex meta.environment.math", "match_all": true },
+			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\\\left\\($", "match_all": true },
+			{ "key": "following_text", "operator": "regex_contains", "operand": "^\\\\right\\)", "match_all": true },
+		]
+	},
+	{
+		"keys": ["backspace"],
+		"command": "run_macro_file", "args": {"file": "res://Packages/Default/Delete Left Right.sublime-macro"},
+		"context": [
+			{ "key": "setting.auto_match_enabled" },
+			{ "key": "latextools.setting.auto_match_math_brackets" },
+			{ "key": "selection_empty", "match_all": true },
+			{ "key": "selector", "operand": "text.tex.latex meta.environment.math", "match_all": true },
+			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\\\left\\( $", "match_all": true },
+			{ "key": "following_text", "operator": "regex_contains", "operand": "^ \\\\right\\)", "match_all": true },
 		]
 	},
 
@@ -666,6 +867,29 @@ LaTeX Package keymap for Linux
 			{ "key": "following_text", "operator": "regex_contains", "operand": "^\\\\right/", "match_all": true },
 		]
 	},
+	{
+		"keys": [" "], "command": "insert_snippet", "args": {"contents": " $0 "},
+		"context": [
+			{ "key": "setting.auto_match_enabled" },
+			{ "key": "latextools.setting.auto_match_math_brackets" },
+			{ "key": "selection_empty", "match_all": true },
+			{ "key": "selector", "operand": "text.tex.latex meta.environment.math", "match_all": true },
+			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\\\left/$", "match_all": true },
+			{ "key": "following_text", "operator": "regex_contains", "operand": "^\\\\right/", "match_all": true },
+		]
+	},
+	{
+		"keys": ["backspace"],
+		"command": "run_macro_file", "args": {"file": "res://Packages/Default/Delete Left Right.sublime-macro"},
+		"context": [
+			{ "key": "setting.auto_match_enabled" },
+			{ "key": "latextools.setting.auto_match_math_brackets" },
+			{ "key": "selection_empty", "match_all": true },
+			{ "key": "selector", "operand": "text.tex.latex meta.environment.math", "match_all": true },
+			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\\\left/ $", "match_all": true },
+			{ "key": "following_text", "operator": "regex_contains", "operand": "^ \\\\right/", "match_all": true },
+		]
+	},
 
 	// Auto-pair left/right pipes in math blocks
 	{
@@ -690,6 +914,29 @@ LaTeX Package keymap for Linux
 			{ "key": "selector", "operand": "text.tex.latex meta.environment.math", "match_all": true },
 			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\\\left\\|$", "match_all": true },
 			{ "key": "following_text", "operator": "regex_contains", "operand": "^\\\\right\\|", "match_all": true },
+		]
+	},
+	{
+		"keys": [" "], "command": "insert_snippet", "args": {"contents": " $0 "},
+		"context": [
+			{ "key": "setting.auto_match_enabled" },
+			{ "key": "latextools.setting.auto_match_math_brackets" },
+			{ "key": "selection_empty", "match_all": true },
+			{ "key": "selector", "operand": "text.tex.latex meta.environment.math", "match_all": true },
+			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\\\left\\|$", "match_all": true },
+			{ "key": "following_text", "operator": "regex_contains", "operand": "^\\\\right\\|", "match_all": true },
+		]
+	},
+	{
+		"keys": ["backspace"],
+		"command": "run_macro_file", "args": {"file": "res://Packages/Default/Delete Left Right.sublime-macro"},
+		"context": [
+			{ "key": "setting.auto_match_enabled" },
+			{ "key": "latextools.setting.auto_match_math_brackets" },
+			{ "key": "selection_empty", "match_all": true },
+			{ "key": "selector", "operand": "text.tex.latex meta.environment.math", "match_all": true },
+			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\\\left\\| $", "match_all": true },
+			{ "key": "following_text", "operator": "regex_contains", "operand": "^ \\\\right\\|", "match_all": true },
 		]
 	},
 

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -557,7 +557,7 @@ LaTeX Package keymap for OS X
 		]
 	},
 
-	// Auto-pair escaped curly braces in math blocks
+	// Auto-pair left/right curly braces in math blocks
 	{
 		"keys": ["{"],
 		"command": "insert_snippet", "args": {"contents": "{$0\\\\right\\\\}"},
@@ -566,7 +566,7 @@ LaTeX Package keymap for OS X
 			{ "key": "selection_empty", "match_all": true },
 			{ "key": "selector", "operand": "text.tex.latex meta.environment.math", "match_all": true },
 			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\\\left\\\\$", "match_all": true },
-			{ "key": "following_text", "operator": "regex_contains", "operand": "^(?:\\s|\\)|\\]|\\}|\\\\|\\$|$)", "match_all": true },
+			{ "key": "following_text", "operator": "regex_contains", "operand": "^(?:\\s|\\)|\\]|\\}|\\\\(?!right\\\\\\})|\\$|$)", "match_all": true },
 		]
 	},
 	{
@@ -590,7 +590,7 @@ LaTeX Package keymap for OS X
 			{ "key": "selection_empty", "match_all": true },
 			{ "key": "selector", "operand": "text.tex.latex meta.environment.math", "match_all": true },
 			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\\\left$", "match_all": true },
-			{ "key": "following_text", "operator": "regex_contains", "operand": "^(?:\\s|\\)|\\]|\\}|\\\\|\\$|$)", "match_all": true },
+			{ "key": "following_text", "operator": "regex_contains", "operand": "^(?:\\s|\\)|\\]|\\}|\\\\(?!right\\])|\\$|$)", "match_all": true },
 		]
 	},
 	{
@@ -614,7 +614,7 @@ LaTeX Package keymap for OS X
 			{ "key": "selection_empty", "match_all": true },
 			{ "key": "selector", "operand": "text.tex.latex meta.environment.math", "match_all": true },
 			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\\\left$", "match_all": true },
-			{ "key": "following_text", "operator": "regex_contains", "operand": "^(?:\\s|\\)|\\]|\\}|\\\\|\\$|$)", "match_all": true },
+			{ "key": "following_text", "operator": "regex_contains", "operand": "^(?:\\s|\\)|\\]|\\}|\\\\(?!right\\))|\\$|$)", "match_all": true },
 		]
 	},
 	{
@@ -629,21 +629,73 @@ LaTeX Package keymap for OS X
 		]
 	},
 
+	// Auto-pair left/right slashes in math blocks
+	{
+		"keys": ["/"],
+		"command": "insert_snippet", "args": {"contents": "/$0\\\\right/"},
+		"context": [
+			{ "key": "setting.auto_match_enabled" },
+			{ "key": "selection_empty", "match_all": true },
+			{ "key": "selector", "operand": "text.tex.latex meta.environment.math", "match_all": true },
+			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\\\left$", "match_all": true },
+			{ "key": "following_text", "operator": "regex_contains", "operand": "^(?:\\s|\\)|\\]|\\}|\\\\(?!right/)|\\$|$)", "match_all": true },
+		]
+	},
+	{
+		"keys": ["backspace"],
+		"command": "run_macro_file", "args": {"file": "res://Packages/LaTeXTools/Delete Left Right Bracket 1.sublime-macro"},
+		"context": [
+			{ "key": "setting.auto_match_enabled" },
+			{ "key": "selection_empty", "match_all": true },
+			{ "key": "selector", "operand": "text.tex.latex meta.environment.math", "match_all": true },
+			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\\\left/$", "match_all": true },
+			{ "key": "following_text", "operator": "regex_contains", "operand": "^\\\\right/", "match_all": true },
+		]
+	},
+
+	// Auto-pair left/right pipes in math blocks
+	{
+		"keys": ["|"],
+		"command": "insert_snippet", "args": {"contents": "|$0\\\\right|"},
+		"context": [
+			{ "key": "setting.auto_match_enabled" },
+			{ "key": "selection_empty", "match_all": true },
+			{ "key": "selector", "operand": "text.tex.latex meta.environment.math", "match_all": true },
+			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\\\left$", "match_all": true },
+			{ "key": "following_text", "operator": "regex_contains", "operand": "^(?:\\s|\\)|\\]|\\}|\\\\(?!right\\|)|\\$|$)", "match_all": true },
+		]
+	},
+	{
+		"keys": ["backspace"],
+		"command": "run_macro_file", "args": {"file": "res://Packages/LaTeXTools/Delete Left Right Bracket 1.sublime-macro"},
+		"context": [
+			{ "key": "setting.auto_match_enabled" },
+			{ "key": "selection_empty", "match_all": true },
+			{ "key": "selector", "operand": "text.tex.latex meta.environment.math", "match_all": true },
+			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\\\left\\|$", "match_all": true },
+			{ "key": "following_text", "operator": "regex_contains", "operand": "^\\\\right\\|", "match_all": true },
+		]
+	},
+
+	// ------------------------------------------------------------------
+	// Indent content between braces/brackets/parentheses
+	// ------------------------------------------------------------------
+
 	// Indent content
 	{
 		"keys": ["enter"], "command": "insert_snippet", "args": {"contents": "\n\t$0\n"},
 		"context": [
 			{ "key": "selector", "operand": "text.tex.latex meta.environment.math" },
-			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*(?:\\\\left)?(?:\\\\)?(\\(|\\[|{)$", "match_all": true },
-			{ "key": "following_text", "operator": "regex_contains", "operand": "^(?:\\\\right)?(?:\\\\)?(\\)|\\]|})", "match_all": true },
+			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*(?:\\\\left)?(?:\\\\)?[(\\[{/|]$", "match_all": true },
+			{ "key": "following_text", "operator": "regex_contains", "operand": "^(?:\\\\right)?(?:\\\\)?[)\\]}/|]", "match_all": true },
 		]
 	},
 	{
 		"keys": ["keypad_enter"], "command": "insert_snippet", "args": {"contents": "\n\t$0\n"},
 		"context": [
 			{ "key": "selector", "operand": "text.tex.latex meta.environment.math" },
-			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*(?:\\\\left)?(?:\\\\)?(\\(|\\[|{)$", "match_all": true },
-			{ "key": "following_text", "operator": "regex_contains", "operand": "^(?:\\\\right)?(?:\\\\)?(\\)|\\]|})", "match_all": true },
+			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*(?:\\\\left)?(?:\\\\)?[(\\[{/|]$", "match_all": true },
+			{ "key": "following_text", "operator": "regex_contains", "operand": "^(?:\\\\right)?(?:\\\\)?[)\\]}/|]", "match_all": true },
 		]
 	},
 

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -458,6 +458,27 @@ LaTeX Package keymap for OS X
 			{ "key": "following_text", "operator": "regex_contains", "operand": "^(?:\\s|\\)|\\]|\\}|\\$|$)", "match_all": true }
 		]
 	},
+	{
+		"keys": [" "], "command": "insert_snippet", "args": {"contents": " $0 "},
+		"context": [
+			{ "key": "setting.auto_match_enabled" },
+			{ "key": "selection_empty", "match_all": true },
+			{ "key": "selector", "operand": "text.tex.latex", "match_all": true },
+			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\{$", "match_all": true },
+			{ "key": "following_text", "operator": "regex_contains", "operand": "^\\}", "match_all": true },
+		]
+	},
+	{
+		"keys": ["backspace"],
+		"command": "run_macro_file", "args": {"file": "res://Packages/Default/Delete Left Right.sublime-macro"},
+		"context": [
+			{ "key": "setting.auto_match_enabled" },
+			{ "key": "selection_empty", "match_all": true },
+			{ "key": "selector", "operand": "text.tex.latex", "match_all": true },
+			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\{ $", "match_all": true },
+			{ "key": "following_text", "operator": "regex_contains", "operand": "^ \\}", "match_all": true },
+		]
+	},
 
 	// Auto-pair square brackets (also in front of $)
 	{
@@ -471,6 +492,27 @@ LaTeX Package keymap for OS X
 			{ "key": "following_text", "operator": "regex_contains", "operand": "^(?:\\s|\\)|\\]|\\}|\\$|$)", "match_all": true }
 		]
 	},
+	{
+		"keys": [" "], "command": "insert_snippet", "args": {"contents": " $0 "},
+		"context": [
+			{ "key": "setting.auto_match_enabled" },
+			{ "key": "selection_empty", "match_all": true },
+			{ "key": "selector", "operand": "text.tex.latex", "match_all": true },
+			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\[$", "match_all": true },
+			{ "key": "following_text", "operator": "regex_contains", "operand": "^\\]", "match_all": true },
+		]
+	},
+	{
+		"keys": ["backspace"],
+		"command": "run_macro_file", "args": {"file": "res://Packages/Default/Delete Left Right.sublime-macro"},
+		"context": [
+			{ "key": "setting.auto_match_enabled" },
+			{ "key": "selection_empty", "match_all": true },
+			{ "key": "selector", "operand": "text.tex.latex", "match_all": true },
+			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\[ $", "match_all": true },
+			{ "key": "following_text", "operator": "regex_contains", "operand": "^ \\]", "match_all": true },
+		]
+	},
 
 	// Auto-pair parentheses (also in front of $)
 	{
@@ -482,6 +524,27 @@ LaTeX Package keymap for OS X
 			{ "key": "selector", "operand": "text.tex.latex" },
 			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*$", "match_all": true },
 			{ "key": "following_text", "operator": "regex_contains", "operand": "^(?:\\s|\\)|\\]|\\}|\\$|$)", "match_all": true }
+		]
+	},
+	{
+		"keys": [" "], "command": "insert_snippet", "args": {"contents": " $0 "},
+		"context": [
+			{ "key": "setting.auto_match_enabled" },
+			{ "key": "selection_empty", "match_all": true },
+			{ "key": "selector", "operand": "text.tex.latex", "match_all": true },
+			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\($", "match_all": true },
+			{ "key": "following_text", "operator": "regex_contains", "operand": "^\\)", "match_all": true },
+		]
+	},
+	{
+		"keys": ["backspace"],
+		"command": "run_macro_file", "args": {"file": "res://Packages/Default/Delete Left Right.sublime-macro"},
+		"context": [
+			{ "key": "setting.auto_match_enabled" },
+			{ "key": "selection_empty", "match_all": true },
+			{ "key": "selector", "operand": "text.tex.latex", "match_all": true },
+			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\( $", "match_all": true },
+			{ "key": "following_text", "operator": "regex_contains", "operand": "^ \\)", "match_all": true },
 		]
 	},
 
@@ -510,6 +573,29 @@ LaTeX Package keymap for OS X
 			{ "key": "following_text", "operator": "regex_contains", "operand": "^\\\\\\}", "match_all": true },
 		]
 	},
+	{
+		"keys": [" "], "command": "insert_snippet", "args": {"contents": " $0 "},
+		"context": [
+			{ "key": "setting.auto_match_enabled" },
+			{ "key": "latextools.setting.auto_match_escaped_brackets" },
+			{ "key": "selection_empty", "match_all": true },
+			{ "key": "selector", "operand": "text.tex.latex", "match_all": true },
+			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\\\\\{$", "match_all": true },
+			{ "key": "following_text", "operator": "regex_contains", "operand": "^\\\\\\}", "match_all": true },
+		]
+	},
+	{
+		"keys": ["backspace"],
+		"command": "run_macro_file", "args": {"file": "res://Packages/Default/Delete Left Right.sublime-macro"},
+		"context": [
+			{ "key": "setting.auto_match_enabled" },
+			{ "key": "latextools.setting.auto_match_escaped_brackets" },
+			{ "key": "selection_empty", "match_all": true },
+			{ "key": "selector", "operand": "text.tex.latex", "match_all": true },
+			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\\\\\{ $", "match_all": true },
+			{ "key": "following_text", "operator": "regex_contains", "operand": "^ \\\\\\}", "match_all": true },
+		]
+	},
 
 	// Auto-pair escaped square brackets
 	{
@@ -534,6 +620,29 @@ LaTeX Package keymap for OS X
 			{ "key": "selector", "operand": "text.tex.latex", "match_all": true },
 			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\\\\\[$", "match_all": true },
 			{ "key": "following_text", "operator": "regex_contains", "operand": "^\\\\\\]", "match_all": true },
+		]
+	},
+	{
+		"keys": [" "], "command": "insert_snippet", "args": {"contents": " $0 "},
+		"context": [
+			{ "key": "setting.auto_match_enabled" },
+			{ "key": "latextools.setting.auto_match_escaped_brackets" },
+			{ "key": "selection_empty", "match_all": true },
+			{ "key": "selector", "operand": "text.tex.latex", "match_all": true },
+			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\\\\\[$", "match_all": true },
+			{ "key": "following_text", "operator": "regex_contains", "operand": "^\\\\\\]", "match_all": true },
+		]
+	},
+	{
+		"keys": ["backspace"],
+		"command": "run_macro_file", "args": {"file": "res://Packages/Default/Delete Left Right.sublime-macro"},
+		"context": [
+			{ "key": "setting.auto_match_enabled" },
+			{ "key": "latextools.setting.auto_match_escaped_brackets" },
+			{ "key": "selection_empty", "match_all": true },
+			{ "key": "selector", "operand": "text.tex.latex", "match_all": true },
+			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\\\\\[ $", "match_all": true },
+			{ "key": "following_text", "operator": "regex_contains", "operand": "^ \\\\\\]", "match_all": true },
 		]
 	},
 
@@ -562,6 +671,29 @@ LaTeX Package keymap for OS X
 			{ "key": "following_text", "operator": "regex_contains", "operand": "^\\\\\\)", "match_all": true },
 		]
 	},
+	{
+		"keys": [" "], "command": "insert_snippet", "args": {"contents": " $0 "},
+		"context": [
+			{ "key": "setting.auto_match_enabled" },
+			{ "key": "latextools.setting.auto_match_escaped_brackets" },
+			{ "key": "selection_empty", "match_all": true },
+			{ "key": "selector", "operand": "text.tex.latex", "match_all": true },
+			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\\\\\($", "match_all": true },
+			{ "key": "following_text", "operator": "regex_contains", "operand": "^\\\\\\)", "match_all": true },
+		]
+	},
+	{
+		"keys": ["backspace"],
+		"command": "run_macro_file", "args": {"file": "res://Packages/Default/Delete Left Right.sublime-macro"},
+		"context": [
+			{ "key": "setting.auto_match_enabled" },
+			{ "key": "latextools.setting.auto_match_escaped_brackets" },
+			{ "key": "selection_empty", "match_all": true },
+			{ "key": "selector", "operand": "text.tex.latex", "match_all": true },
+			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\\\\\( $", "match_all": true },
+			{ "key": "following_text", "operator": "regex_contains", "operand": "^ \\\\\\)", "match_all": true },
+		]
+	},
 
 	// Auto-pair left/right curly braces in math blocks
 	{
@@ -586,6 +718,29 @@ LaTeX Package keymap for OS X
 			{ "key": "selector", "operand": "text.tex.latex meta.environment.math", "match_all": true },
 			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\\\left\\\\\\{$", "match_all": true },
 			{ "key": "following_text", "operator": "regex_contains", "operand": "^\\\\right\\\\\\}", "match_all": true },
+		]
+	},
+	{
+		"keys": [" "], "command": "insert_snippet", "args": {"contents": " $0 "},
+		"context": [
+			{ "key": "setting.auto_match_enabled" },
+			{ "key": "latextools.setting.auto_match_math_brackets" },
+			{ "key": "selection_empty", "match_all": true },
+			{ "key": "selector", "operand": "text.tex.latex meta.environment.math", "match_all": true },
+			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\\\left\\\\\\{$", "match_all": true },
+			{ "key": "following_text", "operator": "regex_contains", "operand": "^\\\\right\\\\\\}", "match_all": true },
+		]
+	},
+	{
+		"keys": ["backspace"],
+		"command": "run_macro_file", "args": {"file": "res://Packages/Default/Delete Left Right.sublime-macro"},
+		"context": [
+			{ "key": "setting.auto_match_enabled" },
+			{ "key": "latextools.setting.auto_match_math_brackets" },
+			{ "key": "selection_empty", "match_all": true },
+			{ "key": "selector", "operand": "text.tex.latex meta.environment.math", "match_all": true },
+			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\\\left\\\\\\{ $", "match_all": true },
+			{ "key": "following_text", "operator": "regex_contains", "operand": "^ \\\\right\\\\\\}", "match_all": true },
 		]
 	},
 
@@ -614,6 +769,29 @@ LaTeX Package keymap for OS X
 			{ "key": "following_text", "operator": "regex_contains", "operand": "^\\\\right\\]", "match_all": true },
 		]
 	},
+	{
+		"keys": [" "], "command": "insert_snippet", "args": {"contents": " $0 "},
+		"context": [
+			{ "key": "setting.auto_match_enabled" },
+			{ "key": "latextools.setting.auto_match_math_brackets" },
+			{ "key": "selection_empty", "match_all": true },
+			{ "key": "selector", "operand": "text.tex.latex meta.environment.math", "match_all": true },
+			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\\\left\\[$", "match_all": true },
+			{ "key": "following_text", "operator": "regex_contains", "operand": "^\\\\right\\]", "match_all": true },
+		]
+	},
+	{
+		"keys": ["backspace"],
+		"command": "run_macro_file", "args": {"file": "res://Packages/Default/Delete Left Right.sublime-macro"},
+		"context": [
+			{ "key": "setting.auto_match_enabled" },
+			{ "key": "latextools.setting.auto_match_math_brackets" },
+			{ "key": "selection_empty", "match_all": true },
+			{ "key": "selector", "operand": "text.tex.latex meta.environment.math", "match_all": true },
+			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\\\left\\[ $", "match_all": true },
+			{ "key": "following_text", "operator": "regex_contains", "operand": "^ \\\\right\\]", "match_all": true },
+		]
+	},
 
 	// Auto-pair escpaed parentheses in math blocks
 	{
@@ -638,6 +816,29 @@ LaTeX Package keymap for OS X
 			{ "key": "selector", "operand": "text.tex.latex meta.environment.math", "match_all": true },
 			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\\\left\\($", "match_all": true },
 			{ "key": "following_text", "operator": "regex_contains", "operand": "^\\\\right\\)", "match_all": true },
+		]
+	},
+	{
+		"keys": [" "], "command": "insert_snippet", "args": {"contents": " $0 "},
+		"context": [
+			{ "key": "setting.auto_match_enabled" },
+			{ "key": "latextools.setting.auto_match_math_brackets" },
+			{ "key": "selection_empty", "match_all": true },
+			{ "key": "selector", "operand": "text.tex.latex meta.environment.math", "match_all": true },
+			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\\\left\\($", "match_all": true },
+			{ "key": "following_text", "operator": "regex_contains", "operand": "^\\\\right\\)", "match_all": true },
+		]
+	},
+	{
+		"keys": ["backspace"],
+		"command": "run_macro_file", "args": {"file": "res://Packages/Default/Delete Left Right.sublime-macro"},
+		"context": [
+			{ "key": "setting.auto_match_enabled" },
+			{ "key": "latextools.setting.auto_match_math_brackets" },
+			{ "key": "selection_empty", "match_all": true },
+			{ "key": "selector", "operand": "text.tex.latex meta.environment.math", "match_all": true },
+			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\\\left\\( $", "match_all": true },
+			{ "key": "following_text", "operator": "regex_contains", "operand": "^ \\\\right\\)", "match_all": true },
 		]
 	},
 
@@ -666,6 +867,29 @@ LaTeX Package keymap for OS X
 			{ "key": "following_text", "operator": "regex_contains", "operand": "^\\\\right/", "match_all": true },
 		]
 	},
+	{
+		"keys": [" "], "command": "insert_snippet", "args": {"contents": " $0 "},
+		"context": [
+			{ "key": "setting.auto_match_enabled" },
+			{ "key": "latextools.setting.auto_match_math_brackets" },
+			{ "key": "selection_empty", "match_all": true },
+			{ "key": "selector", "operand": "text.tex.latex meta.environment.math", "match_all": true },
+			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\\\left/$", "match_all": true },
+			{ "key": "following_text", "operator": "regex_contains", "operand": "^\\\\right/", "match_all": true },
+		]
+	},
+	{
+		"keys": ["backspace"],
+		"command": "run_macro_file", "args": {"file": "res://Packages/Default/Delete Left Right.sublime-macro"},
+		"context": [
+			{ "key": "setting.auto_match_enabled" },
+			{ "key": "latextools.setting.auto_match_math_brackets" },
+			{ "key": "selection_empty", "match_all": true },
+			{ "key": "selector", "operand": "text.tex.latex meta.environment.math", "match_all": true },
+			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\\\left/ $", "match_all": true },
+			{ "key": "following_text", "operator": "regex_contains", "operand": "^ \\\\right/", "match_all": true },
+		]
+	},
 
 	// Auto-pair left/right pipes in math blocks
 	{
@@ -690,6 +914,29 @@ LaTeX Package keymap for OS X
 			{ "key": "selector", "operand": "text.tex.latex meta.environment.math", "match_all": true },
 			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\\\left\\|$", "match_all": true },
 			{ "key": "following_text", "operator": "regex_contains", "operand": "^\\\\right\\|", "match_all": true },
+		]
+	},
+	{
+		"keys": [" "], "command": "insert_snippet", "args": {"contents": " $0 "},
+		"context": [
+			{ "key": "setting.auto_match_enabled" },
+			{ "key": "latextools.setting.auto_match_math_brackets" },
+			{ "key": "selection_empty", "match_all": true },
+			{ "key": "selector", "operand": "text.tex.latex meta.environment.math", "match_all": true },
+			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\\\left\\|$", "match_all": true },
+			{ "key": "following_text", "operator": "regex_contains", "operand": "^\\\\right\\|", "match_all": true },
+		]
+	},
+	{
+		"keys": ["backspace"],
+		"command": "run_macro_file", "args": {"file": "res://Packages/Default/Delete Left Right.sublime-macro"},
+		"context": [
+			{ "key": "setting.auto_match_enabled" },
+			{ "key": "latextools.setting.auto_match_math_brackets" },
+			{ "key": "selection_empty", "match_all": true },
+			{ "key": "selector", "operand": "text.tex.latex meta.environment.math", "match_all": true },
+			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\\\left\\| $", "match_all": true },
+			{ "key": "following_text", "operator": "regex_contains", "operand": "^ \\\\right\\|", "match_all": true },
 		]
 	},
 

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -446,19 +446,6 @@ LaTeX Package keymap for OS X
 	// Auto-pair braces/brackets/parentheses
 	// ------------------------------------------------------------------
 
-	// Override default "wrap_block" binding
-	{
-		"keys": ["{"],
-		"command": "insert_snippet", "args": { "contents": "{$0}" },
-		"context": [
-			{ "key": "indented_block", "match_all": true },
-			{ "key": "setting.auto_match_enabled" },
-			{ "key": "selection_empty", "match_all": true },
-			{ "key": "selector", "operand": "text.tex.latex" },
-			{ "key": "following_text", "operator": "regex_match", "operand": "^$", "match_all": true }
-		]
-	},
-
 	// Auto-pair curly brackets (also in front of $)
 	{
 		"keys": ["{"],
@@ -466,8 +453,8 @@ LaTeX Package keymap for OS X
 		"context": [
 			{ "key": "setting.auto_match_enabled" },
 			{ "key": "selection_empty", "match_all": true },
-			{ "key": "selector", "operand": "text.tex.latex meta.environment.math" },
-			{ "key": "preceding_text", "operator": "not_regex_contains", "operand": "\\\\$", "match_all": true },
+			{ "key": "selector", "operand": "text.tex.latex" },
+			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*$", "match_all": true },
 			{ "key": "following_text", "operator": "regex_contains", "operand": "^(?:\\s|\\)|\\]|\\}|\\$|$)", "match_all": true }
 		]
 	},
@@ -479,8 +466,8 @@ LaTeX Package keymap for OS X
 		"context": [
 			{ "key": "setting.auto_match_enabled" },
 			{ "key": "selection_empty", "match_all": true },
-			{ "key": "selector", "operand": "text.tex.latex meta.environment.math" },
-			{ "key": "preceding_text", "operator": "not_regex_contains", "operand": "\\\\$", "match_all": true },
+			{ "key": "selector", "operand": "text.tex.latex" },
+			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*$", "match_all": true },
 			{ "key": "following_text", "operator": "regex_contains", "operand": "^(?:\\s|\\)|\\]|\\}|\\$|$)", "match_all": true }
 		]
 	},
@@ -492,8 +479,8 @@ LaTeX Package keymap for OS X
 		"context": [
 			{ "key": "setting.auto_match_enabled" },
 			{ "key": "selection_empty", "match_all": true },
-			{ "key": "selector", "operand": "text.tex.latex meta.environment.math" },
-			{ "key": "preceding_text", "operator": "not_regex_contains", "operand": "\\\\$", "match_all": true },
+			{ "key": "selector", "operand": "text.tex.latex" },
+			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*$", "match_all": true },
 			{ "key": "following_text", "operator": "regex_contains", "operand": "^(?:\\s|\\)|\\]|\\}|\\$|$)", "match_all": true }
 		]
 	},
@@ -506,7 +493,7 @@ LaTeX Package keymap for OS X
 			{ "key": "setting.auto_match_enabled" },
 			{ "key": "selection_empty", "match_all": true },
 			{ "key": "selector", "operand": "text.tex.latex", "match_all": true },
-			{ "key": "preceding_text", "operator": "regex_contains", "operand": "\\\\$", "match_all": true },
+			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\\\$", "match_all": true },
 			{ "key": "following_text", "operator": "regex_contains", "operand": "^(?:\\s|\\)|\\]|\\}|\\\\|\\$|$)", "match_all": true },
 		]
 	},
@@ -517,7 +504,7 @@ LaTeX Package keymap for OS X
 			{ "key": "setting.auto_match_enabled" },
 			{ "key": "selection_empty", "match_all": true },
 			{ "key": "selector", "operand": "text.tex.latex", "match_all": true },
-			{ "key": "preceding_text", "operator": "regex_contains", "operand": "\\\\\\{$", "match_all": true },
+			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\\\\\{$", "match_all": true },
 			{ "key": "following_text", "operator": "regex_contains", "operand": "^\\\\\\}", "match_all": true },
 		]
 	},
@@ -530,7 +517,7 @@ LaTeX Package keymap for OS X
 			{ "key": "setting.auto_match_enabled" },
 			{ "key": "selection_empty", "match_all": true },
 			{ "key": "selector", "operand": "text.tex.latex", "match_all": true },
-			{ "key": "preceding_text", "operator": "regex_contains", "operand": "\\\\$", "match_all": true },
+			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\\\$", "match_all": true },
 			{ "key": "following_text", "operator": "regex_contains", "operand": "^(?:\\s|\\)|\\]|\\}|\\\\|\\$|$)", "match_all": true },
 		]
 	},
@@ -541,7 +528,7 @@ LaTeX Package keymap for OS X
 			{ "key": "setting.auto_match_enabled" },
 			{ "key": "selection_empty", "match_all": true },
 			{ "key": "selector", "operand": "text.tex.latex", "match_all": true },
-			{ "key": "preceding_text", "operator": "regex_contains", "operand": "\\\\\\[$", "match_all": true },
+			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\\\\\[$", "match_all": true },
 			{ "key": "following_text", "operator": "regex_contains", "operand": "^\\\\\\]", "match_all": true },
 		]
 	},
@@ -554,7 +541,7 @@ LaTeX Package keymap for OS X
 			{ "key": "setting.auto_match_enabled" },
 			{ "key": "selection_empty", "match_all": true },
 			{ "key": "selector", "operand": "text.tex.latex", "match_all": true },
-			{ "key": "preceding_text", "operator": "regex_contains", "operand": "\\\\$", "match_all": true },
+			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\\\$", "match_all": true },
 			{ "key": "following_text", "operator": "regex_contains", "operand": "^(?:\\s|\\)|\\]|\\}|\\\\|\\$|$)", "match_all": true },
 		]
 	},
@@ -565,7 +552,7 @@ LaTeX Package keymap for OS X
 			{ "key": "setting.auto_match_enabled" },
 			{ "key": "selection_empty", "match_all": true },
 			{ "key": "selector", "operand": "text.tex.latex", "match_all": true },
-			{ "key": "preceding_text", "operator": "regex_contains", "operand": "\\\\\\($", "match_all": true },
+			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\\\\\($", "match_all": true },
 			{ "key": "following_text", "operator": "regex_contains", "operand": "^\\\\\\)", "match_all": true },
 		]
 	},
@@ -578,8 +565,19 @@ LaTeX Package keymap for OS X
 			{ "key": "setting.auto_match_enabled" },
 			{ "key": "selection_empty", "match_all": true },
 			{ "key": "selector", "operand": "text.tex.latex meta.environment.math", "match_all": true },
-			{ "key": "preceding_text", "operator": "regex_contains", "operand": "\\\\left\\\\$", "match_all": true },
+			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\\\left\\\\$", "match_all": true },
 			{ "key": "following_text", "operator": "regex_contains", "operand": "^(?:\\s|\\)|\\]|\\}|\\\\|\\$|$)", "match_all": true },
+		]
+	},
+	{
+		"keys": ["backspace"],
+		"command": "run_macro_file", "args": {"file": "res://Packages/LaTeXTools/Delete Left Right Bracket 2.sublime-macro"},
+		"context": [
+			{ "key": "setting.auto_match_enabled" },
+			{ "key": "selection_empty", "match_all": true },
+			{ "key": "selector", "operand": "text.tex.latex meta.environment.math", "match_all": true },
+			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\\\left\\\\\\{$", "match_all": true },
+			{ "key": "following_text", "operator": "regex_contains", "operand": "^\\\\right\\\\\\}", "match_all": true },
 		]
 	},
 
@@ -591,8 +589,19 @@ LaTeX Package keymap for OS X
 			{ "key": "setting.auto_match_enabled" },
 			{ "key": "selection_empty", "match_all": true },
 			{ "key": "selector", "operand": "text.tex.latex meta.environment.math", "match_all": true },
-			{ "key": "preceding_text", "operator": "regex_contains", "operand": "\\\\left$", "match_all": true },
+			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\\\left$", "match_all": true },
 			{ "key": "following_text", "operator": "regex_contains", "operand": "^(?:\\s|\\)|\\]|\\}|\\\\|\\$|$)", "match_all": true },
+		]
+	},
+	{
+		"keys": ["backspace"],
+		"command": "run_macro_file", "args": {"file": "res://Packages/LaTeXTools/Delete Left Right Bracket 1.sublime-macro"},
+		"context": [
+			{ "key": "setting.auto_match_enabled" },
+			{ "key": "selection_empty", "match_all": true },
+			{ "key": "selector", "operand": "text.tex.latex meta.environment.math", "match_all": true },
+			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\\\left\\[$", "match_all": true },
+			{ "key": "following_text", "operator": "regex_contains", "operand": "^\\\\right\\]", "match_all": true },
 		]
 	},
 
@@ -604,54 +613,19 @@ LaTeX Package keymap for OS X
 			{ "key": "setting.auto_match_enabled" },
 			{ "key": "selection_empty", "match_all": true },
 			{ "key": "selector", "operand": "text.tex.latex meta.environment.math", "match_all": true },
-			{ "key": "preceding_text", "operator": "regex_contains", "operand": "\\\\left$", "match_all": true },
+			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\\\left$", "match_all": true },
 			{ "key": "following_text", "operator": "regex_contains", "operand": "^(?:\\s|\\)|\\]|\\}|\\\\|\\$|$)", "match_all": true },
 		]
 	},
-
-	// Remove auto-paired escaped brackets in math blocks
 	{
 		"keys": ["backspace"],
 		"command": "run_macro_file", "args": {"file": "res://Packages/LaTeXTools/Delete Left Right Bracket 1.sublime-macro"},
 		"context": [
 			{ "key": "setting.auto_match_enabled" },
 			{ "key": "selection_empty", "match_all": true },
-			{ "key": "selector", "operand": "text.tex.latex", "match_all": true },
-			{ "key": "preceding_text", "operator": "regex_contains", "operand": "\\\\left.$", "match_all": true },
-			{ "key": "following_text", "operator": "regex_contains", "operand": "^\\\\right.", "match_all": true },
-		]
-	},
-	{
-		"keys": ["backspace"],
-		"command": "run_macro_file", "args": {"file": "res://Packages/LaTeXTools/Delete Left Right Bracket 2 1.sublime-macro"},
-		"context": [
-			{ "key": "setting.auto_match_enabled" },
-			{ "key": "selection_empty", "match_all": true },
-			{ "key": "selector", "operand": "text.tex.latex", "match_all": true },
-			{ "key": "preceding_text", "operator": "regex_contains", "operand": "\\\\left\\\\.$", "match_all": true },
-			{ "key": "following_text", "operator": "regex_contains", "operand": "^\\\\right.", "match_all": true },
-		]
-	},
-	{
-		"keys": ["backspace"],
-		"command": "run_macro_file", "args": {"file": "res://Packages/LaTeXTools/Delete Left Right Bracket 1 2.sublime-macro"},
-		"context": [
-			{ "key": "setting.auto_match_enabled" },
-			{ "key": "selection_empty", "match_all": true },
-			{ "key": "selector", "operand": "text.tex.latex", "match_all": true },
-			{ "key": "preceding_text", "operator": "regex_contains", "operand": "\\\\left.$", "match_all": true },
-			{ "key": "following_text", "operator": "regex_contains", "operand": "^\\\\right\\\\.", "match_all": true },
-		]
-	},
-	{
-		"keys": ["backspace"],
-		"command": "run_macro_file", "args": {"file": "res://Packages/LaTeXTools/Delete Left Right Bracket 2.sublime-macro"},
-		"context": [
-			{ "key": "setting.auto_match_enabled" },
-			{ "key": "selection_empty", "match_all": true },
-			{ "key": "selector", "operand": "text.tex.latex", "match_all": true },
-			{ "key": "preceding_text", "operator": "regex_contains", "operand": "\\\\left\\\\.$", "match_all": true },
-			{ "key": "following_text", "operator": "regex_contains", "operand": "^\\\\right\\\\.", "match_all": true },
+			{ "key": "selector", "operand": "text.tex.latex meta.environment.math", "match_all": true },
+			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\\\left\\($", "match_all": true },
+			{ "key": "following_text", "operator": "regex_contains", "operand": "^\\\\right\\)", "match_all": true },
 		]
 	},
 
@@ -660,15 +634,15 @@ LaTeX Package keymap for OS X
 		"keys": ["enter"], "command": "insert_snippet", "args": {"contents": "\n\t$0\n"},
 		"context": [
 			{ "key": "selector", "operand": "text.tex.latex meta.environment.math" },
-			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:\\\\left)?(?:\\\\)?(\\(|\\[|{)$", "match_all": true },
+			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*(?:\\\\left)?(?:\\\\)?(\\(|\\[|{)$", "match_all": true },
 			{ "key": "following_text", "operator": "regex_contains", "operand": "^(?:\\\\right)?(?:\\\\)?(\\)|\\]|})", "match_all": true },
 		]
 	},
 	{
 		"keys": ["keypad_enter"], "command": "insert_snippet", "args": {"contents": "\n\t$0\n"},
 		"context": [
-			{ "key": "selector", "operand": "text.tex.latex" },
-			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:\\\\left)?(?:\\\\)?(\\(|\\[|{)$", "match_all": true },
+			{ "key": "selector", "operand": "text.tex.latex meta.environment.math" },
+			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*(?:\\\\left)?(?:\\\\)?(\\(|\\[|{)$", "match_all": true },
 			{ "key": "following_text", "operator": "regex_contains", "operand": "^(?:\\\\right)?(?:\\\\)?(\\)|\\]|})", "match_all": true },
 		]
 	},
@@ -687,7 +661,7 @@ LaTeX Package keymap for OS X
 			// don't insert, it inside math environments
 			{ "key": "selector", "operand": "text.tex.latex - meta.environment.math - string.other.math", "match_all": true },
 			// do not insert this if it is escaped
-			{ "key": "preceding_text", "operator": "not_regex_contains", "operand": "(?:\\\\\\\\)*(?:\\\\|\\$)$", "match_all": true },
+			{ "key": "preceding_text", "operator": "not_regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*(?:\\\\|\\$)$", "match_all": true },
 			// don't insert, if there is an open dollar math environment at the end of the line
 			{ "key": "eol_selector", "operator": "not_equal",
 			  "operand": "meta.environment.math.inline.dollar - punctuation.definition.string.end, string.other.math - punctuation.definition.string.end",

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -491,6 +491,7 @@ LaTeX Package keymap for OS X
 		"command": "insert_snippet", "args": {"contents": "{$0\\\\}"},
 		"context": [
 			{ "key": "setting.auto_match_enabled" },
+			{ "key": "latextools.setting.auto_match_escaped_brackets" },
 			{ "key": "selection_empty", "match_all": true },
 			{ "key": "selector", "operand": "text.tex.latex", "match_all": true },
 			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\\\$", "match_all": true },
@@ -502,6 +503,7 @@ LaTeX Package keymap for OS X
 		"command": "run_macro_file", "args": {"file": "res://Packages/LaTeXTools/Delete Left Right Twice.sublime-macro"},
 		"context": [
 			{ "key": "setting.auto_match_enabled" },
+			{ "key": "latextools.setting.auto_match_escaped_brackets" },
 			{ "key": "selection_empty", "match_all": true },
 			{ "key": "selector", "operand": "text.tex.latex", "match_all": true },
 			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\\\\\{$", "match_all": true },
@@ -515,6 +517,7 @@ LaTeX Package keymap for OS X
 		"command": "insert_snippet", "args": {"contents": "[$0\\\\]"},
 		"context": [
 			{ "key": "setting.auto_match_enabled" },
+			{ "key": "latextools.setting.auto_match_escaped_brackets" },
 			{ "key": "selection_empty", "match_all": true },
 			{ "key": "selector", "operand": "text.tex.latex", "match_all": true },
 			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\\\$", "match_all": true },
@@ -526,6 +529,7 @@ LaTeX Package keymap for OS X
 		"command": "run_macro_file", "args": {"file": "res://Packages/LaTeXTools/Delete Left Right Twice.sublime-macro"},
 		"context": [
 			{ "key": "setting.auto_match_enabled" },
+			{ "key": "latextools.setting.auto_match_escaped_brackets" },
 			{ "key": "selection_empty", "match_all": true },
 			{ "key": "selector", "operand": "text.tex.latex", "match_all": true },
 			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\\\\\[$", "match_all": true },
@@ -539,6 +543,7 @@ LaTeX Package keymap for OS X
 		"command": "insert_snippet", "args": {"contents": "($0\\\\)"},
 		"context": [
 			{ "key": "setting.auto_match_enabled" },
+			{ "key": "latextools.setting.auto_match_escaped_brackets" },
 			{ "key": "selection_empty", "match_all": true },
 			{ "key": "selector", "operand": "text.tex.latex", "match_all": true },
 			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\\\$", "match_all": true },
@@ -550,6 +555,7 @@ LaTeX Package keymap for OS X
 		"command": "run_macro_file", "args": {"file": "res://Packages/LaTeXTools/Delete Left Right Twice.sublime-macro"},
 		"context": [
 			{ "key": "setting.auto_match_enabled" },
+			{ "key": "latextools.setting.auto_match_escaped_brackets" },
 			{ "key": "selection_empty", "match_all": true },
 			{ "key": "selector", "operand": "text.tex.latex", "match_all": true },
 			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\\\\\($", "match_all": true },
@@ -563,6 +569,7 @@ LaTeX Package keymap for OS X
 		"command": "insert_snippet", "args": {"contents": "{$0\\\\right\\\\}"},
 		"context": [
 			{ "key": "setting.auto_match_enabled" },
+			{ "key": "latextools.setting.auto_match_math_brackets" },
 			{ "key": "selection_empty", "match_all": true },
 			{ "key": "selector", "operand": "text.tex.latex meta.environment.math", "match_all": true },
 			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\\\left\\\\$", "match_all": true },
@@ -574,6 +581,7 @@ LaTeX Package keymap for OS X
 		"command": "run_macro_file", "args": {"file": "res://Packages/LaTeXTools/Delete Left Right Bracket 2.sublime-macro"},
 		"context": [
 			{ "key": "setting.auto_match_enabled" },
+			{ "key": "latextools.setting.auto_match_math_brackets" },
 			{ "key": "selection_empty", "match_all": true },
 			{ "key": "selector", "operand": "text.tex.latex meta.environment.math", "match_all": true },
 			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\\\left\\\\\\{$", "match_all": true },
@@ -587,6 +595,7 @@ LaTeX Package keymap for OS X
 		"command": "insert_snippet", "args": {"contents": "[$0\\\\right]"},
 		"context": [
 			{ "key": "setting.auto_match_enabled" },
+			{ "key": "latextools.setting.auto_match_math_brackets" },
 			{ "key": "selection_empty", "match_all": true },
 			{ "key": "selector", "operand": "text.tex.latex meta.environment.math", "match_all": true },
 			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\\\left$", "match_all": true },
@@ -598,6 +607,7 @@ LaTeX Package keymap for OS X
 		"command": "run_macro_file", "args": {"file": "res://Packages/LaTeXTools/Delete Left Right Bracket 1.sublime-macro"},
 		"context": [
 			{ "key": "setting.auto_match_enabled" },
+			{ "key": "latextools.setting.auto_match_math_brackets" },
 			{ "key": "selection_empty", "match_all": true },
 			{ "key": "selector", "operand": "text.tex.latex meta.environment.math", "match_all": true },
 			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\\\left\\[$", "match_all": true },
@@ -611,6 +621,7 @@ LaTeX Package keymap for OS X
 		"command": "insert_snippet", "args": {"contents": "($0\\\\right)"},
 		"context": [
 			{ "key": "setting.auto_match_enabled" },
+			{ "key": "latextools.setting.auto_match_math_brackets" },
 			{ "key": "selection_empty", "match_all": true },
 			{ "key": "selector", "operand": "text.tex.latex meta.environment.math", "match_all": true },
 			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\\\left$", "match_all": true },
@@ -622,6 +633,7 @@ LaTeX Package keymap for OS X
 		"command": "run_macro_file", "args": {"file": "res://Packages/LaTeXTools/Delete Left Right Bracket 1.sublime-macro"},
 		"context": [
 			{ "key": "setting.auto_match_enabled" },
+			{ "key": "latextools.setting.auto_match_math_brackets" },
 			{ "key": "selection_empty", "match_all": true },
 			{ "key": "selector", "operand": "text.tex.latex meta.environment.math", "match_all": true },
 			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\\\left\\($", "match_all": true },
@@ -635,6 +647,7 @@ LaTeX Package keymap for OS X
 		"command": "insert_snippet", "args": {"contents": "/$0\\\\right/"},
 		"context": [
 			{ "key": "setting.auto_match_enabled" },
+			{ "key": "latextools.setting.auto_match_math_brackets" },
 			{ "key": "selection_empty", "match_all": true },
 			{ "key": "selector", "operand": "text.tex.latex meta.environment.math", "match_all": true },
 			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\\\left$", "match_all": true },
@@ -646,6 +659,7 @@ LaTeX Package keymap for OS X
 		"command": "run_macro_file", "args": {"file": "res://Packages/LaTeXTools/Delete Left Right Bracket 1.sublime-macro"},
 		"context": [
 			{ "key": "setting.auto_match_enabled" },
+			{ "key": "latextools.setting.auto_match_math_brackets" },
 			{ "key": "selection_empty", "match_all": true },
 			{ "key": "selector", "operand": "text.tex.latex meta.environment.math", "match_all": true },
 			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\\\left/$", "match_all": true },
@@ -659,6 +673,7 @@ LaTeX Package keymap for OS X
 		"command": "insert_snippet", "args": {"contents": "|$0\\\\right|"},
 		"context": [
 			{ "key": "setting.auto_match_enabled" },
+			{ "key": "latextools.setting.auto_match_math_brackets" },
 			{ "key": "selection_empty", "match_all": true },
 			{ "key": "selector", "operand": "text.tex.latex meta.environment.math", "match_all": true },
 			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\\\left$", "match_all": true },
@@ -670,6 +685,7 @@ LaTeX Package keymap for OS X
 		"command": "run_macro_file", "args": {"file": "res://Packages/LaTeXTools/Delete Left Right Bracket 1.sublime-macro"},
 		"context": [
 			{ "key": "setting.auto_match_enabled" },
+			{ "key": "latextools.setting.auto_match_math_brackets" },
 			{ "key": "selection_empty", "match_all": true },
 			{ "key": "selector", "operand": "text.tex.latex meta.environment.math", "match_all": true },
 			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\\\left\\|$", "match_all": true },

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -446,19 +446,6 @@ LaTeX Package keymap for Linux
 	// Auto-pair braces/brackets/parentheses
 	// ------------------------------------------------------------------
 
-	// Override default "wrap_block" binding
-	{
-		"keys": ["{"],
-		"command": "insert_snippet", "args": { "contents": "{$0}" },
-		"context": [
-			{ "key": "indented_block", "match_all": true },
-			{ "key": "setting.auto_match_enabled" },
-			{ "key": "selection_empty", "match_all": true },
-			{ "key": "selector", "operand": "text.tex.latex" },
-			{ "key": "following_text", "operator": "regex_match", "operand": "^$", "match_all": true }
-		]
-	},
-
 	// Auto-pair curly brackets (also in front of $)
 	{
 		"keys": ["{"],
@@ -466,8 +453,8 @@ LaTeX Package keymap for Linux
 		"context": [
 			{ "key": "setting.auto_match_enabled" },
 			{ "key": "selection_empty", "match_all": true },
-			{ "key": "selector", "operand": "text.tex.latex meta.environment.math" },
-			{ "key": "preceding_text", "operator": "not_regex_contains", "operand": "\\\\$", "match_all": true },
+			{ "key": "selector", "operand": "text.tex.latex" },
+			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*$", "match_all": true },
 			{ "key": "following_text", "operator": "regex_contains", "operand": "^(?:\\s|\\)|\\]|\\}|\\$|$)", "match_all": true }
 		]
 	},
@@ -479,8 +466,8 @@ LaTeX Package keymap for Linux
 		"context": [
 			{ "key": "setting.auto_match_enabled" },
 			{ "key": "selection_empty", "match_all": true },
-			{ "key": "selector", "operand": "text.tex.latex meta.environment.math" },
-			{ "key": "preceding_text", "operator": "not_regex_contains", "operand": "\\\\$", "match_all": true },
+			{ "key": "selector", "operand": "text.tex.latex" },
+			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*$", "match_all": true },
 			{ "key": "following_text", "operator": "regex_contains", "operand": "^(?:\\s|\\)|\\]|\\}|\\$|$)", "match_all": true }
 		]
 	},
@@ -492,8 +479,8 @@ LaTeX Package keymap for Linux
 		"context": [
 			{ "key": "setting.auto_match_enabled" },
 			{ "key": "selection_empty", "match_all": true },
-			{ "key": "selector", "operand": "text.tex.latex meta.environment.math" },
-			{ "key": "preceding_text", "operator": "not_regex_contains", "operand": "\\\\$", "match_all": true },
+			{ "key": "selector", "operand": "text.tex.latex" },
+			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*$", "match_all": true },
 			{ "key": "following_text", "operator": "regex_contains", "operand": "^(?:\\s|\\)|\\]|\\}|\\$|$)", "match_all": true }
 		]
 	},
@@ -506,7 +493,7 @@ LaTeX Package keymap for Linux
 			{ "key": "setting.auto_match_enabled" },
 			{ "key": "selection_empty", "match_all": true },
 			{ "key": "selector", "operand": "text.tex.latex", "match_all": true },
-			{ "key": "preceding_text", "operator": "regex_contains", "operand": "\\\\$", "match_all": true },
+			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\\\$", "match_all": true },
 			{ "key": "following_text", "operator": "regex_contains", "operand": "^(?:\\s|\\)|\\]|\\}|\\\\|\\$|$)", "match_all": true },
 		]
 	},
@@ -517,7 +504,7 @@ LaTeX Package keymap for Linux
 			{ "key": "setting.auto_match_enabled" },
 			{ "key": "selection_empty", "match_all": true },
 			{ "key": "selector", "operand": "text.tex.latex", "match_all": true },
-			{ "key": "preceding_text", "operator": "regex_contains", "operand": "\\\\\\{$", "match_all": true },
+			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\\\\\{$", "match_all": true },
 			{ "key": "following_text", "operator": "regex_contains", "operand": "^\\\\\\}", "match_all": true },
 		]
 	},
@@ -530,7 +517,7 @@ LaTeX Package keymap for Linux
 			{ "key": "setting.auto_match_enabled" },
 			{ "key": "selection_empty", "match_all": true },
 			{ "key": "selector", "operand": "text.tex.latex", "match_all": true },
-			{ "key": "preceding_text", "operator": "regex_contains", "operand": "\\\\$", "match_all": true },
+			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\\\$", "match_all": true },
 			{ "key": "following_text", "operator": "regex_contains", "operand": "^(?:\\s|\\)|\\]|\\}|\\\\|\\$|$)", "match_all": true },
 		]
 	},
@@ -541,7 +528,7 @@ LaTeX Package keymap for Linux
 			{ "key": "setting.auto_match_enabled" },
 			{ "key": "selection_empty", "match_all": true },
 			{ "key": "selector", "operand": "text.tex.latex", "match_all": true },
-			{ "key": "preceding_text", "operator": "regex_contains", "operand": "\\\\\\[$", "match_all": true },
+			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\\\\\[$", "match_all": true },
 			{ "key": "following_text", "operator": "regex_contains", "operand": "^\\\\\\]", "match_all": true },
 		]
 	},
@@ -554,7 +541,7 @@ LaTeX Package keymap for Linux
 			{ "key": "setting.auto_match_enabled" },
 			{ "key": "selection_empty", "match_all": true },
 			{ "key": "selector", "operand": "text.tex.latex", "match_all": true },
-			{ "key": "preceding_text", "operator": "regex_contains", "operand": "\\\\$", "match_all": true },
+			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\\\$", "match_all": true },
 			{ "key": "following_text", "operator": "regex_contains", "operand": "^(?:\\s|\\)|\\]|\\}|\\\\|\\$|$)", "match_all": true },
 		]
 	},
@@ -565,7 +552,7 @@ LaTeX Package keymap for Linux
 			{ "key": "setting.auto_match_enabled" },
 			{ "key": "selection_empty", "match_all": true },
 			{ "key": "selector", "operand": "text.tex.latex", "match_all": true },
-			{ "key": "preceding_text", "operator": "regex_contains", "operand": "\\\\\\($", "match_all": true },
+			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\\\\\($", "match_all": true },
 			{ "key": "following_text", "operator": "regex_contains", "operand": "^\\\\\\)", "match_all": true },
 		]
 	},
@@ -578,8 +565,19 @@ LaTeX Package keymap for Linux
 			{ "key": "setting.auto_match_enabled" },
 			{ "key": "selection_empty", "match_all": true },
 			{ "key": "selector", "operand": "text.tex.latex meta.environment.math", "match_all": true },
-			{ "key": "preceding_text", "operator": "regex_contains", "operand": "\\\\left\\\\$", "match_all": true },
+			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\\\left\\\\$", "match_all": true },
 			{ "key": "following_text", "operator": "regex_contains", "operand": "^(?:\\s|\\)|\\]|\\}|\\\\|\\$|$)", "match_all": true },
+		]
+	},
+	{
+		"keys": ["backspace"],
+		"command": "run_macro_file", "args": {"file": "res://Packages/LaTeXTools/Delete Left Right Bracket 2.sublime-macro"},
+		"context": [
+			{ "key": "setting.auto_match_enabled" },
+			{ "key": "selection_empty", "match_all": true },
+			{ "key": "selector", "operand": "text.tex.latex meta.environment.math", "match_all": true },
+			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\\\left\\\\\\{$", "match_all": true },
+			{ "key": "following_text", "operator": "regex_contains", "operand": "^\\\\right\\\\\\}", "match_all": true },
 		]
 	},
 
@@ -591,8 +589,19 @@ LaTeX Package keymap for Linux
 			{ "key": "setting.auto_match_enabled" },
 			{ "key": "selection_empty", "match_all": true },
 			{ "key": "selector", "operand": "text.tex.latex meta.environment.math", "match_all": true },
-			{ "key": "preceding_text", "operator": "regex_contains", "operand": "\\\\left$", "match_all": true },
+			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\\\left$", "match_all": true },
 			{ "key": "following_text", "operator": "regex_contains", "operand": "^(?:\\s|\\)|\\]|\\}|\\\\|\\$|$)", "match_all": true },
+		]
+	},
+	{
+		"keys": ["backspace"],
+		"command": "run_macro_file", "args": {"file": "res://Packages/LaTeXTools/Delete Left Right Bracket 1.sublime-macro"},
+		"context": [
+			{ "key": "setting.auto_match_enabled" },
+			{ "key": "selection_empty", "match_all": true },
+			{ "key": "selector", "operand": "text.tex.latex meta.environment.math", "match_all": true },
+			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\\\left\\[$", "match_all": true },
+			{ "key": "following_text", "operator": "regex_contains", "operand": "^\\\\right\\]", "match_all": true },
 		]
 	},
 
@@ -604,54 +613,19 @@ LaTeX Package keymap for Linux
 			{ "key": "setting.auto_match_enabled" },
 			{ "key": "selection_empty", "match_all": true },
 			{ "key": "selector", "operand": "text.tex.latex meta.environment.math", "match_all": true },
-			{ "key": "preceding_text", "operator": "regex_contains", "operand": "\\\\left$", "match_all": true },
+			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\\\left$", "match_all": true },
 			{ "key": "following_text", "operator": "regex_contains", "operand": "^(?:\\s|\\)|\\]|\\}|\\\\|\\$|$)", "match_all": true },
 		]
 	},
-
-	// Remove auto-paired escaped brackets in math blocks
 	{
 		"keys": ["backspace"],
 		"command": "run_macro_file", "args": {"file": "res://Packages/LaTeXTools/Delete Left Right Bracket 1.sublime-macro"},
 		"context": [
 			{ "key": "setting.auto_match_enabled" },
 			{ "key": "selection_empty", "match_all": true },
-			{ "key": "selector", "operand": "text.tex.latex", "match_all": true },
-			{ "key": "preceding_text", "operator": "regex_contains", "operand": "\\\\left.$", "match_all": true },
-			{ "key": "following_text", "operator": "regex_contains", "operand": "^\\\\right.", "match_all": true },
-		]
-	},
-	{
-		"keys": ["backspace"],
-		"command": "run_macro_file", "args": {"file": "res://Packages/LaTeXTools/Delete Left Right Bracket 2 1.sublime-macro"},
-		"context": [
-			{ "key": "setting.auto_match_enabled" },
-			{ "key": "selection_empty", "match_all": true },
-			{ "key": "selector", "operand": "text.tex.latex", "match_all": true },
-			{ "key": "preceding_text", "operator": "regex_contains", "operand": "\\\\left\\\\.$", "match_all": true },
-			{ "key": "following_text", "operator": "regex_contains", "operand": "^\\\\right.", "match_all": true },
-		]
-	},
-	{
-		"keys": ["backspace"],
-		"command": "run_macro_file", "args": {"file": "res://Packages/LaTeXTools/Delete Left Right Bracket 1 2.sublime-macro"},
-		"context": [
-			{ "key": "setting.auto_match_enabled" },
-			{ "key": "selection_empty", "match_all": true },
-			{ "key": "selector", "operand": "text.tex.latex", "match_all": true },
-			{ "key": "preceding_text", "operator": "regex_contains", "operand": "\\\\left.$", "match_all": true },
-			{ "key": "following_text", "operator": "regex_contains", "operand": "^\\\\right\\\\.", "match_all": true },
-		]
-	},
-	{
-		"keys": ["backspace"],
-		"command": "run_macro_file", "args": {"file": "res://Packages/LaTeXTools/Delete Left Right Bracket 2.sublime-macro"},
-		"context": [
-			{ "key": "setting.auto_match_enabled" },
-			{ "key": "selection_empty", "match_all": true },
-			{ "key": "selector", "operand": "text.tex.latex", "match_all": true },
-			{ "key": "preceding_text", "operator": "regex_contains", "operand": "\\\\left\\\\.$", "match_all": true },
-			{ "key": "following_text", "operator": "regex_contains", "operand": "^\\\\right\\\\.", "match_all": true },
+			{ "key": "selector", "operand": "text.tex.latex meta.environment.math", "match_all": true },
+			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\\\left\\($", "match_all": true },
+			{ "key": "following_text", "operator": "regex_contains", "operand": "^\\\\right\\)", "match_all": true },
 		]
 	},
 
@@ -659,16 +633,16 @@ LaTeX Package keymap for Linux
 	{
 		"keys": ["enter"], "command": "insert_snippet", "args": {"contents": "\n\t$0\n"},
 		"context": [
-			{ "key": "selector", "operand": "text.tex.latex" },
-			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:\\\\left)?(?:\\\\)?(\\(|\\[|{)$", "match_all": true },
+			{ "key": "selector", "operand": "text.tex.latex meta.environment.math" },
+			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*(?:\\\\left)?(?:\\\\)?(\\(|\\[|{)$", "match_all": true },
 			{ "key": "following_text", "operator": "regex_contains", "operand": "^(?:\\\\right)?(?:\\\\)?(\\)|\\]|})", "match_all": true },
 		]
 	},
 	{
 		"keys": ["keypad_enter"], "command": "insert_snippet", "args": {"contents": "\n\t$0\n"},
 		"context": [
-			{ "key": "selector", "operand": "text.tex.latex" },
-			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:\\\\left)?(?:\\\\)?(\\(|\\[|{)$", "match_all": true },
+			{ "key": "selector", "operand": "text.tex.latex meta.environment.math" },
+			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*(?:\\\\left)?(?:\\\\)?(\\(|\\[|{)$", "match_all": true },
 			{ "key": "following_text", "operator": "regex_contains", "operand": "^(?:\\\\right)?(?:\\\\)?(\\)|\\]|})", "match_all": true },
 		]
 	},
@@ -687,7 +661,7 @@ LaTeX Package keymap for Linux
 			// don't insert, it inside math environments
 			{ "key": "selector", "operand": "text.tex.latex - meta.environment.math - string.other.math", "match_all": true },
 			// do not insert this if it is escaped
-			{ "key": "preceding_text", "operator": "not_regex_contains", "operand": "(?:\\\\\\\\)*(?:\\\\|\\$)$", "match_all": true },
+			{ "key": "preceding_text", "operator": "not_regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*(?:\\\\|\\$)$", "match_all": true },
 			// don't insert, if there is an open dollar math environment at the end of the line
 			{ "key": "eol_selector", "operator": "not_equal",
 			  "operand": "meta.environment.math.inline.dollar - punctuation.definition.string.end, string.other.math - punctuation.definition.string.end",
@@ -737,7 +711,7 @@ LaTeX Package keymap for Linux
 			{ "key": "selection_empty", "match_all": true },
 			{ "key": "selector", "operand": "text.tex.latex meta.environment.math.block.dollar" },
 			// do not insert this if it is escaped
-			{ "key": "preceding_text", "operator": "not_regex_contains", "operand": "(?:\\\\{2})*(?:\\\\|\\$)$", "match_all": true }
+			{ "key": "preceding_text", "operator": "not_regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*(?:\\\\|\\$)$", "match_all": true }
 		]
 	},
 

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -491,6 +491,7 @@ LaTeX Package keymap for Linux
 		"command": "insert_snippet", "args": {"contents": "{$0\\\\}"},
 		"context": [
 			{ "key": "setting.auto_match_enabled" },
+			{ "key": "latextools.setting.auto_match_escaped_brackets" },
 			{ "key": "selection_empty", "match_all": true },
 			{ "key": "selector", "operand": "text.tex.latex", "match_all": true },
 			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\\\$", "match_all": true },
@@ -502,6 +503,7 @@ LaTeX Package keymap for Linux
 		"command": "run_macro_file", "args": {"file": "res://Packages/LaTeXTools/Delete Left Right Twice.sublime-macro"},
 		"context": [
 			{ "key": "setting.auto_match_enabled" },
+			{ "key": "latextools.setting.auto_match_escaped_brackets" },
 			{ "key": "selection_empty", "match_all": true },
 			{ "key": "selector", "operand": "text.tex.latex", "match_all": true },
 			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\\\\\{$", "match_all": true },
@@ -515,6 +517,7 @@ LaTeX Package keymap for Linux
 		"command": "insert_snippet", "args": {"contents": "[$0\\\\]"},
 		"context": [
 			{ "key": "setting.auto_match_enabled" },
+			{ "key": "latextools.setting.auto_match_escaped_brackets" },
 			{ "key": "selection_empty", "match_all": true },
 			{ "key": "selector", "operand": "text.tex.latex", "match_all": true },
 			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\\\$", "match_all": true },
@@ -526,6 +529,7 @@ LaTeX Package keymap for Linux
 		"command": "run_macro_file", "args": {"file": "res://Packages/LaTeXTools/Delete Left Right Twice.sublime-macro"},
 		"context": [
 			{ "key": "setting.auto_match_enabled" },
+			{ "key": "latextools.setting.auto_match_escaped_brackets" },
 			{ "key": "selection_empty", "match_all": true },
 			{ "key": "selector", "operand": "text.tex.latex", "match_all": true },
 			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\\\\\[$", "match_all": true },
@@ -539,6 +543,7 @@ LaTeX Package keymap for Linux
 		"command": "insert_snippet", "args": {"contents": "($0\\\\)"},
 		"context": [
 			{ "key": "setting.auto_match_enabled" },
+			{ "key": "latextools.setting.auto_match_escaped_brackets" },
 			{ "key": "selection_empty", "match_all": true },
 			{ "key": "selector", "operand": "text.tex.latex", "match_all": true },
 			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\\\$", "match_all": true },
@@ -550,6 +555,7 @@ LaTeX Package keymap for Linux
 		"command": "run_macro_file", "args": {"file": "res://Packages/LaTeXTools/Delete Left Right Twice.sublime-macro"},
 		"context": [
 			{ "key": "setting.auto_match_enabled" },
+			{ "key": "latextools.setting.auto_match_escaped_brackets" },
 			{ "key": "selection_empty", "match_all": true },
 			{ "key": "selector", "operand": "text.tex.latex", "match_all": true },
 			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\\\\\($", "match_all": true },
@@ -563,6 +569,7 @@ LaTeX Package keymap for Linux
 		"command": "insert_snippet", "args": {"contents": "{$0\\\\right\\\\}"},
 		"context": [
 			{ "key": "setting.auto_match_enabled" },
+			{ "key": "latextools.setting.auto_match_math_brackets" },
 			{ "key": "selection_empty", "match_all": true },
 			{ "key": "selector", "operand": "text.tex.latex meta.environment.math", "match_all": true },
 			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\\\left\\\\$", "match_all": true },
@@ -574,6 +581,7 @@ LaTeX Package keymap for Linux
 		"command": "run_macro_file", "args": {"file": "res://Packages/LaTeXTools/Delete Left Right Bracket 2.sublime-macro"},
 		"context": [
 			{ "key": "setting.auto_match_enabled" },
+			{ "key": "latextools.setting.auto_match_math_brackets" },
 			{ "key": "selection_empty", "match_all": true },
 			{ "key": "selector", "operand": "text.tex.latex meta.environment.math", "match_all": true },
 			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\\\left\\\\\\{$", "match_all": true },
@@ -587,6 +595,7 @@ LaTeX Package keymap for Linux
 		"command": "insert_snippet", "args": {"contents": "[$0\\\\right]"},
 		"context": [
 			{ "key": "setting.auto_match_enabled" },
+			{ "key": "latextools.setting.auto_match_math_brackets" },
 			{ "key": "selection_empty", "match_all": true },
 			{ "key": "selector", "operand": "text.tex.latex meta.environment.math", "match_all": true },
 			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\\\left$", "match_all": true },
@@ -598,6 +607,7 @@ LaTeX Package keymap for Linux
 		"command": "run_macro_file", "args": {"file": "res://Packages/LaTeXTools/Delete Left Right Bracket 1.sublime-macro"},
 		"context": [
 			{ "key": "setting.auto_match_enabled" },
+			{ "key": "latextools.setting.auto_match_math_brackets" },
 			{ "key": "selection_empty", "match_all": true },
 			{ "key": "selector", "operand": "text.tex.latex meta.environment.math", "match_all": true },
 			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\\\left\\[$", "match_all": true },
@@ -611,6 +621,7 @@ LaTeX Package keymap for Linux
 		"command": "insert_snippet", "args": {"contents": "($0\\\\right)"},
 		"context": [
 			{ "key": "setting.auto_match_enabled" },
+			{ "key": "latextools.setting.auto_match_math_brackets" },
 			{ "key": "selection_empty", "match_all": true },
 			{ "key": "selector", "operand": "text.tex.latex meta.environment.math", "match_all": true },
 			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\\\left$", "match_all": true },
@@ -622,6 +633,7 @@ LaTeX Package keymap for Linux
 		"command": "run_macro_file", "args": {"file": "res://Packages/LaTeXTools/Delete Left Right Bracket 1.sublime-macro"},
 		"context": [
 			{ "key": "setting.auto_match_enabled" },
+			{ "key": "latextools.setting.auto_match_math_brackets" },
 			{ "key": "selection_empty", "match_all": true },
 			{ "key": "selector", "operand": "text.tex.latex meta.environment.math", "match_all": true },
 			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\\\left\\($", "match_all": true },
@@ -635,6 +647,7 @@ LaTeX Package keymap for Linux
 		"command": "insert_snippet", "args": {"contents": "/$0\\\\right/"},
 		"context": [
 			{ "key": "setting.auto_match_enabled" },
+			{ "key": "latextools.setting.auto_match_math_brackets" },
 			{ "key": "selection_empty", "match_all": true },
 			{ "key": "selector", "operand": "text.tex.latex meta.environment.math", "match_all": true },
 			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\\\left$", "match_all": true },
@@ -646,6 +659,7 @@ LaTeX Package keymap for Linux
 		"command": "run_macro_file", "args": {"file": "res://Packages/LaTeXTools/Delete Left Right Bracket 1.sublime-macro"},
 		"context": [
 			{ "key": "setting.auto_match_enabled" },
+			{ "key": "latextools.setting.auto_match_math_brackets" },
 			{ "key": "selection_empty", "match_all": true },
 			{ "key": "selector", "operand": "text.tex.latex meta.environment.math", "match_all": true },
 			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\\\left/$", "match_all": true },
@@ -659,6 +673,7 @@ LaTeX Package keymap for Linux
 		"command": "insert_snippet", "args": {"contents": "|$0\\\\right|"},
 		"context": [
 			{ "key": "setting.auto_match_enabled" },
+			{ "key": "latextools.setting.auto_match_math_brackets" },
 			{ "key": "selection_empty", "match_all": true },
 			{ "key": "selector", "operand": "text.tex.latex meta.environment.math", "match_all": true },
 			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\\\left$", "match_all": true },
@@ -670,6 +685,7 @@ LaTeX Package keymap for Linux
 		"command": "run_macro_file", "args": {"file": "res://Packages/LaTeXTools/Delete Left Right Bracket 1.sublime-macro"},
 		"context": [
 			{ "key": "setting.auto_match_enabled" },
+			{ "key": "latextools.setting.auto_match_math_brackets" },
 			{ "key": "selection_empty", "match_all": true },
 			{ "key": "selector", "operand": "text.tex.latex meta.environment.math", "match_all": true },
 			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\\\left\\|$", "match_all": true },

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -557,7 +557,7 @@ LaTeX Package keymap for Linux
 		]
 	},
 
-	// Auto-pair escaped curly braces in math blocks
+	// Auto-pair left/right curly braces in math blocks
 	{
 		"keys": ["{"],
 		"command": "insert_snippet", "args": {"contents": "{$0\\\\right\\\\}"},
@@ -566,7 +566,7 @@ LaTeX Package keymap for Linux
 			{ "key": "selection_empty", "match_all": true },
 			{ "key": "selector", "operand": "text.tex.latex meta.environment.math", "match_all": true },
 			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\\\left\\\\$", "match_all": true },
-			{ "key": "following_text", "operator": "regex_contains", "operand": "^(?:\\s|\\)|\\]|\\}|\\\\|\\$|$)", "match_all": true },
+			{ "key": "following_text", "operator": "regex_contains", "operand": "^(?:\\s|\\)|\\]|\\}|\\\\(?!right\\\\\\})|\\$|$)", "match_all": true },
 		]
 	},
 	{
@@ -590,7 +590,7 @@ LaTeX Package keymap for Linux
 			{ "key": "selection_empty", "match_all": true },
 			{ "key": "selector", "operand": "text.tex.latex meta.environment.math", "match_all": true },
 			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\\\left$", "match_all": true },
-			{ "key": "following_text", "operator": "regex_contains", "operand": "^(?:\\s|\\)|\\]|\\}|\\\\|\\$|$)", "match_all": true },
+			{ "key": "following_text", "operator": "regex_contains", "operand": "^(?:\\s|\\)|\\]|\\}|\\\\(?!right\\])|\\$|$)", "match_all": true },
 		]
 	},
 	{
@@ -614,7 +614,7 @@ LaTeX Package keymap for Linux
 			{ "key": "selection_empty", "match_all": true },
 			{ "key": "selector", "operand": "text.tex.latex meta.environment.math", "match_all": true },
 			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\\\left$", "match_all": true },
-			{ "key": "following_text", "operator": "regex_contains", "operand": "^(?:\\s|\\)|\\]|\\}|\\\\|\\$|$)", "match_all": true },
+			{ "key": "following_text", "operator": "regex_contains", "operand": "^(?:\\s|\\)|\\]|\\}|\\\\(?!right\\))|\\$|$)", "match_all": true },
 		]
 	},
 	{
@@ -629,21 +629,73 @@ LaTeX Package keymap for Linux
 		]
 	},
 
+	// Auto-pair left/right slashes in math blocks
+	{
+		"keys": ["/"],
+		"command": "insert_snippet", "args": {"contents": "/$0\\\\right/"},
+		"context": [
+			{ "key": "setting.auto_match_enabled" },
+			{ "key": "selection_empty", "match_all": true },
+			{ "key": "selector", "operand": "text.tex.latex meta.environment.math", "match_all": true },
+			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\\\left$", "match_all": true },
+			{ "key": "following_text", "operator": "regex_contains", "operand": "^(?:\\s|\\)|\\]|\\}|\\\\(?!right/)|\\$|$)", "match_all": true },
+		]
+	},
+	{
+		"keys": ["backspace"],
+		"command": "run_macro_file", "args": {"file": "res://Packages/LaTeXTools/Delete Left Right Bracket 1.sublime-macro"},
+		"context": [
+			{ "key": "setting.auto_match_enabled" },
+			{ "key": "selection_empty", "match_all": true },
+			{ "key": "selector", "operand": "text.tex.latex meta.environment.math", "match_all": true },
+			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\\\left/$", "match_all": true },
+			{ "key": "following_text", "operator": "regex_contains", "operand": "^\\\\right/", "match_all": true },
+		]
+	},
+
+	// Auto-pair left/right pipes in math blocks
+	{
+		"keys": ["|"],
+		"command": "insert_snippet", "args": {"contents": "|$0\\\\right|"},
+		"context": [
+			{ "key": "setting.auto_match_enabled" },
+			{ "key": "selection_empty", "match_all": true },
+			{ "key": "selector", "operand": "text.tex.latex meta.environment.math", "match_all": true },
+			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\\\left$", "match_all": true },
+			{ "key": "following_text", "operator": "regex_contains", "operand": "^(?:\\s|\\)|\\]|\\}|\\\\(?!right\\|)|\\$|$)", "match_all": true },
+		]
+	},
+	{
+		"keys": ["backspace"],
+		"command": "run_macro_file", "args": {"file": "res://Packages/LaTeXTools/Delete Left Right Bracket 1.sublime-macro"},
+		"context": [
+			{ "key": "setting.auto_match_enabled" },
+			{ "key": "selection_empty", "match_all": true },
+			{ "key": "selector", "operand": "text.tex.latex meta.environment.math", "match_all": true },
+			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\\\left\\|$", "match_all": true },
+			{ "key": "following_text", "operator": "regex_contains", "operand": "^\\\\right\\|", "match_all": true },
+		]
+	},
+
+	// ------------------------------------------------------------------
+	// Indent content between braces/brackets/parentheses
+	// ------------------------------------------------------------------
+
 	// Indent content
 	{
 		"keys": ["enter"], "command": "insert_snippet", "args": {"contents": "\n\t$0\n"},
 		"context": [
 			{ "key": "selector", "operand": "text.tex.latex meta.environment.math" },
-			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*(?:\\\\left)?(?:\\\\)?(\\(|\\[|{)$", "match_all": true },
-			{ "key": "following_text", "operator": "regex_contains", "operand": "^(?:\\\\right)?(?:\\\\)?(\\)|\\]|})", "match_all": true },
+			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*(?:\\\\left)?(?:\\\\)?[(\\[{/|]$", "match_all": true },
+			{ "key": "following_text", "operator": "regex_contains", "operand": "^(?:\\\\right)?(?:\\\\)?[)\\]}/|]", "match_all": true },
 		]
 	},
 	{
 		"keys": ["keypad_enter"], "command": "insert_snippet", "args": {"contents": "\n\t$0\n"},
 		"context": [
 			{ "key": "selector", "operand": "text.tex.latex meta.environment.math" },
-			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*(?:\\\\left)?(?:\\\\)?(\\(|\\[|{)$", "match_all": true },
-			{ "key": "following_text", "operator": "regex_contains", "operand": "^(?:\\\\right)?(?:\\\\)?(\\)|\\]|})", "match_all": true },
+			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*(?:\\\\left)?(?:\\\\)?[(\\[{/|]$", "match_all": true },
+			{ "key": "following_text", "operator": "regex_contains", "operand": "^(?:\\\\right)?(?:\\\\)?[)\\]}/|]", "match_all": true },
 		]
 	},
 

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -458,6 +458,27 @@ LaTeX Package keymap for Linux
 			{ "key": "following_text", "operator": "regex_contains", "operand": "^(?:\\s|\\)|\\]|\\}|\\$|$)", "match_all": true }
 		]
 	},
+	{
+		"keys": [" "], "command": "insert_snippet", "args": {"contents": " $0 "},
+		"context": [
+			{ "key": "setting.auto_match_enabled" },
+			{ "key": "selection_empty", "match_all": true },
+			{ "key": "selector", "operand": "text.tex.latex", "match_all": true },
+			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\{$", "match_all": true },
+			{ "key": "following_text", "operator": "regex_contains", "operand": "^\\}", "match_all": true },
+		]
+	},
+	{
+		"keys": ["backspace"],
+		"command": "run_macro_file", "args": {"file": "res://Packages/Default/Delete Left Right.sublime-macro"},
+		"context": [
+			{ "key": "setting.auto_match_enabled" },
+			{ "key": "selection_empty", "match_all": true },
+			{ "key": "selector", "operand": "text.tex.latex", "match_all": true },
+			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\{ $", "match_all": true },
+			{ "key": "following_text", "operator": "regex_contains", "operand": "^ \\}", "match_all": true },
+		]
+	},
 
 	// Auto-pair square brackets (also in front of $)
 	{
@@ -471,6 +492,27 @@ LaTeX Package keymap for Linux
 			{ "key": "following_text", "operator": "regex_contains", "operand": "^(?:\\s|\\)|\\]|\\}|\\$|$)", "match_all": true }
 		]
 	},
+	{
+		"keys": [" "], "command": "insert_snippet", "args": {"contents": " $0 "},
+		"context": [
+			{ "key": "setting.auto_match_enabled" },
+			{ "key": "selection_empty", "match_all": true },
+			{ "key": "selector", "operand": "text.tex.latex", "match_all": true },
+			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\[$", "match_all": true },
+			{ "key": "following_text", "operator": "regex_contains", "operand": "^\\]", "match_all": true },
+		]
+	},
+	{
+		"keys": ["backspace"],
+		"command": "run_macro_file", "args": {"file": "res://Packages/Default/Delete Left Right.sublime-macro"},
+		"context": [
+			{ "key": "setting.auto_match_enabled" },
+			{ "key": "selection_empty", "match_all": true },
+			{ "key": "selector", "operand": "text.tex.latex", "match_all": true },
+			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\[ $", "match_all": true },
+			{ "key": "following_text", "operator": "regex_contains", "operand": "^ \\]", "match_all": true },
+		]
+	},
 
 	// Auto-pair parentheses (also in front of $)
 	{
@@ -482,6 +524,27 @@ LaTeX Package keymap for Linux
 			{ "key": "selector", "operand": "text.tex.latex" },
 			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*$", "match_all": true },
 			{ "key": "following_text", "operator": "regex_contains", "operand": "^(?:\\s|\\)|\\]|\\}|\\$|$)", "match_all": true }
+		]
+	},
+	{
+		"keys": [" "], "command": "insert_snippet", "args": {"contents": " $0 "},
+		"context": [
+			{ "key": "setting.auto_match_enabled" },
+			{ "key": "selection_empty", "match_all": true },
+			{ "key": "selector", "operand": "text.tex.latex", "match_all": true },
+			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\($", "match_all": true },
+			{ "key": "following_text", "operator": "regex_contains", "operand": "^\\)", "match_all": true },
+		]
+	},
+	{
+		"keys": ["backspace"],
+		"command": "run_macro_file", "args": {"file": "res://Packages/Default/Delete Left Right.sublime-macro"},
+		"context": [
+			{ "key": "setting.auto_match_enabled" },
+			{ "key": "selection_empty", "match_all": true },
+			{ "key": "selector", "operand": "text.tex.latex", "match_all": true },
+			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\( $", "match_all": true },
+			{ "key": "following_text", "operator": "regex_contains", "operand": "^ \\)", "match_all": true },
 		]
 	},
 
@@ -510,6 +573,29 @@ LaTeX Package keymap for Linux
 			{ "key": "following_text", "operator": "regex_contains", "operand": "^\\\\\\}", "match_all": true },
 		]
 	},
+	{
+		"keys": [" "], "command": "insert_snippet", "args": {"contents": " $0 "},
+		"context": [
+			{ "key": "setting.auto_match_enabled" },
+			{ "key": "latextools.setting.auto_match_escaped_brackets" },
+			{ "key": "selection_empty", "match_all": true },
+			{ "key": "selector", "operand": "text.tex.latex", "match_all": true },
+			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\\\\\{$", "match_all": true },
+			{ "key": "following_text", "operator": "regex_contains", "operand": "^\\\\\\}", "match_all": true },
+		]
+	},
+	{
+		"keys": ["backspace"],
+		"command": "run_macro_file", "args": {"file": "res://Packages/Default/Delete Left Right.sublime-macro"},
+		"context": [
+			{ "key": "setting.auto_match_enabled" },
+			{ "key": "latextools.setting.auto_match_escaped_brackets" },
+			{ "key": "selection_empty", "match_all": true },
+			{ "key": "selector", "operand": "text.tex.latex", "match_all": true },
+			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\\\\\{ $", "match_all": true },
+			{ "key": "following_text", "operator": "regex_contains", "operand": "^ \\\\\\}", "match_all": true },
+		]
+	},
 
 	// Auto-pair escaped square brackets
 	{
@@ -534,6 +620,29 @@ LaTeX Package keymap for Linux
 			{ "key": "selector", "operand": "text.tex.latex", "match_all": true },
 			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\\\\\[$", "match_all": true },
 			{ "key": "following_text", "operator": "regex_contains", "operand": "^\\\\\\]", "match_all": true },
+		]
+	},
+	{
+		"keys": [" "], "command": "insert_snippet", "args": {"contents": " $0 "},
+		"context": [
+			{ "key": "setting.auto_match_enabled" },
+			{ "key": "latextools.setting.auto_match_escaped_brackets" },
+			{ "key": "selection_empty", "match_all": true },
+			{ "key": "selector", "operand": "text.tex.latex", "match_all": true },
+			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\\\\\[$", "match_all": true },
+			{ "key": "following_text", "operator": "regex_contains", "operand": "^\\\\\\]", "match_all": true },
+		]
+	},
+	{
+		"keys": ["backspace"],
+		"command": "run_macro_file", "args": {"file": "res://Packages/Default/Delete Left Right.sublime-macro"},
+		"context": [
+			{ "key": "setting.auto_match_enabled" },
+			{ "key": "latextools.setting.auto_match_escaped_brackets" },
+			{ "key": "selection_empty", "match_all": true },
+			{ "key": "selector", "operand": "text.tex.latex", "match_all": true },
+			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\\\\\[ $", "match_all": true },
+			{ "key": "following_text", "operator": "regex_contains", "operand": "^ \\\\\\]", "match_all": true },
 		]
 	},
 
@@ -562,6 +671,29 @@ LaTeX Package keymap for Linux
 			{ "key": "following_text", "operator": "regex_contains", "operand": "^\\\\\\)", "match_all": true },
 		]
 	},
+	{
+		"keys": [" "], "command": "insert_snippet", "args": {"contents": " $0 "},
+		"context": [
+			{ "key": "setting.auto_match_enabled" },
+			{ "key": "latextools.setting.auto_match_escaped_brackets" },
+			{ "key": "selection_empty", "match_all": true },
+			{ "key": "selector", "operand": "text.tex.latex", "match_all": true },
+			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\\\\\($", "match_all": true },
+			{ "key": "following_text", "operator": "regex_contains", "operand": "^\\\\\\)", "match_all": true },
+		]
+	},
+	{
+		"keys": ["backspace"],
+		"command": "run_macro_file", "args": {"file": "res://Packages/Default/Delete Left Right.sublime-macro"},
+		"context": [
+			{ "key": "setting.auto_match_enabled" },
+			{ "key": "latextools.setting.auto_match_escaped_brackets" },
+			{ "key": "selection_empty", "match_all": true },
+			{ "key": "selector", "operand": "text.tex.latex", "match_all": true },
+			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\\\\\( $", "match_all": true },
+			{ "key": "following_text", "operator": "regex_contains", "operand": "^ \\\\\\)", "match_all": true },
+		]
+	},
 
 	// Auto-pair left/right curly braces in math blocks
 	{
@@ -586,6 +718,29 @@ LaTeX Package keymap for Linux
 			{ "key": "selector", "operand": "text.tex.latex meta.environment.math", "match_all": true },
 			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\\\left\\\\\\{$", "match_all": true },
 			{ "key": "following_text", "operator": "regex_contains", "operand": "^\\\\right\\\\\\}", "match_all": true },
+		]
+	},
+	{
+		"keys": [" "], "command": "insert_snippet", "args": {"contents": " $0 "},
+		"context": [
+			{ "key": "setting.auto_match_enabled" },
+			{ "key": "latextools.setting.auto_match_math_brackets" },
+			{ "key": "selection_empty", "match_all": true },
+			{ "key": "selector", "operand": "text.tex.latex meta.environment.math", "match_all": true },
+			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\\\left\\\\\\{$", "match_all": true },
+			{ "key": "following_text", "operator": "regex_contains", "operand": "^\\\\right\\\\\\}", "match_all": true },
+		]
+	},
+	{
+		"keys": ["backspace"],
+		"command": "run_macro_file", "args": {"file": "res://Packages/Default/Delete Left Right.sublime-macro"},
+		"context": [
+			{ "key": "setting.auto_match_enabled" },
+			{ "key": "latextools.setting.auto_match_math_brackets" },
+			{ "key": "selection_empty", "match_all": true },
+			{ "key": "selector", "operand": "text.tex.latex meta.environment.math", "match_all": true },
+			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\\\left\\\\\\{ $", "match_all": true },
+			{ "key": "following_text", "operator": "regex_contains", "operand": "^ \\\\right\\\\\\}", "match_all": true },
 		]
 	},
 
@@ -614,6 +769,29 @@ LaTeX Package keymap for Linux
 			{ "key": "following_text", "operator": "regex_contains", "operand": "^\\\\right\\]", "match_all": true },
 		]
 	},
+	{
+		"keys": [" "], "command": "insert_snippet", "args": {"contents": " $0 "},
+		"context": [
+			{ "key": "setting.auto_match_enabled" },
+			{ "key": "latextools.setting.auto_match_math_brackets" },
+			{ "key": "selection_empty", "match_all": true },
+			{ "key": "selector", "operand": "text.tex.latex meta.environment.math", "match_all": true },
+			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\\\left\\[$", "match_all": true },
+			{ "key": "following_text", "operator": "regex_contains", "operand": "^\\\\right\\]", "match_all": true },
+		]
+	},
+	{
+		"keys": ["backspace"],
+		"command": "run_macro_file", "args": {"file": "res://Packages/Default/Delete Left Right.sublime-macro"},
+		"context": [
+			{ "key": "setting.auto_match_enabled" },
+			{ "key": "latextools.setting.auto_match_math_brackets" },
+			{ "key": "selection_empty", "match_all": true },
+			{ "key": "selector", "operand": "text.tex.latex meta.environment.math", "match_all": true },
+			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\\\left\\[ $", "match_all": true },
+			{ "key": "following_text", "operator": "regex_contains", "operand": "^ \\\\right\\]", "match_all": true },
+		]
+	},
 
 	// Auto-pair escpaed parentheses in math blocks
 	{
@@ -638,6 +816,29 @@ LaTeX Package keymap for Linux
 			{ "key": "selector", "operand": "text.tex.latex meta.environment.math", "match_all": true },
 			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\\\left\\($", "match_all": true },
 			{ "key": "following_text", "operator": "regex_contains", "operand": "^\\\\right\\)", "match_all": true },
+		]
+	},
+	{
+		"keys": [" "], "command": "insert_snippet", "args": {"contents": " $0 "},
+		"context": [
+			{ "key": "setting.auto_match_enabled" },
+			{ "key": "latextools.setting.auto_match_math_brackets" },
+			{ "key": "selection_empty", "match_all": true },
+			{ "key": "selector", "operand": "text.tex.latex meta.environment.math", "match_all": true },
+			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\\\left\\($", "match_all": true },
+			{ "key": "following_text", "operator": "regex_contains", "operand": "^\\\\right\\)", "match_all": true },
+		]
+	},
+	{
+		"keys": ["backspace"],
+		"command": "run_macro_file", "args": {"file": "res://Packages/Default/Delete Left Right.sublime-macro"},
+		"context": [
+			{ "key": "setting.auto_match_enabled" },
+			{ "key": "latextools.setting.auto_match_math_brackets" },
+			{ "key": "selection_empty", "match_all": true },
+			{ "key": "selector", "operand": "text.tex.latex meta.environment.math", "match_all": true },
+			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\\\left\\( $", "match_all": true },
+			{ "key": "following_text", "operator": "regex_contains", "operand": "^ \\\\right\\)", "match_all": true },
 		]
 	},
 
@@ -666,6 +867,29 @@ LaTeX Package keymap for Linux
 			{ "key": "following_text", "operator": "regex_contains", "operand": "^\\\\right/", "match_all": true },
 		]
 	},
+	{
+		"keys": [" "], "command": "insert_snippet", "args": {"contents": " $0 "},
+		"context": [
+			{ "key": "setting.auto_match_enabled" },
+			{ "key": "latextools.setting.auto_match_math_brackets" },
+			{ "key": "selection_empty", "match_all": true },
+			{ "key": "selector", "operand": "text.tex.latex meta.environment.math", "match_all": true },
+			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\\\left/$", "match_all": true },
+			{ "key": "following_text", "operator": "regex_contains", "operand": "^\\\\right/", "match_all": true },
+		]
+	},
+	{
+		"keys": ["backspace"],
+		"command": "run_macro_file", "args": {"file": "res://Packages/Default/Delete Left Right.sublime-macro"},
+		"context": [
+			{ "key": "setting.auto_match_enabled" },
+			{ "key": "latextools.setting.auto_match_math_brackets" },
+			{ "key": "selection_empty", "match_all": true },
+			{ "key": "selector", "operand": "text.tex.latex meta.environment.math", "match_all": true },
+			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\\\left/ $", "match_all": true },
+			{ "key": "following_text", "operator": "regex_contains", "operand": "^ \\\\right/", "match_all": true },
+		]
+	},
 
 	// Auto-pair left/right pipes in math blocks
 	{
@@ -690,6 +914,29 @@ LaTeX Package keymap for Linux
 			{ "key": "selector", "operand": "text.tex.latex meta.environment.math", "match_all": true },
 			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\\\left\\|$", "match_all": true },
 			{ "key": "following_text", "operator": "regex_contains", "operand": "^\\\\right\\|", "match_all": true },
+		]
+	},
+	{
+		"keys": [" "], "command": "insert_snippet", "args": {"contents": " $0 "},
+		"context": [
+			{ "key": "setting.auto_match_enabled" },
+			{ "key": "latextools.setting.auto_match_math_brackets" },
+			{ "key": "selection_empty", "match_all": true },
+			{ "key": "selector", "operand": "text.tex.latex meta.environment.math", "match_all": true },
+			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\\\left\\|$", "match_all": true },
+			{ "key": "following_text", "operator": "regex_contains", "operand": "^\\\\right\\|", "match_all": true },
+		]
+	},
+	{
+		"keys": ["backspace"],
+		"command": "run_macro_file", "args": {"file": "res://Packages/Default/Delete Left Right.sublime-macro"},
+		"context": [
+			{ "key": "setting.auto_match_enabled" },
+			{ "key": "latextools.setting.auto_match_math_brackets" },
+			{ "key": "selection_empty", "match_all": true },
+			{ "key": "selector", "operand": "text.tex.latex meta.environment.math", "match_all": true },
+			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?:^|[^\\\\])(\\\\{2})*\\\\left\\| $", "match_all": true },
+			{ "key": "following_text", "operator": "regex_contains", "operand": "^ \\\\right\\|", "match_all": true },
 		]
 	},
 

--- a/LaTeXTools.sublime-settings
+++ b/LaTeXTools.sublime-settings
@@ -49,6 +49,14 @@
 	// valid values: "none", "part", "chapter", "section"
 	"word_count_sub_level": "none",
 
+	// auto-pair escaped brackets when typing
+	// e.g. \[ expands to \[\]
+	"auto_match_escaped_brackets": true,
+
+	// auto-pair special math related brackets when typing
+	// e.g. \left[ expands to \left[\right]
+	"auto_match_math_brackets": true,
+
 // ------------------------------------------------------------------
 // LaTeX Completions Settings
 // ------------------------------------------------------------------

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -34,6 +34,8 @@ If at any time you wish to erase your customizations and start afresh, you can s
 * `word_count_sub_level` (`"none"`): controls the level at which subcounts of words can be generated. Valid values are: `"none"`, `"part"`, `"chapter"`, and `"section"`.
 * `temp_files_exts`: list of file extensions to be considered temporary, and hence deleted using the `C-l, backspace` command.
 * `temp_files_ignored_folders`: subdirectories to skip when deleting temp files.
+* `auto_match_escaped_brackets`: auto-pair escaped brackets when typing (e.g. `\[` expands to `\[\]`)
+* `auto_match_math_brackets`: auto-pair special math related brackets when typing (e.g. `\left[` expands to `\left[\right]`)
 
 ## Preview Settings
 


### PR DESCRIPTION
Resolves #1618 

This commit properly handles escape sequences in front of opening brackets, in order to avoid false-positive auto-pairing in unwanted situations.