### PR TITLE
Fix Skim viewer crash by casting `script_file` (PosixPath) → `str`

### DIFF
--- a/plugins/viewer/skim_viewer.py
+++ b/plugins/viewer/skim_viewer.py
@@ -64,7 +64,7 @@ class SkimViewer(BaseViewer):
             script_file.write_bytes(data)
             script_file.chmod(script_file.stat().st_mode | stat.S_IXUSR)
 
-        command = ["/bin/sh", script_file, "-r"]
+        command = ["/bin/sh", str(script_file), "-r"]
 
         if keep_focus:
             command.append("-g")


### PR DESCRIPTION
**Summary**  

Opening PDFs with the Skim viewer crashed with:

```vbnet
TypeError: expected string or bytes-like object
  at shlex.quote(...)
  at latextools/utils/external_command.py
```

Root cause: `plugins/viewer/skim_viewer.py` passed a `pathlib.Path` (`script_file`) in the `command` list to `external_command()`. That function later quotes each arg with `shlex.quote()`, which requires `str`/`bytes`.

**Change**  

Cast `script_file` to `str` when building the command:

```diff
- command = ["/bin/sh", script_file, "-r"]
+ command = ["/bin/sh", str(script_file), "-r"]
```