### PR TITLE
Bug fix: return aux dir in get_aux_directory for traditional builder

### DIFF
--- a/latextools/utils/output_directory.py
+++ b/latextools/utils/output_directory.py
@@ -29,8 +29,11 @@ class UnsavedFileException(Exception):
 # return_setting indicates that the raw setting should be returned
 # as well as the auxiliary directory
 def get_aux_directory(view_or_root, return_setting=False):
+    # traditional builder is based on TeXLive latexmk (macOS/Linux) or MiKTeX texify (Windows) — both distros (builders) support `--aux-directory` flag
+    using_traditional = (get_setting("builder", "traditional") == "traditional")
+
     # not supported using texify or the simple builder
-    if not using_miktex() or using_texify_or_simple():
+    if not (using_miktex() or using_traditional) or using_texify_or_simple():
         if return_setting:
             return (None, None)
         else:


### PR DESCRIPTION
# Description

This PR fixes a bug in the `get_aux_directory` function in `./latextools/utils/output_directory.py` where the **traditional builder** (based on TeXLive’s `latexmk` on macOS/Linux or MiKTeX’s `texify` on Windows) was not properly handled.

Both TeXLive and MiKTeX support the `--aux-directory` flag, but the function was incorrectly returning `None` for traditional builds. This change ensures that the auxiliary directory is returned when using the traditional builder, if the user has set it.

---

# Changes Made

* Added explicit detection of the **traditional builder**:
    
    ```python
    using_traditional = (get_setting("builder", "traditional") == "traditional")
    ```
* Updated condition in `get_aux_directory` to include `using_traditional` so that the auxiliary directory is returned in supported cases.

---

# Updated Function

```python
def get_aux_directory(view_or_root, return_setting=False):
    # traditional builder is based on TeXLive latexmk (macOS/Linux) or MiKTeX texify (Windows) — both distros (builders) support `--aux-directory` flag
    using_traditional = (get_setting("builder", "traditional") == "traditional")  # detect the builder

    # not supported using texify or the simple builder
    if not (using_miktex() or using_traditional) or using_texify_or_simple():
        if return_setting:
            return (None, None)
        else:
            return None
```

---

# Rationale

* The bug prevented the proper use of `--aux-directory` with the **traditional builder**, even though it is supported by the underlying tools (`latexmk` and `texify`).
* This fix improves consistency with the documentation and ensures users can leverage auxiliary directories as expected when using traditional builds.

---

# Testing

* Verified on:
    * **TeXLive (macOS/Linux)** with `latexmk`
* Confirmed that auxiliary directory paths are correctly returned when set by the user.
