### PR TITLE
Use aux-directory as working directory when building PDF

### DIFF
--- a/docs/settings.md
+++ b/docs/settings.md
@@ -91,7 +91,7 @@ This section refers to setting that can be found in a platform-specific block fo
 
 ## Output Directory Settings
 
-* `aux_directory` (`""`): specifies the auxiliary directory to store any auxiliary files generated during a LaTeX build. Note that the auxiliary directory option is only useful if you are using MiKTeX. Path can be specified using either an absolute path or a relative path. If `aux_directory` is set from the project file, a relative path will be interpreted as relative to the project file. If it is set in the settings file, it will be interpreted relative to the main tex file. In addition, the following special values are honored:
+* `aux_directory` (`".aux"`): specifies the auxiliary directory to store any auxiliary files generated during a LaTeX build. Path can be specified absolute or relative to `tex_root` or, if `aux_directory` set in a project file, relative to project file's location. In addition, the following special values are honored:
   * `<<temp>>`: uses a temporary directory in the system temp directory instead of a specified path; this directory will be unique to each main file, but does not persist across restarts.
   * `<<cache>>`: uses the ST cache directory (or a suitable directory on ST2) to store the output files; unlike the `<<temp>>` option, this directory can persist across restarts.
   * `<<project>>`: uses a sub-directory in the same folder as the main tex file with what should be a unique name; note, this is probably not all that useful and you're better off using one of the other two options or a named relative path

--- a/latextools/make_pdf.py
+++ b/latextools/make_pdf.py
@@ -201,7 +201,7 @@ class CmdThread(threading.Thread):
 
             try:
                 ws = re.compile(r"\s+")
-                (errors, warnings, badboxes) = parse_tex_log(data, self.caller.builder.tex_dir)
+                (errors, warnings, badboxes) = parse_tex_log(data, self.caller.builder.aux_directory_full)
                 content = [""]
                 if errors:
                     content.append("Errors:")

--- a/plugins/builder/script_builder.py
+++ b/plugins/builder/script_builder.py
@@ -67,3 +67,5 @@ class ScriptBuilder(PdfBuilder):
                 raise ValueError(f"Invalid command type! '{cmd}' must be a 'str' or 'list'!")
 
             yield (cmd, f"Running '{cmd}'...")
+
+        self.copy_assets_to_output()


### PR DESCRIPTION
This commit...

1. adds main TeX document's location to TEXINPUTS,BIBINTPUTS and BSTINPUTS
2. uses aux-directory as current working directory for executed commands
3. removes `--output-directory` arguments from pdflatex and latexmk

These changes enable all builders - traditional (latexmk & texify), basic builder, script builder - to make use of aux-directory the same way.

It actually also simplifies support for bibtex, as it doesn't need special environment variables being set.