### PR TITLE
Cancel completions if escaped backslash is typed

### DIFF
--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -66,6 +66,24 @@ LaTeX Package keymap for Linux
 	// TODO: remove ctrl+l,ctrl+space
 	// ------------------------------------------------------------------
 
+	// Cancel Completions, if escaped backslash, aka. newline, is typed
+	// note: ST's cancelCompletion doesn't handle it well.
+	{
+		"keys": ["\\"],
+		"command": "chain",
+		"args": {
+			"commands": [
+				{"command": "hide_auto_complete" },
+				{"command": "insert", "args": {"characters": "\\"} }
+			]
+		},
+		"context": [
+			{ "key": "auto_complete_visible" },
+			{ "key": "selector", "operand": "text.tex" },
+			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?<!\\\\)(\\\\{2})*\\\\$" }
+		]
+	},
+
 	{
 		"keys": ["ctrl+l","ctrl+space"],
 		"command": "latextools_fill_all",

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -66,6 +66,25 @@ LaTeX Package keymap for OS X
 	// TODO: remove cmd+l,ctrl+space
 	// ------------------------------------------------------------------
 
+
+	// Cancel Completions, if escaped backslash, aka. newline, is typed
+	// note: ST's cancelCompletion doesn't handle it well.
+	{
+		"keys": ["\\"],
+		"command": "chain",
+		"args": {
+			"commands": [
+				{"command": "hide_auto_complete" },
+				{"command": "insert", "args": {"characters": "\\"} }
+			]
+		},
+		"context": [
+			{ "key": "auto_complete_visible" },
+			{ "key": "selector", "operand": "text.tex" },
+			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?<!\\\\)(\\\\{2})*\\\\$" }
+		]
+	},
+
 	{
 		"keys": ["super+l","ctrl+space"],
 		"command": "latextools_fill_all",

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -66,6 +66,24 @@ LaTeX Package keymap for Linux
 	// TODO: remove ctrl+l,ctrl+space
 	// ------------------------------------------------------------------
 
+	// Cancel Completions, if escaped backslash, aka. newline, is typed
+	// note: ST's cancelCompletion doesn't handle it well.
+	{
+		"keys": ["\\"],
+		"command": "chain",
+		"args": {
+			"commands": [
+				{"command": "hide_auto_complete" },
+				{"command": "insert", "args": {"characters": "\\"} }
+			]
+		},
+		"context": [
+			{ "key": "auto_complete_visible" },
+			{ "key": "selector", "operand": "text.tex" },
+			{ "key": "preceding_text", "operator": "regex_contains", "operand": "(?<!\\\\)(\\\\{2})*\\\\$" }
+		]
+	},
+
 	{
 		"keys": ["ctrl+l","ctrl+space"],
 		"command": "latextools_fill_all",


### PR DESCRIPTION
Fixes #1655

This commit adds a key binding to actively cancel auto completions, if escaped backslash `\\` is typed, which indicates a manual "newline".

It prevents unwanted completions from being inserted, if enter is pressed.

Note: A key binding is used as `cancelCompletion` rule doesn't provide reliable
      behavior, especially if `\\` is typed in the middle of a sentence.