### PR TITLE
Add option to open incomplete PDF after build

### DIFF
--- a/LaTeXTools.sublime-settings
+++ b/LaTeXTools.sublime-settings
@@ -559,7 +559,11 @@
 	// specifies whether LaTeXTools should open the PDF file on a
 	// successful build. If set to false, the PDF file won't be opened
 	// unless explicitly launched using C-l,v or C-l,j
-	"open_pdf_on_build": true,
+	// Valid values are:
+	// - "never": 	Never open PDF file after build
+	// - "success": Open PDF after build, only if it is reported complete.
+	// - "always":  Open PDF after build, even if it might be incomplete.
+	"open_pdf_on_build": "success",
 
 	// OPTION: "disable_focus_hack"
 	// if set to true, this will stop LaTeXTools from attempting to steal focus

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -157,7 +157,10 @@ Any other value will be interpreted as the default.
 
 * `viewer_settings`: these are viewer-specific settings. Please see the section on [Viewers](available-viewers.md) for details of what should be set here.
 
-* `open_pdf_on_build` (`true`): Controls whether LaTeXTools will automatically open the configured PDF viewer on a successful build. If set to `false`, the PDF viewer will only be launched if explicitly requested using `C-l,v` or `C-l,j`.
+* `open_pdf_on_build` (`"success"`): Controls whether to open configured PDF viewer after build. 
+  * `"never"`: PDF viewer is only launched if explicitly requested using `C-l,v` or `C-l,j`.
+  * `"success"`: PDF is opened only, if build reports success.
+  * `"always"`: PDF file is opened, even if build reported an error and PDF is most likely incomplete.
 
 * `disable_focus_hack` (`false`): if `true`, the focus hack that LaTeXTools uses to return focus to Sublime in some circumstances will not be run. **Note**: This does not mean that the *viewer* won't steal the focus, only that LaTeXTools won't try to steal the focus back.
 

--- a/plugins/builder/basic_builder.py
+++ b/plugins/builder/basic_builder.py
@@ -124,5 +124,3 @@ class BasicBuilder(PdfBuilder):
         # we may save one pdflatex run
         if "Rerun to get cross-references right." in self.out:
             yield (latex, f"running {engine}...")
-
-        self.copy_assets_to_output()

--- a/plugins/builder/pdf_builder.py
+++ b/plugins/builder/pdf_builder.py
@@ -335,15 +335,19 @@ class PdfBuilder(LaTeXToolsPlugin):
         if self.aux_directory_full != self.output_directory_full:
             for ext in (".synctex.gz", ".pdf"):
                 asset_name = self.base_name + ext
-                src_file = os.path.join(self.aux_directory_full, asset_name)
+
                 dst_file = os.path.join(self.output_directory_full, asset_name)
-
-                src_st = os.stat(src_file)
-
                 try:
                     dst_st = os.stat(dst_file)
                 except FileNotFoundError:
                     dst_st = None
+
+                src_file = os.path.join(self.aux_directory_full, asset_name)
+                try:
+                    src_st = os.stat(src_file)
+                except FileNotFoundError:
+                    logger.debug(f"Source {src_file} does not exist, skipping!")
+                    continue
 
                 # copy if target does not exist, is older or differs in size
                 if (

--- a/plugins/builder/traditional_builder.py
+++ b/plugins/builder/traditional_builder.py
@@ -127,7 +127,3 @@ class TraditionalBuilder(PdfBuilder):
 
         # texify wants the .tex extension; latexmk doesn't care either way
         yield (cmd + [self.tex_name], f"running {cmd[0]}...")
-
-        # Sync compiled documents with output directory.
-        if latexmk and self.aux_directory:
-            self.copy_assets_to_output()


### PR DESCRIPTION
Resolve #1654
Resolve #1659

This PR modifies possible values of `"open_pdf_on_build"` setting to:

* `"never"`: PDF viewer is only launched if explicitly requested using `C-l,v` or `C-l,j`.
* `"success"`: PDF is opened only, if build reports success.
* `"always"`: PDF file is opened, even if build reported an error and PDF is most likely incomplete.
