### PR TITLE
Display compile time after build

### DIFF
--- a/LaTeXTools Build Output.sublime-syntax
+++ b/LaTeXTools Build Output.sublime-syntax
@@ -7,7 +7,7 @@ version: 2
 hidden: true
 
 variables:
-  build_results: ^\[(?:Build (?:cancelled by user|failed|skipped)|Done)!\]$
+  build_results: ^\[(?:(?:Build (?:cancelled by user|failed|skipped))!|Finished in .+)\]$
   log_file: ^((.+?)(?:(:)(\d+))?)(:)[ ](Double-click here to open the full log\.)$
 
 contexts:
@@ -106,5 +106,5 @@ contexts:
       scope: meta.summary.failure.build.latextools message.error.build.latextools
     - match: ^\[Build cancelled by user!\]$\n?
       scope: meta.summary.failure.build.latextools message.warning.build.latextools
-    - match: ^\[(?:Build skipped|Done)!\]$\n?
+    - match: ^\[(?:Build skipped!|Finished in .+)\]$\n?
       scope: meta.summary.success.build.latextools message.info.build.latextools

--- a/tests/syntax/syntax_test_build.log
+++ b/tests/syntax/syntax_test_build.log
@@ -82,6 +82,10 @@ C:\Data\LaTeX\test-1400\.aux\test-index.log:1: Double-click here to open the ful
 # <- meta.summary.success.build.latextools message.info.build.latextools - meta.messages - meta.logfile
 #^^^^^^^^^^^^^^^^ meta.summary.success.build.latextools message.info.build.latextools - meta.messages - meta.logfile
 
-[Done!]
+[Finished in 3.4s]
 # <- meta.summary.success.build.latextools message.info.build.latextools - meta.messages - meta.logfile
-#^^^^^^^ meta.summary.success.build.latextools message.info.build.latextools - meta.messages - meta.logfile
+#^^^^^^^^^^^^^^^^^ meta.summary.success.build.latextools message.info.build.latextools - meta.messages - meta.logfile
+
+[Finished in 14:25]
+# <- meta.summary.success.build.latextools message.info.build.latextools - meta.messages - meta.logfile
+#^^^^^^^^^^^^^^^^^^ meta.summary.success.build.latextools message.info.build.latextools - meta.messages - meta.logfile


### PR DESCRIPTION
Resolves #374

If build succeeds, output duration as default build system.

```
[Finished in 20.4s]
```