### PR TITLE
Wrap selection in environment with newline stripped

### DIFF
--- a/snippets/Wrap in command.sublime-snippet
+++ b/snippets/Wrap in command.sublime-snippet
@@ -1,5 +1,5 @@
 <snippet>
-	<content><![CDATA[\\${1:cmd}{${2:$SELECTION}}]]></content>
+	<content><![CDATA[\\${1:cmd}{${2:${SELECTION/\n$//g}}}]]></content>
 	<scope>text.tex.latex</scope>
 	<description>Wrap selection in LaTeX command</description>
 </snippet>

--- a/snippets/Wrap in environment.sublime-snippet
+++ b/snippets/Wrap in environment.sublime-snippet
@@ -1,7 +1,7 @@
 <snippet>
 	<content><![CDATA[
 \\begin{${1:env}}
-	$SELECTION
+	${SELECTION/\n$//g}
 \\end{$1}
 ]]></content>
 	<scope>text.tex.latex</scope>


### PR DESCRIPTION
Resolves #1016

This PR automatically stripps a single newline from selection, when wrapping it into an environment or command.

As a result outcome is the same regardless a line is selected with or without trailing newline character - in other words: the caret is at the eol of selected line or bol of line after.