### PR TITLE
LaTeX decode bibliography paths

### DIFF
--- a/latextools/latex_cite_completions.py
+++ b/latextools/latex_cite_completions.py
@@ -256,13 +256,15 @@ def find_bib_files(root):
         # extract absolute filepath for each bib file
         rootdir = os.path.dirname(root)
         for res in resources:
-            # We join with rootdir, the dir of the master file
-            candidate_file = os.path.normpath(os.path.join(rootdir, res))
+            candidate_file = analysis.decode_path(res, rootdir)
+            if not candidate_file:
+                continue
+
             # if the file doesn't exist, search the default tex paths
             if not os.path.exists(candidate_file):
                 candidate_file = kpsewhich(res, "mlbib")
 
-            if candidate_file is not None and os.path.exists(candidate_file):
+            if candidate_file and os.path.exists(candidate_file):
                 result.add(candidate_file)
 
         return tuple(result)

--- a/latextools/utils/analysis.py
+++ b/latextools/utils/analysis.py
@@ -628,3 +628,31 @@ class objectview:
 
     def __setattr__(self, attr, value):
         raise TypeError("cannot set value on an objectview")
+
+
+def decode_path(string, base_path=None):
+    """
+    Decodes latex string to path.
+
+    :Eyample:
+        \\string~/bibliography/global.bib  -> /home/me/bibliography/global.bib
+
+    If `base_path` is given and string is a relative path,
+    both are joined to a normalized absolute path.
+
+    :Eyample:
+        with base_path = "/base/path"
+
+        bib/global.bib  -> /base/path/bib/global.bib
+
+    :returns:
+        A valid OS path with all LaTeX escapes removed.
+    """
+    if string:
+        string = string.replace("\\string", "")
+    if string:
+        string = os.path.expanduser(string)
+        if base_path and not os.path.abspath(string):
+            string = os.path.join(base_path, string)
+        return os.path.normpath(string)
+    return None


### PR DESCRIPTION
Resolves #998

This commit introduces a naive hacky way to remove `\string` from path strings. Fixes bibliography lookup in case path contains `\string` tokens.

Note: 

1. It probably requires more than that to make sure path strings are correctly decoded and converted to valid os paths.
2. Other modules like `\graphicsinput` may also be affected.