### PR TITLE
Wrap word under caret into bold/emphasis/underline

### DIFF
--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -352,11 +352,42 @@ LaTeX Package keymap for Linux
 		]
 	},
 
-	// Wrap selected text in emph, bold or underline
+	// Wrap word under caret in bold
+	{
+		"keys": ["ctrl+l","ctrl+b"],
+		"command": "chain",
+		"args": {
+			"commands": [
+				{ "command": "expand_selection", "args": { "to": "word" } },
+				{ "command": "insert_snippet", "args": { "name":"Packages/LaTeXTools/snippets/latex/bf.sublime-snippet" } }
+			]
+		},
+		"context": [
+			{ "key": "selection_empty", "match_all": true },
+			{ "key": "selector", "operand": "text.tex.latex - text.tex.latex meta.environment.math" }
+		]
+	},
+	{
+		"keys": ["ctrl+l","ctrl+b"],
+		"command": "chain",
+		"args": {
+			"commands": [
+				{ "command": "expand_selection", "args": { "to": "word" } },
+				{ "command": "insert_snippet", "args": { "name":"Packages/LaTeXTools/snippets/math/bf.sublime-snippet" } }
+			]
+		},
+		"context": [
+			{ "key": "selection_empty", "match_all": true },
+			{ "key": "selector", "operand": "text.tex.latex meta.environment.math" }
+		]
+	},
+
+	// Wrap selected text in bold
 	{
 		"keys": ["ctrl+l","ctrl+b"],
 		"command": "insert_snippet", "args": { "name":"Packages/LaTeXTools/snippets/latex/bf.sublime-snippet" },
 		"context": [
+			{ "key": "selection_empty", "operand": false, "match_all": true },
 			{ "key": "selector", "operand": "text.tex.latex - text.tex.latex meta.environment.math" }
 		]
 	},
@@ -364,27 +395,147 @@ LaTeX Package keymap for Linux
 		"keys": ["ctrl+l","ctrl+b"],
 		"command": "insert_snippet", "args": { "name":"Packages/LaTeXTools/snippets/math/bf.sublime-snippet" },
 		"context": [
+			{ "key": "selection_empty", "operand": false, "match_all": true },
 			{ "key": "selector", "operand": "text.tex.latex meta.environment.math" }
 		]
 	},
+
+	// Wrap word under caret in emph
+	{
+		"keys": ["ctrl+l","ctrl+e"],
+		"command": "chain",
+		"args": {
+			"commands": [
+				{ "command": "expand_selection", "args": { "to": "word" } },
+				{ "command": "insert_snippet", "args": { "name":"Packages/LaTeXTools/snippets/latex/em.sublime-snippet" } }
+			]
+		},
+		"context": [
+			{ "key": "selection_empty", "match_all": true },
+			{ "key": "selector", "operand": "text.tex.latex" }
+		]
+	},
+
+	// Wrap selected text in emph
 	{
 		"keys": ["ctrl+l","ctrl+e"],
 		"command": "insert_snippet", "args": { "name":"Packages/LaTeXTools/snippets/latex/em.sublime-snippet" },
 		"context": [
+			{ "key": "selection_empty", "operand": false, "match_all": true },
 			{ "key": "selector", "operand": "text.tex.latex" }
 		]
 	},
+
+	// Wrap word under caret in italic
+	{
+		"keys": ["ctrl+l","ctrl+i"],
+		"command": "chain",
+		"args": {
+			"commands": [
+				{ "command": "expand_selection", "args": { "to": "word" } },
+				{ "command": "insert_snippet", "args": { "name":"Packages/LaTeXTools/snippets/latex/it.sublime-snippet" } }
+			]
+		},
+		"context": [
+			{ "key": "selection_empty", "match_all": true },
+			{ "key": "selector", "operand": "text.tex.latex - text.tex.latex meta.environment.math" }
+		]
+	},
+	{
+		"keys": ["ctrl+l","ctrl+i"],
+		"command": "chain",
+		"args": {
+			"commands": [
+				{ "command": "expand_selection", "args": { "to": "word" } },
+				{ "command": "insert_snippet", "args": { "name":"Packages/LaTeXTools/snippets/math/it.sublime-snippet" } }
+			]
+		},
+		"context": [
+			{ "key": "selection_empty", "match_all": true },
+			{ "key": "selector", "operand": "text.tex.latex meta.environment.math" }
+		]
+	},
+
+	// Wrap selected text in italic
+	{
+		"keys": ["ctrl+l","ctrl+i"],
+		"command": "insert_snippet", "args": { "name":"Packages/LaTeXTools/snippets/latex/it.sublime-snippet" },
+		"context": [
+			{ "key": "selection_empty", "operand": false, "match_all": true },
+			{ "key": "selector", "operand": "text.tex.latex - text.tex.latex meta.environment.math" }
+		]
+	},
+	{
+		"keys": ["ctrl+l","ctrl+i"],
+		"command": "insert_snippet", "args": { "name":"Packages/LaTeXTools/snippets/math/it.sublime-snippet" },
+		"context": [
+			{ "key": "selection_empty", "operand": false, "match_all": true },
+			{ "key": "selector", "operand": "text.tex.latex meta.environment.math" }
+		]
+	},
+
+	// Wrap word under caret in sl
+	{
+		"keys": ["ctrl+l","ctrl+s"],
+		"command": "chain",
+		"args": {
+			"commands": [
+				{ "command": "expand_selection", "args": { "to": "word" } },
+				{ "command": "insert_snippet", "args": { "name":"Packages/LaTeXTools/snippets/latex/sl.sublime-snippet" } }
+			]
+		},
+		"context": [
+			{ "key": "selection_empty", "match_all": true },
+			{ "key": "selector", "operand": "text.tex.latex - text.tex.latex meta.environment.math" }
+		]
+	},
+
+	// Wrap selected text in sl
 	{
 		"keys": ["ctrl+l","ctrl+s"],
 		"command": "insert_snippet", "args": { "name":"Packages/LaTeXTools/snippets/latex/sl.sublime-snippet" },
 		"context": [
+			{ "key": "selection_empty", "operand": false, "match_all": true },
+			{ "key": "selector", "operand": "text.tex.latex - text.tex.latex meta.environment.math" }
+		]
+	},
+
+	// Wrap word under caret in tt
+	{
+		"keys": ["ctrl+l","ctrl+t"],
+		"command": "chain",
+		"args": {
+			"commands": [
+				{ "command": "expand_selection", "args": { "to": "word" } },
+				{ "command": "insert_snippet", "args": { "name":"Packages/LaTeXTools/snippets/latex/tt.sublime-snippet" } }
+			]
+		},
+		"context": [
+			{ "key": "selection_empty", "match_all": true },
 			{ "key": "selector", "operand": "text.tex.latex - text.tex.latex meta.environment.math" }
 		]
 	},
 	{
 		"keys": ["ctrl+l","ctrl+t"],
+		"command": "chain",
+		"args": {
+			"commands": [
+				{ "command": "expand_selection", "args": { "to": "word" } },
+				{ "command": "insert_snippet", "args": { "name":"Packages/LaTeXTools/snippets/math/tt.sublime-snippet" } }
+			]
+		},
+		"context": [
+			{ "key": "selection_empty", "match_all": true },
+			{ "key": "selector", "operand": "text.tex.latex meta.environment.math" }
+		]
+	},
+
+	// Wrap selected text in tt
+	{
+		"keys": ["ctrl+l","ctrl+t"],
 		"command": "insert_snippet", "args": { "name":"Packages/LaTeXTools/snippets/latex/tt.sublime-snippet" },
 		"context": [
+			{ "key": "selection_empty", "operand": false, "match_all": true },
 			{ "key": "selector", "operand": "text.tex.latex - text.tex.latex meta.environment.math" }
 		]
 	},
@@ -392,13 +543,33 @@ LaTeX Package keymap for Linux
 		"keys": ["ctrl+l","ctrl+t"],
 		"command": "insert_snippet", "args": { "name":"Packages/LaTeXTools/snippets/math/tt.sublime-snippet" },
 		"context": [
+			{ "key": "selection_empty", "operand": false, "match_all": true },
 			{ "key": "selector", "operand": "text.tex.latex meta.environment.math" }
 		]
 	},
+
+	// Wrap word under caret in underline
+	{
+		"keys": ["ctrl+l","ctrl+u"],
+		"command": "chain",
+		"args": {
+			"commands": [
+				{ "command": "expand_selection", "args": { "to": "word" } },
+				{ "command": "insert_snippet", "args": { "name":"Packages/LaTeXTools/snippets/latex/un.sublime-snippet" } }
+			]
+		},
+		"context": [
+			{ "key": "selection_empty", "match_all": true },
+			{ "key": "selector", "operand": "text.tex.latex" }
+		]
+	},
+
+	// Wrap selected text in underline
 	{
 		"keys": ["ctrl+l","ctrl+u"],
 		"command": "insert_snippet", "args": { "name":"Packages/LaTeXTools/snippets/latex/un.sublime-snippet" },
 		"context": [
+			{ "key": "selection_empty", "operand": false, "match_all": true },
 			{ "key": "selector", "operand": "text.tex.latex" }
 		]
 	},

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -352,11 +352,42 @@ LaTeX Package keymap for OS X
 		]
 	},
 
-	// Wrap selected text in emph, bold or underline
+	// Wrap word under caret in bold
+	{
+		"keys": ["super+l","super+b"],
+		"command": "chain",
+		"args": {
+			"commands": [
+				{ "command": "expand_selection", "args": { "to": "word" } },
+				{ "command": "insert_snippet", "args": { "name":"Packages/LaTeXTools/snippets/latex/bf.sublime-snippet" } }
+			]
+		},
+		"context": [
+			{ "key": "selection_empty", "match_all": true },
+			{ "key": "selector", "operand": "text.tex.latex - text.tex.latex meta.environment.math" }
+		]
+	},
+	{
+		"keys": ["super+l","super+b"],
+		"command": "chain",
+		"args": {
+			"commands": [
+				{ "command": "expand_selection", "args": { "to": "word" } },
+				{ "command": "insert_snippet", "args": { "name":"Packages/LaTeXTools/snippets/math/bf.sublime-snippet" } }
+			]
+		},
+		"context": [
+			{ "key": "selection_empty", "match_all": true },
+			{ "key": "selector", "operand": "text.tex.latex meta.environment.math" }
+		]
+	},
+
+	// Wrap selected text in bold
 	{
 		"keys": ["super+l","super+b"],
 		"command": "insert_snippet", "args": { "name":"Packages/LaTeXTools/snippets/latex/bf.sublime-snippet" },
 		"context": [
+			{ "key": "selection_empty", "operand": false, "match_all": true },
 			{ "key": "selector", "operand": "text.tex.latex - text.tex.latex meta.environment.math" }
 		]
 	},
@@ -364,27 +395,147 @@ LaTeX Package keymap for OS X
 		"keys": ["super+l","super+b"],
 		"command": "insert_snippet", "args": { "name":"Packages/LaTeXTools/snippets/math/bf.sublime-snippet" },
 		"context": [
+			{ "key": "selection_empty", "operand": false, "match_all": true },
 			{ "key": "selector", "operand": "text.tex.latex meta.environment.math" }
 		]
 	},
+
+	// Wrap word under caret in emph
+	{
+		"keys": ["super+l","super+e"],
+		"command": "chain",
+		"args": {
+			"commands": [
+				{ "command": "expand_selection", "args": { "to": "word" } },
+				{ "command": "insert_snippet", "args": { "name":"Packages/LaTeXTools/snippets/latex/em.sublime-snippet" } }
+			]
+		},
+		"context": [
+			{ "key": "selection_empty", "match_all": true },
+			{ "key": "selector", "operand": "text.tex.latex" }
+		]
+	},
+
+	// Wrap selected text in emph
 	{
 		"keys": ["super+l","super+e"],
 		"command": "insert_snippet", "args": { "name":"Packages/LaTeXTools/snippets/latex/em.sublime-snippet" },
 		"context": [
+			{ "key": "selection_empty", "operand": false, "match_all": true },
 			{ "key": "selector", "operand": "text.tex.latex" }
 		]
 	},
+
+	// Wrap word under caret in italic
+	{
+		"keys": ["super+l","super+i"],
+		"command": "chain",
+		"args": {
+			"commands": [
+				{ "command": "expand_selection", "args": { "to": "word" } },
+				{ "command": "insert_snippet", "args": { "name":"Packages/LaTeXTools/snippets/latex/it.sublime-snippet" } }
+			]
+		},
+		"context": [
+			{ "key": "selection_empty", "match_all": true },
+			{ "key": "selector", "operand": "text.tex.latex - text.tex.latex meta.environment.math" }
+		]
+	},
+	{
+		"keys": ["super+l","super+i"],
+		"command": "chain",
+		"args": {
+			"commands": [
+				{ "command": "expand_selection", "args": { "to": "word" } },
+				{ "command": "insert_snippet", "args": { "name":"Packages/LaTeXTools/snippets/math/it.sublime-snippet" } }
+			]
+		},
+		"context": [
+			{ "key": "selection_empty", "match_all": true },
+			{ "key": "selector", "operand": "text.tex.latex meta.environment.math" }
+		]
+	},
+
+	// Wrap selected text in italic
+	{
+		"keys": ["super+l","super+i"],
+		"command": "insert_snippet", "args": { "name":"Packages/LaTeXTools/snippets/latex/it.sublime-snippet" },
+		"context": [
+			{ "key": "selection_empty", "operand": false, "match_all": true },
+			{ "key": "selector", "operand": "text.tex.latex - text.tex.latex meta.environment.math" }
+		]
+	},
+	{
+		"keys": ["super+l","super+i"],
+		"command": "insert_snippet", "args": { "name":"Packages/LaTeXTools/snippets/math/it.sublime-snippet" },
+		"context": [
+			{ "key": "selection_empty", "operand": false, "match_all": true },
+			{ "key": "selector", "operand": "text.tex.latex meta.environment.math" }
+		]
+	},
+
+	// Wrap word under caret in sl
+	{
+		"keys": ["super+l","super+s"],
+		"command": "chain",
+		"args": {
+			"commands": [
+				{ "command": "expand_selection", "args": { "to": "word" } },
+				{ "command": "insert_snippet", "args": { "name":"Packages/LaTeXTools/snippets/latex/sl.sublime-snippet" } }
+			]
+		},
+		"context": [
+			{ "key": "selection_empty", "match_all": true },
+			{ "key": "selector", "operand": "text.tex.latex - text.tex.latex meta.environment.math" }
+		]
+	},
+
+	// Wrap selected text in sl
 	{
 		"keys": ["super+l","super+s"],
 		"command": "insert_snippet", "args": { "name":"Packages/LaTeXTools/snippets/latex/sl.sublime-snippet" },
 		"context": [
+			{ "key": "selection_empty", "operand": false, "match_all": true },
+			{ "key": "selector", "operand": "text.tex.latex - text.tex.latex meta.environment.math" }
+		]
+	},
+
+	// Wrap word under caret in tt
+	{
+		"keys": ["super+l","super+t"],
+		"command": "chain",
+		"args": {
+			"commands": [
+				{ "command": "expand_selection", "args": { "to": "word" } },
+				{ "command": "insert_snippet", "args": { "name":"Packages/LaTeXTools/snippets/latex/tt.sublime-snippet" } }
+			]
+		},
+		"context": [
+			{ "key": "selection_empty", "match_all": true },
 			{ "key": "selector", "operand": "text.tex.latex - text.tex.latex meta.environment.math" }
 		]
 	},
 	{
 		"keys": ["super+l","super+t"],
+		"command": "chain",
+		"args": {
+			"commands": [
+				{ "command": "expand_selection", "args": { "to": "word" } },
+				{ "command": "insert_snippet", "args": { "name":"Packages/LaTeXTools/snippets/math/tt.sublime-snippet" } }
+			]
+		},
+		"context": [
+			{ "key": "selection_empty", "match_all": true },
+			{ "key": "selector", "operand": "text.tex.latex meta.environment.math" }
+		]
+	},
+
+	// Wrap selected text in tt
+	{
+		"keys": ["super+l","super+t"],
 		"command": "insert_snippet", "args": { "name":"Packages/LaTeXTools/snippets/latex/tt.sublime-snippet" },
 		"context": [
+			{ "key": "selection_empty", "operand": false, "match_all": true },
 			{ "key": "selector", "operand": "text.tex.latex - text.tex.latex meta.environment.math" }
 		]
 	},
@@ -392,13 +543,33 @@ LaTeX Package keymap for OS X
 		"keys": ["super+l","super+t"],
 		"command": "insert_snippet", "args": { "name":"Packages/LaTeXTools/snippets/math/tt.sublime-snippet" },
 		"context": [
+			{ "key": "selection_empty", "operand": false, "match_all": true },
 			{ "key": "selector", "operand": "text.tex.latex meta.environment.math" }
 		]
 	},
+
+	// Wrap word under caret in underline
+	{
+		"keys": ["super+l","super+u"],
+		"command": "chain",
+		"args": {
+			"commands": [
+				{ "command": "expand_selection", "args": { "to": "word" } },
+				{ "command": "insert_snippet", "args": { "name":"Packages/LaTeXTools/snippets/latex/un.sublime-snippet" } }
+			]
+		},
+		"context": [
+			{ "key": "selection_empty", "match_all": true },
+			{ "key": "selector", "operand": "text.tex.latex" }
+		]
+	},
+
+	// Wrap selected text in underline
 	{
 		"keys": ["super+l","super+u"],
 		"command": "insert_snippet", "args": { "name":"Packages/LaTeXTools/snippets/latex/un.sublime-snippet" },
 		"context": [
+			{ "key": "selection_empty", "operand": false, "match_all": true },
 			{ "key": "selector", "operand": "text.tex.latex" }
 		]
 	},

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -352,11 +352,42 @@ LaTeX Package keymap for Linux
 		]
 	},
 
-	// Wrap selected text in emph, bold or underline
+	// Wrap word under caret in bold
+	{
+		"keys": ["ctrl+l","ctrl+b"],
+		"command": "chain",
+		"args": {
+			"commands": [
+				{ "command": "expand_selection", "args": { "to": "word" } },
+				{ "command": "insert_snippet", "args": { "name":"Packages/LaTeXTools/snippets/latex/bf.sublime-snippet" } }
+			]
+		},
+		"context": [
+			{ "key": "selection_empty", "match_all": true },
+			{ "key": "selector", "operand": "text.tex.latex - text.tex.latex meta.environment.math" }
+		]
+	},
+	{
+		"keys": ["ctrl+l","ctrl+b"],
+		"command": "chain",
+		"args": {
+			"commands": [
+				{ "command": "expand_selection", "args": { "to": "word" } },
+				{ "command": "insert_snippet", "args": { "name":"Packages/LaTeXTools/snippets/math/bf.sublime-snippet" } }
+			]
+		},
+		"context": [
+			{ "key": "selection_empty", "match_all": true },
+			{ "key": "selector", "operand": "text.tex.latex meta.environment.math" }
+		]
+	},
+
+	// Wrap selected text in bold
 	{
 		"keys": ["ctrl+l","ctrl+b"],
 		"command": "insert_snippet", "args": { "name":"Packages/LaTeXTools/snippets/latex/bf.sublime-snippet" },
 		"context": [
+			{ "key": "selection_empty", "operand": false, "match_all": true },
 			{ "key": "selector", "operand": "text.tex.latex - text.tex.latex meta.environment.math" }
 		]
 	},
@@ -364,27 +395,147 @@ LaTeX Package keymap for Linux
 		"keys": ["ctrl+l","ctrl+b"],
 		"command": "insert_snippet", "args": { "name":"Packages/LaTeXTools/snippets/math/bf.sublime-snippet" },
 		"context": [
+			{ "key": "selection_empty", "operand": false, "match_all": true },
 			{ "key": "selector", "operand": "text.tex.latex meta.environment.math" }
 		]
 	},
+
+	// Wrap word under caret in emph
+	{
+		"keys": ["ctrl+l","ctrl+e"],
+		"command": "chain",
+		"args": {
+			"commands": [
+				{ "command": "expand_selection", "args": { "to": "word" } },
+				{ "command": "insert_snippet", "args": { "name":"Packages/LaTeXTools/snippets/latex/em.sublime-snippet" } }
+			]
+		},
+		"context": [
+			{ "key": "selection_empty", "match_all": true },
+			{ "key": "selector", "operand": "text.tex.latex" }
+		]
+	},
+
+	// Wrap selected text in emph
 	{
 		"keys": ["ctrl+l","ctrl+e"],
 		"command": "insert_snippet", "args": { "name":"Packages/LaTeXTools/snippets/latex/em.sublime-snippet" },
 		"context": [
+			{ "key": "selection_empty", "operand": false, "match_all": true },
 			{ "key": "selector", "operand": "text.tex.latex" }
 		]
 	},
+
+	// Wrap word under caret in italic
+	{
+		"keys": ["ctrl+l","ctrl+i"],
+		"command": "chain",
+		"args": {
+			"commands": [
+				{ "command": "expand_selection", "args": { "to": "word" } },
+				{ "command": "insert_snippet", "args": { "name":"Packages/LaTeXTools/snippets/latex/it.sublime-snippet" } }
+			]
+		},
+		"context": [
+			{ "key": "selection_empty", "match_all": true },
+			{ "key": "selector", "operand": "text.tex.latex - text.tex.latex meta.environment.math" }
+		]
+	},
+	{
+		"keys": ["ctrl+l","ctrl+i"],
+		"command": "chain",
+		"args": {
+			"commands": [
+				{ "command": "expand_selection", "args": { "to": "word" } },
+				{ "command": "insert_snippet", "args": { "name":"Packages/LaTeXTools/snippets/math/it.sublime-snippet" } }
+			]
+		},
+		"context": [
+			{ "key": "selection_empty", "match_all": true },
+			{ "key": "selector", "operand": "text.tex.latex meta.environment.math" }
+		]
+	},
+
+	// Wrap selected text in italic
+	{
+		"keys": ["ctrl+l","ctrl+i"],
+		"command": "insert_snippet", "args": { "name":"Packages/LaTeXTools/snippets/latex/it.sublime-snippet" },
+		"context": [
+			{ "key": "selection_empty", "operand": false, "match_all": true },
+			{ "key": "selector", "operand": "text.tex.latex - text.tex.latex meta.environment.math" }
+		]
+	},
+	{
+		"keys": ["ctrl+l","ctrl+i"],
+		"command": "insert_snippet", "args": { "name":"Packages/LaTeXTools/snippets/math/it.sublime-snippet" },
+		"context": [
+			{ "key": "selection_empty", "operand": false, "match_all": true },
+			{ "key": "selector", "operand": "text.tex.latex meta.environment.math" }
+		]
+	},
+
+	// Wrap word under caret in sl
+	{
+		"keys": ["ctrl+l","ctrl+s"],
+		"command": "chain",
+		"args": {
+			"commands": [
+				{ "command": "expand_selection", "args": { "to": "word" } },
+				{ "command": "insert_snippet", "args": { "name":"Packages/LaTeXTools/snippets/latex/sl.sublime-snippet" } }
+			]
+		},
+		"context": [
+			{ "key": "selection_empty", "match_all": true },
+			{ "key": "selector", "operand": "text.tex.latex - text.tex.latex meta.environment.math" }
+		]
+	},
+
+	// Wrap selected text in sl
 	{
 		"keys": ["ctrl+l","ctrl+s"],
 		"command": "insert_snippet", "args": { "name":"Packages/LaTeXTools/snippets/latex/sl.sublime-snippet" },
 		"context": [
+			{ "key": "selection_empty", "operand": false, "match_all": true },
+			{ "key": "selector", "operand": "text.tex.latex - text.tex.latex meta.environment.math" }
+		]
+	},
+
+	// Wrap word under caret in tt
+	{
+		"keys": ["ctrl+l","ctrl+t"],
+		"command": "chain",
+		"args": {
+			"commands": [
+				{ "command": "expand_selection", "args": { "to": "word" } },
+				{ "command": "insert_snippet", "args": { "name":"Packages/LaTeXTools/snippets/latex/tt.sublime-snippet" } }
+			]
+		},
+		"context": [
+			{ "key": "selection_empty", "match_all": true },
 			{ "key": "selector", "operand": "text.tex.latex - text.tex.latex meta.environment.math" }
 		]
 	},
 	{
 		"keys": ["ctrl+l","ctrl+t"],
+		"command": "chain",
+		"args": {
+			"commands": [
+				{ "command": "expand_selection", "args": { "to": "word" } },
+				{ "command": "insert_snippet", "args": { "name":"Packages/LaTeXTools/snippets/math/tt.sublime-snippet" } }
+			]
+		},
+		"context": [
+			{ "key": "selection_empty", "match_all": true },
+			{ "key": "selector", "operand": "text.tex.latex meta.environment.math" }
+		]
+	},
+
+	// Wrap selected text in tt
+	{
+		"keys": ["ctrl+l","ctrl+t"],
 		"command": "insert_snippet", "args": { "name":"Packages/LaTeXTools/snippets/latex/tt.sublime-snippet" },
 		"context": [
+			{ "key": "selection_empty", "operand": false, "match_all": true },
 			{ "key": "selector", "operand": "text.tex.latex - text.tex.latex meta.environment.math" }
 		]
 	},
@@ -392,13 +543,33 @@ LaTeX Package keymap for Linux
 		"keys": ["ctrl+l","ctrl+t"],
 		"command": "insert_snippet", "args": { "name":"Packages/LaTeXTools/snippets/math/tt.sublime-snippet" },
 		"context": [
+			{ "key": "selection_empty", "operand": false, "match_all": true },
 			{ "key": "selector", "operand": "text.tex.latex meta.environment.math" }
 		]
 	},
+
+	// Wrap word under caret in underline
+	{
+		"keys": ["ctrl+l","ctrl+u"],
+		"command": "chain",
+		"args": {
+			"commands": [
+				{ "command": "expand_selection", "args": { "to": "word" } },
+				{ "command": "insert_snippet", "args": { "name":"Packages/LaTeXTools/snippets/latex/un.sublime-snippet" } }
+			]
+		},
+		"context": [
+			{ "key": "selection_empty", "match_all": true },
+			{ "key": "selector", "operand": "text.tex.latex" }
+		]
+	},
+
+	// Wrap selected text in underline
 	{
 		"keys": ["ctrl+l","ctrl+u"],
 		"command": "insert_snippet", "args": { "name":"Packages/LaTeXTools/snippets/latex/un.sublime-snippet" },
 		"context": [
+			{ "key": "selection_empty", "operand": false, "match_all": true },
 			{ "key": "selector", "operand": "text.tex.latex" }
 		]
 	},


### PR DESCRIPTION
Resolves #1043

This commit adds separate key bindings for wrapping words or selections into emphasis tags. If nothing is selected, expand selection to word boundaries before inserting emphasis snippet.