### PR TITLE
Fix math preview in Markdown syntaxes

### DIFF
--- a/LaTeXTools.sublime-settings
+++ b/LaTeXTools.sublime-settings
@@ -167,7 +167,7 @@
 	// to only preview math environment
 	// Set it to "text.tex.latex meta.environment.math"
 	// to preview every math command or environment
-	"preview_math_scope": "text.tex.latex meta.environment.math.block",
+	"preview_math_scope": "meta.environment.math.block",
 
 	// The program to compile the latex template files, possible values are
 	// pdflatex, xelatex, lualatex, latex

--- a/latextools/preview/__init__.py
+++ b/latextools/preview/__init__.py
@@ -32,12 +32,8 @@ class PreviewPhantomListener(sublime_plugin.ViewEventListener):
 
     @classmethod
     def is_applicable(cls, settings):
-        try:
-            view = currentframe().f_back.f_locals["view"]
-            return len(view.find_by_selector("text.tex.latex")) > 0
-        except KeyError:
-            syntax = settings.get("syntax")
-            return syntax == "Packages/LaTeX/LaTeX.sublime-syntax"
+        syntax = str(settings.get("syntax", ""))
+        return any(s in syntax for s in ("LaTeX", "Markdown"))
 
     @classmethod
     def applies_to_primary_view_only(cls):


### PR DESCRIPTION
Resolves #1362
Resolves https://github.com/REditorSupport/sublime-ide-r/issues/4

This commit enables math preview phantoms in Markdown syntax.

Primarily targets R-Markdown, but also applies to ordinary Markdown, which also uses LaTeX style equations.