### PR TITLE
Use ST's default build output panel

### DIFF
--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -642,16 +642,6 @@ LaTeX Package keymap for Linux
 		],
 	},
 
-	// Show panel
-	{
-		"keys": ["shift+escape"],
-		"command": "show_panel", "args": { "panel": "output.latextools" },
-		"context": [
-			{ "key": "selector", "operand": "text.tex.latex" },
-			{ "key": "panel_visible", "operand": false }
-		]
-	},
-
 	// ------------------------------------------------------------------
 	// Auto-pair braces/brackets/parentheses
 	// ------------------------------------------------------------------

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -642,16 +642,6 @@ LaTeX Package keymap for OS X
 		],
 	},
 
-	// Show panel
-	{
-		"keys": ["shift+escape"],
-		"command": "show_panel", "args": { "panel": "output.latextools" },
-		"context": [
-			{ "key": "selector", "operand": "text.tex.latex" },
-			{ "key": "panel_visible", "operand": false }
-		]
-	},
-
 	// ------------------------------------------------------------------
 	// Auto-pair braces/brackets/parentheses
 	// ------------------------------------------------------------------

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -642,16 +642,6 @@ LaTeX Package keymap for Linux
 		],
 	},
 
-	// Show panel
-	{
-		"keys": ["shift+escape"],
-		"command": "show_panel", "args": { "panel": "output.latextools" },
-		"context": [
-			{ "key": "selector", "operand": "text.tex.latex" },
-			{ "key": "panel_visible", "operand": false }
-		]
-	},
-
 	// ------------------------------------------------------------------
 	// Auto-pair braces/brackets/parentheses
 	// ------------------------------------------------------------------

--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -88,7 +88,7 @@
 	{
 		"caption": "LaTeXTools: Show build panel",
 		"command": "show_panel",
-		"args": { "panel": "output.latextools" }
+		"args": { "panel": "output.exec" }
 	},
 	{
 		"caption": "Preferences: LaTeXTools Settings",

--- a/latextools/make_pdf.py
+++ b/latextools/make_pdf.py
@@ -421,7 +421,7 @@ class LatextoolsMakePdfCommand(sublime_plugin.WindowCommand):
             sublime.error_message(f"{tex_name} is not a TeX source file: cannot compile.")
             return
 
-        self.output_view = self.window.create_output_panel("latextools")
+        self.output_view = self.window.create_output_panel("exec")
         output_view_settings = self.output_view.settings()
         output_view_settings.set("result_file_regex", file_regex)
         output_view_settings.set("result_base_dir", tex_dir)
@@ -552,7 +552,7 @@ class LatextoolsMakePdfCommand(sublime_plugin.WindowCommand):
                 sublime.error_message(
                     f"Cannot find builder {builder_name}.\nCheck your LaTeXTools Preferences"
                 )
-                self.window.run_command("hide_panel", {"panel": "output.latextools"})
+                self.window.run_command("hide_panel", {"panel": "output.exec"})
                 return
 
         if builder_name == "script" and script_commands:
@@ -586,7 +586,7 @@ class LatextoolsMakePdfCommand(sublime_plugin.WindowCommand):
 
     def show_output_panel(self, force=False):
         if force or self.show_panel_level != "never":
-            self.window.run_command("show_panel", {"panel": "output.latextools"})
+            self.window.run_command("show_panel", {"panel": "output.exec"})
 
     # Also from exec.py
     # Set the selection to the start of the output panel, so next_result works


### PR DESCRIPTION
Addresses #1680

This commit teaches make_pdf command to re-use ST's default build output panel "output.exec" to integrate more seamlessly.

1. It enables displaying build panel via default main menu item

   Menu > Tools > Build Results > Show Build Results

2. It makes separate key bindings for `shift+escape` obsolete