### PR TITLE
Rewrite tex log parser

### DIFF
--- a/Compile to PDF.sublime-build
+++ b/Compile to PDF.sublime-build
@@ -13,12 +13,13 @@
 	"selector": "text.tex.latex",
 
 	// patterns:
-	// 1. \\UNC\path
-	// 2. D:\windows\path
-	// 3. smb://url.path
-	// 4. /absolute/unix/path
-	// 5. relative/path
-	"file_regex": "^((?:\\\\|[A-Za-z]:|[A-Za-z]+://)?[^:?*\n]*?):([0-9]+)(?::([0-9]+))?: (.*)",
+	// 1. \\UNC\path\file.ext
+	// 2. D:\windows\path\file.ext
+	// 3. smb://url.path/file.ext
+	// 4. /absolute/unix/path/file.ext
+	// 5. relative/path/file.ext
+	// 6. file.ext
+	"file_regex": "^((?:\\\\|[A-Za-z]:|[A-Za-z]+://)?[^:?*\\n]+\\.[^:?*\\s\\n]+)(?::([0-9]+))?(?::([0-9]+))?: (.+)",
 
 	"variants": [
 		{

--- a/latextools/preview/preview_math.py
+++ b/latextools/preview/preview_math.py
@@ -16,7 +16,7 @@ from ..utils.logging import logger
 from ..utils.settings import get_setting
 from ..utils.settings import subscribe_settings_change
 from ..utils.settings import unsubscribe_settings_change
-from ..utils.tex_log import parse_tex_log
+from ..utils.tex_log import parse_log_file
 from ..utils.utils import cpu_count
 from .preview_utils import ghostscript_installed
 from .preview_utils import get_ghostscript_version
@@ -222,11 +222,8 @@ def _create_image(
         if not log_exists:
             err_log.append("No log file found.")
         else:
-            with open(log_file, "rb") as f:
-                log_data = f.read()
-
             try:
-                errors, warnings, _ = parse_tex_log(log_data, temp_path)
+                errors, warnings, _ = parse_log_file(log_file)
             except Exception as e:
                 err_log.append(f"Error while parsing log file: {e}")
                 errors = warnings = []
@@ -244,13 +241,6 @@ def _create_image(
         err_log.append(latex_document)
         err_log.append("-----END DOCUMENT-----")
 
-        if log_exists:
-            err_log.append("")
-            log_content = log_data.decode("utf8", "ignore")
-            err_log.append("Log file:")
-            err_log.append("-----BEGIN LOG-----")
-            err_log.append(log_content)
-            err_log.append("-----END LOG-----")
     elif not gs_error_occurred and not os.path.exists(image_path):
         err_log.append("Failed to convert pdf to png to preview.")
 

--- a/latextools/utils/tex_log.py
+++ b/latextools/utils/tex_log.py
@@ -1,880 +1,251 @@
-# ST2/ST3 compat
-import re
-import sys
-import os.path
-
-print_debug = False
-interactive = False
-extra_file_ext = []
+from __future__ import annotations
+from itertools import chain
+import os
+import regex as re
+import sublime
+import sublime_plugin
 
 
-def debug(s):
-    if print_debug:
-        print(f"parseTeXlog: {s}")
+class LogRule:
+    MAX_MSG: int = 400
+    selector: str
+
+    @classmethod
+    def process_text(cls, text: str) -> tuple[int, str]:
+        raise NotImplementedError
 
 
-# The following function is only used when debugging interactively.
-#
-# If file is not found, ask me if we are debugging
-# Rationale: if we are debugging from the command line, perhaps we are parsing
-# a log file from a user, so apply heuristics and / or ask if the file not
-# found is actually legit
-#
-# Return value: the question is, "Should I skip this file?" Hence:
-#   True means YES, DO SKIP IT, IT IS NOT A FILE
-#   False means NO, DO NOT SKIP IT, IT IS A FILE
-def debug_skip_file(f, root_dir):
-    # If we are not debugging, then it's not a file for sure, so skip it
-    # if not (print_debug or interactive):
-    if not (interactive or print_debug):
-        return True
-    debug("debug_skip_file: " + f)
-    f_ext = os.path.splitext(f)[1].lower()[1:]
-    # Heuristic: TeXlive on Mac or Linux (well, Ubuntu at least) or Windows / MiKTeX
-    # Known file extensions:
-    known_file_exts = [
-        "tex",
-        "sty",
-        "cls",
-        "cfg",
-        "def",
-        "mkii",
-        "fd",
-        "map",
-        "clo",
-        "dfu",
-        "ldf",
-        "bdf",
-        "bbx",
-        "cbx",
-        "lbx",
-        "dict",
-    ]
-    if (
-        (f_ext in known_file_exts)
-        and (
-            ("/usr/local/texlive/" in f)
-            or ("/usr/share/texlive/" in f)
-            or ("Program Files\\MiKTeX" in f)
-            or re.search(r"\\MiKTeX(?:\\| )\d\.\d+\\tex", f)
+class BadboxLogRule(LogRule):
+    selector = "meta.warning.box.log - punctuation.terminator"
+
+    @classmethod
+    def process_text(cls, text: str) -> tuple[int, str]:
+        msg = re.split(r"\.$|\[\]|\n", text, 1, re.M)[0]
+        msg = re.sub(r"\s+", " ", msg, re.M)
+        msg = msg.replace("\n", "")
+        msg = msg.strip()
+        if len(msg) > cls.MAX_MSG:
+            msg = msg[: cls.MAX_MSG] + "..."
+
+        if match := re.search(r"lines?\s*(\d+)", text.replace("\n", ""), re.M):
+            line = int(match.group(1))
+        else:
+            line = 0
+
+        return (line, msg)
+
+
+class ExceptionLogRule(LogRule):
+    selector = "meta.exception.log"
+
+    @classmethod
+    def undefined_control_sequence(cls, text) -> tuple[int, str] | None:
+        R"""
+        Handles messages like:
+
+        ! Undefined control sequence.
+        \imprimirautor ->\theauthor
+
+        l.49         }
+
+        ! Undefined control sequence.
+        l.1229 ...canonical \) in \( \SO(8) \) is \( \Spin
+                                                          (7) \), see~\cite[Theorem~...
+        The control sequence at the end of the top line
+        ...and I'll forget about whatever was undefined.
+        """
+        ucs = re.search(
+            r"^(Undefined control sequence)\.\n"
+            r"(?:.*\n)*?"             # optional details about invalid sequence
+            r"l\.(\d+)"               # line number, exception was detected at
+            r"[ ]+([^\n]+)\n"         # command name
+            r"(?:[ ]{3,}([^\n]+))?",  # command continuation (arguments)
+            text,
+            re.M,
         )
-        or ("\\MiKTeX\\tex\\" in f)
-    ):
-        print("TeXlive / MiKTeX FILE! Don't skip it!")
-        return False
-    if f_ext in known_file_exts and re.search(r"(\\|/)texmf\1", f, re.I):
-        print("File in TEXMF tree! Don't skip it!")
-        return False
-    # Heuristic: "version 2010.12.02"
-    if re.match(r"version \d\d\d\d\.\d\d\.\d\d", f):
-        print("Skip it!")
-        return True
-    # Heuristic: TeX Live line
-    if re.match(r"TeX Live 20\d\d(/Debian)?\) \(format", f):
-        print("Skip it!")
-        return True
-    # Heuristic: MiKTeX line
-    if re.match(r"MiKTeX \d\.\d\d?", f):
-        print("Skip it!")
-        return True
-    # Heuristic: no two consecutive spaces in file name
-    if "  " in f:
-        print("Skip it!")
-        return True
-    # Heuristic: various diagnostic messages
-    if (
-        f == "e.g.,"
-        or "ext4): destination with the same identifier" in f
-        or "Kristoffer H. Rose" in f
-    ):
-        print("Skip it!")
-        return True
-    # Heuristic: file in local directory with .tex ending
-    file_exts = extra_file_ext + [
-        "tex",
-        "aux",
-        "bbl",
-        "cls",
-        "sty",
-        "out",
-        "toc",
-        "dbx",
+        if ucs:
+            msg, line, seq1, seq2 = ucs.groups()
+            msg = f"{msg} near {seq1}{seq2 or ''}"
+            msg = re.sub(r"\s+", " ", msg)
+            return (int(line), msg)
+        return None
+
+    @classmethod
+    def any_exception(cls, text: str) -> tuple[int, str]:
+        msg = re.split(r"\.$", text, 1, re.M)[0]
+        msg = re.sub(r"\s+", " ", msg, re.M)
+        msg = msg.replace("\n", "")
+        msg = msg.strip()
+        if len(msg) > cls.MAX_MSG:
+            msg = msg[: cls.MAX_MSG] + "..."
+
+        if match := re.search(r"^l\.(\d+)", text, re.M):
+            line = int(match.group(1))
+        else:
+            line = 0
+
+        return (line, msg)
+
+    @classmethod
+    def process_text(cls, text: str) -> tuple[int, str]:
+        msg = text[2:]  # skip leading `! `
+        for handler in (
+            cls.undefined_control_sequence,
+        ):
+            if result := handler(msg):
+                return result
+
+        return cls.any_exception(msg)
+
+
+class ErrorLogRule(LogRule):
+    selector = "meta.error.log - markup.error"
+
+    @classmethod
+    def process_text(cls, text: str) -> tuple[int, str]:
+        msg = re.split(r"\.$", text, 1, re.M)[0]
+        msg = re.sub(r"\n(?:\(\S+\)[^\S\n]+)", r" ", msg, re.M)
+        msg = re.sub(r"\s+", " ", msg, re.M)
+        msg = msg.replace("\n", "")
+        msg = msg.strip()
+        if len(msg) > cls.MAX_MSG:
+            msg = msg[: cls.MAX_MSG] + "..."
+
+        if match := re.search(r"line\s*(\d+)", text.replace("\n", ""), re.M):
+            line = int(match.group(1))
+        else:
+            line = 0
+
+        return (line, msg)
+
+
+class WarningLogRule(ErrorLogRule):
+    selector = "meta.warning.log - markup.warning"
+
+
+def parse_log_view(view: sublime.View) -> tuple[list[str], list[str], list[str]]:
+    """
+    Extract errors, warnings and badbox messages from a `sublime.View`.
+
+    This function relies on log file already being tokenized by
+    `LaTeXTools Log.sublime-syntax` syntax.
+
+    :param view:
+        The view to extract log items from.
+
+    :returns:
+        3-tuple of lists of strings, containing results
+    """
+    # gather all blocks
+    blocks = []
+    selector = "meta.block.log"
+    while regs := view.find_by_selector(selector):
+        blocks.extend(regs)
+        selector += " meta.block.log"
+
+    # associate blocks with file names and sort by starting position
+    # assumption: each `meta.block` starts with an `entity.name.section.filename`.
+    blocks = [
+        (block, os.path.normpath(view.substr(filename).replace("\n", "").strip()))
+        for block, filename in zip(
+            sorted(blocks),
+            view.find_by_selector(
+                "entity.name.section.filename.log - punctuation.definition.entity"
+            ),
+        )
     ]
-    if (f.startswith(root_dir) or f[0:2] in ["./", ".\\", ".."]) and f_ext in file_exts:
-        print("File! Don't skip it")
-        return False
 
-    # Heuristic: absolute path that looks like home directory
-    if f[0] == "/":
-        if f.split("/")[1] in ["home", "Users"]:
-            print("Assuming home directory file. Don't skip!")
-            return False
-    # N.B. this is not a good technique for detecting the user folder
-    # on Windows, but is hopefully "good enough" for the common configuration
-    # (given that this will not usually be run on the computer that generated
-    # the log)
-    elif re.match(r"^[A-Z]:\\(?:Documents and Settings|Users)\\", f):
-        print("Assuming home directory file. Don't skip!")
-        return False
+    def extract_items(rule: type[LogRule]) -> list[str]:
+        items = []
+        for reg in view.find_by_selector(rule.selector):
+            for sreg, fname in reversed(blocks):
+                if reg in sreg:
+                    item = (fname, *rule.process_text(view.substr(reg)))
+                    if item not in items:
+                        items.append(item)
+                    break
 
-    if not interactive:
-        print("Automatically skipping")
-        return True
+        return items
 
-    choice = input()
+    def format_items(items):
+        return [
+            f"{fname}:{line}: {msg}" if line > 0 else f"{fname}: {msg}"
+            for fname, line, msg in sorted(items)
+        ]
 
-    if choice == "":
-        print("Skip it")
-        return True
-    else:
-        print("FILE! Don't skip it")
-        return False
-
-
-# More robust parsing code: October / November 2012
-# Input: tex log file, read in **binary** form, unprocessed
-# Output: content to be displayed in output panel, split into lines
-
-
-def parse_tex_log(data, root_dir):
-    debug("Parsing log file")
-    errors = []
-    warnings = []
-    badboxes = []
-    parsing = []
-
-    guessed_encoding = "UTF-8"  # for now
-
-    # Split data into lines while in binary form
-    # Then decode using guessed encoding
-    # We need the # of bytes per line, not the # of chars (codepoints), to undo TeX's line breaking
-    # so we construct an array of tuples:
-    #   (decoded line, length of original byte array)
-
-    try:
-        log = [(l.decode(guessed_encoding, "ignore"), len(l)) for l in data.splitlines()]
-    except UnicodeError:
-        debug("log file not in UTF-8 encoding!")
-        errors.append("ERROR: your log file is not in UTF-8 encoding.")
-        errors.append("Sorry, I can't process this file")
-        return (errors, warnings, badboxes)
-
-    # loop over all log lines; construct error message as needed
-    # This will be useful for multi-file documents
-
-    # some regexes
-    # file_rx = re.compile(r"\(([^)]+)$") # OLD
-    # Structure (+ means captured, - means not captured)
-    # + maybe " (for Windows)
-    # + maybe a drive letter and : (for Windows)
-    # + maybe . NEW: or ../ or ..\, with repetitions
-    # + then any char, matched NON-GREEDILY (avoids issues with multiple files on one line?)
-    # + then .
-    # + then any char except for whitespace or " or ); at least ONE such char
-    # + then maybe " (on Windows/MikTeX)
-    # - then whitespace or ), or end of line
-    # + then anything else, captured for recycling
-    # This should take care of e.g. "(./test.tex [12" or "(./test.tex (other.tex"
-    # NOTES:
-    # 1. we capture the initial and ending " if there is one; we'll need to remove it later
-    # 2. we define the basic filename parsing regex so we can recycle it
-    # 3. we allow for any character besides "(" before a file name starts. This gives a lot of
-    #    false positives but we kill them with os.path.isfile
-    file_basic = r"\"?(?:[a-zA-Z]\:)?(?:\.|(?:\.\./)|(?:\.\.\\))*.+?\.[^\s\"\)\.]+\"?"
-    file_rx = re.compile(r"[^\(]*?\((" + file_basic + r")(\s|\"|\)|$)(.*)")
-    # Useless file #1: {filename.ext}; capture subsequent text
-    # Will avoid nested {'s as these can't really appear, except if file names have braces
-    # which is REALLY bad!!!
-    file_useless1_rx = re.compile(r"\{\"?(?:\.|\.\./)*[^\.]+\.[^\{\}]*\"?\}(.*)")
-    # Useless file #2: <filename.ext>; capture subsequent text
-    file_useless2_rx = re.compile(r"<\"?(?:\.|\.\./)*[^\.]+\.[^>]*\"?>(.*)")
-    # attempt to filter out log messages like this:
-    #  (package)          continued warning...
-    # from being considered files
-    file_badmatch_rx = re.compile(r"^\s*\([a-zA-Z]+\)\s{4,}.+")
-    pagenum_begin_rx = re.compile(r"\s*\[\d*(.*)")
-    line_rx = re.compile(r"^l\.(\d+)\s(.*)")  # l.nn <text>
-
-    error_rx = re.compile(r"^([^!:]*?)\bError: (.+)")  # Errors, first line
-    warning_rx = re.compile(r"^([^:]*?)\bWarning: (.+)")  # Warnings, first line
-    line_rx_latex_warn = re.compile(r"input line (\d+)\..*")  # Warnings, line number
-
-    badbox_rx = re.compile(r"^(.*?)Overfull (.*)")  # Bad box warning
-    line_rx_latex_badbox = re.compile(r"lines (\d+)--(.*?)")  # Bad box lines
-    matched_parens_rx = re.compile(
-        r"\([^()]*\)"
-    )  # matched parentheses, to be deleted (note: not if nested)
-    assignment_rx = re.compile(r"\\[^=]*=")  # assignment, heuristics for line merging
-    # Special case: the xy package, which reports end of processing with "loaded)" or "not reloaded)"
-    xypic_begin_rx = re.compile(r"[^()]*?(?:not re)?loaded\)(.*)")
-    xypic_rx = re.compile(r".*?(?:not re)?loaded\)(.*)")
-    # Special case: the comment package, which prints ")" after some text
-    comment_rx = re.compile(r"Excluding comment '.*?'(.*)")
-
-    files = []
-    xypic_flag = (
-        False  # If we have seen xypic, report a warning, not an error for incorrect parsing
+    # gather log items
+    return (
+        format_items(chain(*map(extract_items, (ExceptionLogRule, ErrorLogRule)))),
+        format_items(extract_items(WarningLogRule)),
+        format_items(extract_items(BadboxLogRule)),
     )
 
-    # Support function to handle errors
-    def handle_error(l):
-        if files == []:
-            location = "[no file]"
-            parsing.append("PERR [handle_error no files] " + l)
-            debug(f"PERR [handle_error no files] ({line_num})")
-        else:
-            location = files[-1]
 
-        err_match_line = line_rx_latex_warn.search(l)
-        if err_match_line:
-            err_line = err_match_line.group(1)
-            errors.append(f"{location}:{err_line}: {l}")
-        else:
-            errors.append(f"{location}: {l}")
+def parse_log_file(logfile: str | os.PathLike[str]) -> tuple[list[str], list[str], list[str]]:
+    """
+    Extract errors, warnings and badbox messages from tex build log.
 
-    # Support function to handle warnings
-    def handle_warning(l):
-        if files == []:
-            location = "[no file]"
-            parsing.append("PERR [handle_warning no files] " + l)
-            debug(f"PERR [handle_warning no files] ({line_num})")
-        else:
-            location = files[-1]
+    :param logfile:
+        The logfile
 
-        warn_match_line = line_rx_latex_warn.search(l)
-        if warn_match_line:
-            warn_line = warn_match_line.group(1)
-            warnings.append(f"{location}:{warn_line}: {l}")
-        else:
-            warnings.append(f"{location}: {l}")
+    :returns:
+        3-tuple of lists of strings, containing results
+    """
 
-    # Support function to handle bad boxes
-    def handle_badbox(l):
-        if files == []:
-            location = "[no file]"
-            parsing.append("PERR [handle_badbox no files] " + l)
-            debug(f"PERR [handle_badbox no files] ({line_num})")
-        else:
-            location = files[-1]
+    # find a proper window
+    window = sublime.active_window()
+    if window is None:
+        if not (windows := sublime.windows()):
+            return ([], [], [])
+        window = windows[0]
 
-        badbox_match_line = line_rx_latex_badbox.search(l)
-        if badbox_match_line:
-            badbox_line = badbox_match_line.group(1)
-            badboxes.append(f"{location}:{badbox_line}: {l}")
-        else:
-            badboxes.append(f"{location}: {l}")
+    # create a hidden panel as scratch pad
+    panel = window.create_output_panel("latextools_logfile", unlisted=True)
+    panel_settings = panel.settings()
+    panel_settings.set("auto_indent", False)
+    panel_settings.set("auto_match_enabled", False)
+    panel_settings.set("draw_indent_guides", False)
+    panel_settings.set("draw_white_space", "none")
+    panel_settings.set("detect_indentation", False)
+    panel_settings.set("disable_auto_complete", False)
+    panel_settings.set("encoding", "UTF-8")
+    panel_settings.set("gutter", False)
+    panel_settings.set("line_numbers", False)
+    panel_settings.set("rulers", [])
+    panel_settings.set("tab_size", 2)
+    panel_settings.set("translate_tabs_to_spaces", False)
+    panel_settings.set("word_wrap", False)
+    panel.assign_syntax("Packages/LaTeXTools/LaTeXTools Log.sublime-syntax")
 
-    # State definitions
-    STATE_NORMAL = 0
-    STATE_SKIP = 1
-    STATE_REPORT_FATAL = 2
-    STATE_REPORT_ERROR = 3
-    STATE_REPORT_WARNING = 4
-
-    state = STATE_NORMAL
-
-    # Use our own iterator instead of for loop
-    log_iterator = log.__iter__()
-    line_num = 0
-    line = ""
-    linelen = 0
-
-    recycle_extra = False  # Should we add extra to newly read line?
-    reprocess_extra = False  # Should we reprocess extra, without reading a new line?
-    emergency_stop = False  # If TeX stopped processing, we can't pop all files
-    incomplete_if = False  # Ditto if some \if... statement is not complete
-
-    while True:
-        # first of all, see if we have a line to recycle (see heuristic for "l.<nn>" lines)
-        if recycle_extra:
-            line, linelen = extra, extralen
-            recycle_extra = False
-            line_num += 1
-        elif reprocess_extra:
-            line = (
-                extra  # NOTE: we must remember that we are reprocessing. See long-line heuristics
-            )
-        else:  # we read a new line
-            # save previous line for "! File ended while scanning use of..." message
-            prev_line = line
-            try:
-                line, linelen = next(log_iterator)  # will fail when no more lines
-                line_num += 1
-            except StopIteration:
-                break
-        # Now we deal with TeX's decision to truncate all log lines at 79 characters
-        # If we find a line of exactly 79 characters, we add the subsequent line to it, and continue
-        # until we find a line of less than 79 characters
-        # The problem is that there may be a line of EXACTLY 79 chars. We keep our fingers crossed but also
-        # use some heuristics to avoid disastrous consequences
-        # We are inspired by latexmk (which has no heuristics, though)
-
-        # HEURISTIC: the first line is always long, and we don't care about it
-        # also, the **<file name> line may be long, but we skip it, too (to avoid edge cases)
-        # We make sure we are NOT reprocessing a line!!!
-        # Also, we make sure we do not have a filename match, or it would be clobbered by exending!
-        if (not reprocess_extra) and line_num > 1 and linelen >= 79 and line[0:2] != "**":
-            debug(f"Line {line_num} is {len(line)} characters long; last char is {line[-1]}")
-            # HEURISTICS HERE
-            extend_line = True
-            recycle_extra = False
-            # HEURISTIC: check first if we just have a long "(.../file.tex" (or similar) line
-            # A bit inefficient as we duplicate some of the code below for filename matching
-            file_match = file_rx.match(line)
-            if file_match:
-                if line.startswith("runsystem") or file_badmatch_rx.match(line):
-                    debug("Ignoring possible file: " + line)
-                    file_match = False
-
-            if file_match:
-                debug("MATCHED (long line)")
-                file_name = file_match.group(1)
-
-                # remove quotes if necessary, but first save the count for a later check
-                quotecount = file_name.count('"')
-                file_name = file_name.replace('"', "")
-
-                # Normalize the file path
-                file_name = os.path.normpath(file_name)
-                if not os.path.isabs(file_name):
-                    file_name = os.path.normpath(os.path.join(root_dir, file_name))
-
-                file_extra = file_match.group(2) + file_match.group(3)  # don't call it "extra"
-
-                # NOTE: on TL201X pdftex sometimes writes "pdfTeX warning" right after file name
-                # This may or may not be a stand-alone long line, but in any case if we
-                # extend, the file regex will fire regularly
-                if file_name[-6:] == "pdfTeX" and file_extra[:8] == " warning":
-                    debug("pdfTeX appended to file name, extending")
-                # Else, if the extra stuff is NOT ")" or "", we have more than a single
-                # file name, so again the regular regex will fire
-                elif file_extra not in [")", ""]:
-                    debug("additional text after file name, extending")
-                # If we have exactly ONE quote, we are on Windows but we are missing the final quote
-                # in which case we extend, because we may be missing parentheses otherwise
-                elif quotecount == 1:
-                    debug("only one quote, extending")
-                # Now we have a long line consisting of a potential file name alone
-                # Check if it really is a file name
-                elif (not os.path.isfile(file_name)) and debug_skip_file(file_name, root_dir):
-                    debug("Not a file name")
-                else:
-                    debug("IT'S A (LONG) FILE NAME WITH NO EXTRA TEXT")
-                    extend_line = False  # so we exit right away and continue with parsing
-
-            while extend_line:
-                debug("extending: " + line)
-                try:
-                    extra, extralen = next(log_iterator)
-                    debug("extension? " + extra)
-                    line_num += 1  # for debugging purposes
-                    # HEURISTIC: if extra line begins with "Package:" "File:" "Document Class:",
-                    # or other "well-known markers",
-                    # we just had a long file name, so do not add
-                    if (
-                        extralen > 0
-                        and (
-                            extra[0:5] == "File:"
-                            or extra[0:8] == "Package:"
-                            or extra[0:11] == "Dictionary:"
-                            or extra[0:15] == "Document Class:"
-                        )
-                        or (extra[0:9] == "LaTeX2e <" or assignment_rx.match(extra))
-                    ):
-                        extend_line = False
-                        # no need to recycle extra, as it's nothing we are interested in
-                    # HEURISTIC: when TeX reports an error, it prints some surrounding text
-                    # and may use the whole line. Then it prints "...", and "l.<nn> <text>" on a new line
-                    # pdftex warnings also use "..." at the end of a line.
-                    # If so, do not extend
-                    elif (
-                        line[-3:] == "..."
-                    ):  # and line_rx.match(extra): # a bit inefficient as we match twice
-                        debug("Found [...]")
-                        extend_line = False
-                        recycle_extra = True  # make sure we process the "l.<nn>" line!
-                    # unsure about this...
-                    # if the "extra" (next line) starts with a ( and we already have a
-                    # valid file, this likely starts something else we need to
-                    # process as a file, so add a space...
-                    elif (
-                        extralen > 0
-                        and extra[0] == "("
-                        and (os.path.isfile(file_name) or not debug_skip_file(file_name, root_dir))
-                    ):
-                        line += " " + extra
-                        debug("Extended: " + line)
-                        linelen += extralen + 1
-                        if extralen < 79:
-                            extend_line = False
-                    else:
-                        line += extra
-                        debug("Extended: " + line)
-                        linelen += extralen
-                        if extralen < 79:
-                            extend_line = False
-                except StopIteration:
-                    extend_line = (
-                        False  # end of file, so we must be done. This shouldn't happen, btw
-                    )
-
-        # NOW WE GOT OUR EXTENDED LINE, SO START PROCESSING
-
-        # We may skip the above "if" because we are reprocessing a line, so reset flag:
-        reprocess_extra = False
-        # Check various states
-        if state == STATE_SKIP:
-            state = STATE_NORMAL
-            continue
-        if state == STATE_REPORT_FATAL:
-            # skip everything except "l.<nn> <text>"
-            debug("Reporting fatal error in line: " + line)
-            # We check for emergency stops here, too, because it may occur before the l.nn text
-            if "! Emergency stop." in line:
-                emergency_stop = True
-                debug("Emergency stop found")
-                continue
-            err_match = line_rx.match(line)
-            if not err_match:
-                continue
-            # now we match!
-            # state = STATE_NORMAL
-            # TeX splits the error line in two, so we skip the
-            # second part. In the future we may want to capture that, too
-            # and figure out the column, perhaps.
-            state = STATE_SKIP
-            err_line = err_match.group(1)
-            err_text = err_match.group(2)
-            # err_msg is set from last time
-            if files == []:
-                location = "[no file]"
-                parsing.append("PERR [STATE_REPORT_FATAL no files] " + line)
-                debug(f"PERR [STATE_REPORT_FATAL no files] ({line_num})")
-            else:
-                location = files[-1]
-            debug("Found error: " + err_msg)
-            errors.append(f"{location}:{err_line}: {err_msg} [{err_text}]")
-            continue
-        if state == STATE_REPORT_ERROR:
-            # add current line and check if we are done or not
-            current_error += line
-            if len(line) == 0 or line[-1] == ".":
-                handle_error(current_error)
-                current_error = None
-                state = STATE_NORMAL  # otherwise the state stays at REPORT_ERROR
-            continue
-        if state == STATE_REPORT_WARNING:
-            # add current line and check if we are done or not
-            current_warning += line
-            if len(line) == 0 or line[-1] == ".":
-                handle_warning(current_warning)
-                current_warning = None
-                state = STATE_NORMAL  # otherwise the state stays at REPORT_WARNING
-            continue
-        if line == "":
-            continue
-
-        # Sometimes an \if... is not completed; in this case some files may remain on the stack
-        # I think the same format may apply to different \ifXXX commands, so make it flexible
-        if (
-            len(line) > 0
-            and line.strip()[:23] == "(\\end occurred when \\if"
-            and line.strip()[-15:] == "was incomplete)"
-        ):
-            incomplete_if = True
-            debug(line)
-
-        # Skip things that are clearly not file names, though they may trigger false positives
-        if (
-            len(line) > 0
-            and (
-                line[0:5] == "File:"
-                or line[0:8] == "Package:"
-                or line[0:11] == "Dictionary:"
-                or line[0:15] == "Document Class:"
-            )
-            or (line[0:9] == "LaTeX2e <" or assignment_rx.match(line))
-        ):
-            continue
-
-        # Are we done? Get rid of extra spaces, just in case (we may have extended a line, etc.)
-        if line.strip() == "Here is how much of TeX's memory you used:":
-            if len(files) > 0:
-                if emergency_stop or incomplete_if:
-                    debug("Done processing, files on stack due to known conditions (all is fine!)")
-                elif xypic_flag:
-                    parsing.append("PERR [files on stack (xypic)] " + ";".join(files))
-                else:
-                    parsing.append("PERR [files on stack] " + ";".join(files))
-                files = []
-            # break
-            # We cannot stop here because pdftex may yet have errors to report.
-
-        # Special error reporting for e.g. \footnote{text NO MATCHING PARENS & co
-        if "! File ended while scanning use of" in line:
-            scanned_command = line[35:-2]  # skip space and period at end
-            # we may be unable to report a file by popping it, so HACK HACK HACK
-            file_name, linelen = next(log_iterator)  # <inserted text>
-            file_name, linelen = next(log_iterator)  #      \par
-            file_name, linelen = next(log_iterator)
-            file_name = file_name[3:]  # here is the file name with <*> in front
-            errors.append("TeX STOPPED: " + line[2:-2] + prev_line[:-5])
-            errors.append("TeX reports the error was in file:" + file_name)
-            continue
-
-        # Here, make sure there was no uncaught error, in which case we do more special processing
-        # This will match both tex and pdftex Fatal Error messages
-        if "==> Fatal error occurred," in line:
-            debug("Fatal error detected")
-            if errors == []:
-                errors.append(
-                    "TeX STOPPED: fatal errors occurred. Check the TeX log file for details"
-                )
-            continue
-
-        # If tex just stops processing, we will be left with files on stack, so we keep track of it
-        if "! Emergency stop." in line:
-            state = STATE_SKIP
-            emergency_stop = True
-            debug("Emergency stop found")
-            continue
-
-        # TOo many errors: will also have files on stack. For some reason
-        # we have to do differently from above (need to double-check: why not stop processing if
-        # emergency stop, too?)
-        if "(That makes 100 errors; please try again.)" in line:
-            errors.append("Too many errors. TeX stopped.")
-            debug("100 errors, stopping")
-            break
-
-        # catch over/underfull
-        # skip everything for now
-        # Over/underfull messages end with [] so look for that
-        if line[0:8] == "Overfull" or line[0:9] == "Underfull":
-
-            current_badbox = line
-            if line[-2:] == "[]":  # one-line over/underfull message
-                handle_badbox(current_badbox)
-                continue
-
-            ou_processing = True
-            while ou_processing:
-                try:
-                    line, linelen = next(log_iterator)  # will fail when no more lines
-                except StopIteration:
-                    debug(f"Over/underfull: StopIteration ({line_num})")
-                    break
-                line_num += 1
-                debug(f"Over/underfull: skip " + line + " ({line_num}) ")
-                # Sometimes it's " []" and sometimes it's "[]"...
-                #               if len(line)>0 and line[:3] == " []" or line[:2] == "[]":
-                # NO, it really should be just " []"
-                if len(line) > 0 and line == " []":
-                    ou_processing = False
-                else:
-                    current_badbox += line
-
-            if ou_processing:
-                warnings.append("Malformed LOG file: over/underfull")
-                warnings.append("Please let me know via GitHub")
-                break
-            else:
-                handle_badbox(current_badbox)
-                continue
-
-        # Special case: the bibgerm package, which has comments starting and ending with
-        # **, and then finishes with "**)"
-        if (
-            len(line) > 0
-            and line[:2] == "**"
-            and line[-3:] == "**)"
-            and files
-            and "bibgerm" in files[-1]
-        ):
-            debug("special case: bibgerm")
-            debug(f"{files[-1]:>{len(files)}} ({line_num})")
-            f = files.pop()
-            debug(f"Popped file: {f} ({line_num})")
-            continue
-
-        # Special case: the relsize package, which puts ")" at the end of a
-        # line beginning with "Examine \". Ah well!
-        if (
-            len(line) > 0
-            and line[:9] == "Examine \\"
-            and line[-3:] == ". )"
-            and files
-            and "relsize" in files[-1]
-        ):
-            debug("special case: relsize")
-            debug(f"{files[-1]:>{len(files)}} ({line_num})")
-            f = files.pop()
-            debug(f"Popped file: {f} ({line_num})")
-            continue
-
-        # Special case: the comment package, which puts ")" at the end of a
-        # line beginning with "Excluding comment 'something'"
-        # Since I'm not sure, we match "Excluding comment 'something'" and recycle the rest
-        comment_match = comment_rx.match(line)
-        if comment_match and files and "comment" in files[-1]:
-            debug("special case: comment")
-            extra = comment_match.group(1)
-            debug("Reprocessing " + extra)
-            reprocess_extra = True
-            continue
-
-        # Special case: the numprint package, which prints a line saying
-        # "No configuration file... found.)"
-        # if there is no config file (duh!), and that (!!!) signals the end of processing :-(
-
-        if (
-            len(line) > 0
-            and line.strip() == "No configuration file `numprint.cfg' found.)"
-            and files
-            and "numprint" in files[-1]
-        ):
-            debug("special case: numprint")
-            debug(f"{files[-1]:>{len(files)}} ({line_num})")
-            f = files.pop()
-            debug(f"Popped file: {f} ({line_num})")
-            continue
-
-        # Special case: xypic's "loaded)" at the BEGINNING of a line. Will check later
-        # for matches AFTER other text.
-        xypic_match = xypic_begin_rx.match(line)
-        if xypic_match:
-            debug("xypic match before: " + line)
-            # Do an extra check to make sure we are not too eager: is the topmost file
-            # likely to be an xypic file? Look for xypic in the file name
-            if files and "xypic" in files[-1]:
-                debug(f"{files[-1]:>{len(files)}} ({line_num})")
-                f = files.pop()
-                debug(f"Popped file: {f} ({line_num})")
-                extra = xypic_match.group(1)
-                debug("Reprocessing " + extra)
-                reprocess_extra = True
-                continue
-            else:
-                debug("Found loaded) but top file name doesn't have xy")
-
-        # mostly these are caused by hyperref and re-using internal identifiers
-        if "pdfTeX warning (ext4): destination with the same identifier" in line:
-            # add warning
-            handle_warning(line[line.find("destination with the same identifier") :])
-            continue
-
-        line = line.strip()  # get rid of initial spaces
-        # note: in the next line, and also when we check for "!", we use the fact that "and" short-circuits
-        # denotes end of processing of current file: pop it from stack
-        if len(line) > 0 and line[0] == ")":
-            if files:
-                debug(f"{files[-1]:>{len(files)}} ({line_num})")
-                f = files.pop()
-                debug(f"Popped file: {f} ({line_num})")
-                extra = line[1:]
-                debug("Reprocessing " + extra)
-                reprocess_extra = True
-                continue
-            else:
-                msg = f"PERR [')' no files] ({line_num})"
-                parsing.append(msg)
-                debug(msg)
-                break
-
-        # Opening page indicators: skip and reprocess
-        # Note: here we look for matches at the BEGINNING of a line. We check again below
-        # for matches elsewhere, but AFTER matching for file names.
-        pagenum_begin_match = pagenum_begin_rx.match(line)
-        if pagenum_begin_match:
-            extra = pagenum_begin_match.group(1)
-            debug("Reprocessing " + extra)
-            reprocess_extra = True
-            continue
-
-        # Closing page indicators: skip and reprocess
-        # Also, sometimes we have a useless file <file.tex, then a warning happens and the
-        # last > appears later. Pick up such stray >'s as well.
-        if len(line) > 0 and line[0] in ["]", ">"]:
-            extra = line[1:]
-            debug("Reprocessing " + extra)
-            reprocess_extra = True
-            continue
-
-        # Useless file matches: {filename.ext} or <filename.ext>. We just throw it out
-        file_useless_match = file_useless1_rx.match(line) or file_useless2_rx.match(line)
-        if file_useless_match:
-            extra = file_useless_match.group(1)
-            debug("Useless file: " + line)
-            debug("Reprocessing " + extra)
-            reprocess_extra = True
-            continue
-
-        # this seems to happen often: no need to push / pop it
-        if line[:12] == "(pdftex.def)":
-            continue
-
-        # Now we should have a candidate file. We still have an issue with lines that
-        # look like file names, e.g. "(Font)     blah blah data 2012.10.3" but those will
-        # get killed by the isfile call. Not very efficient, but OK in practice
-        debug("FILE? Line:" + line)
-        file_match = file_rx.match(line)
-        if file_match:
-            if line.startswith("runsystem") or file_badmatch_rx.match(line):
-                debug("Ignoring possible file: " + line)
-                file_match = False
-
-        if file_match:
-            debug("MATCHED")
-            file_name = file_match.group(1)
-            file_name = os.path.normpath(file_name.strip('"'))
-
-            if not os.path.isabs(file_name):
-                file_name = os.path.normpath(os.path.join(root_dir, file_name))
-
-            extra = file_match.group(2) + file_match.group(3)
-            # remove quotes if necessary
-            file_name = file_name.replace('"', "")
-            # on TL2011 pdftex sometimes writes "pdfTeX warning" right after file name
-            # so fix it
-            # TODO: report pdftex warning
-            if file_name[-6:] == "pdfTeX" and extra[:8] == " warning":
-                debug("pdfTeX appended to file name; removed")
-                file_name = file_name[:-6]
-                extra = "pdfTeX" + extra
-            # This kills off stupid matches
-            if (not os.path.isfile(file_name)) and debug_skip_file(file_name, root_dir):
-                # continue
-                # NOTE BIG CHANGE HERE: CONTINUE PROCESSING IF NO MATCH
-                pass
-            else:
-                debug("IT'S A FILE!")
-                files.append(file_name)
-                debug(f"{files[-1]:>{len(files)}} ({line_num})")
-                # Check if it's a xypic file
-                if (not xypic_flag) and "xypic" in file_name:
-                    xypic_flag = True
-                    debug("xypic detected, demoting parsing error to warnings")
-                # now we recycle the remainder of this line
-                debug("Reprocessing " + extra)
-                reprocess_extra = True
-                continue
-
-        # Special case: match xypic's " loaded)" markers
-        # You may think we already checked for this. But, NO! We must check both BEFORE and
-        # AFTER looking for file matches. The problem is that we
-        # may have the " loaded)" marker either after non-file text, or after a loaded
-        # file name. Aaaarghh!!!
-        xypic_match = xypic_rx.match(line)
-        if xypic_match:
-            debug("xypic match after: " + line)
-            # Do an extra check to make sure we are not too eager: is the topmost file
-            # likely to be an xypic file? Look for xypic in the file name
-            if files and "xypic" in files[-1]:
-                debug(f"{files[-1]:>{len(files)}} ({line_num})")
-                f = files.pop()
-                debug(f"Popped file: {f} ({line_num})")
-                extra = xypic_match.group(1)
-                debug("Reprocessing " + extra)
-                reprocess_extra = True
-                continue
-            else:
-                debug("Found loaded) but top file name doesn't have xy")
-
-        if len(line) > 0 and line[0] == "!":  # Now it's surely an error
-            debug("Fatal error found: " + line)
-            # If it's a pdftex error, it's on the current line, so report it
-            if "pdfTeX error" in line:
-                err_msg = line[1:].strip()  # remove '!' and possibly spaces
-                # This may or may not have a file location associated with it.
-                # Be conservative and do not try to report one.
-                errors.append(err_msg)
-                errors.append("Check the TeX log file for more information")
-                continue
-            # special: all text was ignored after line
-            if "all text was ignored after line" in line:
-                # we may be unable to report a file by popping it, so HACK HACK HACK
-                file_name, linelen = next(log_iterator)  # <inserted text>
-                file_name, linelen = next(log_iterator)  #      \fi
-                file_name, linelen = next(log_iterator)
-                file_name = file_name[3:]  # here is the file name with <*> in front
-                errors.append("TeX STOPPED: " + line[1:].strip())
-                errors.append("TeX reports the error was in file:" + file_name)
-                continue
-            # Now it's a regular TeX error
-            err_msg = line[2:]  # skip "! "
-            # next time around, err_msg will be set and we'll extract all info
-            state = STATE_REPORT_FATAL
-            continue
-
-        error_match = error_rx.match(line)
-        if error_match:
-            debug("Error found: " + line)
-            # if last character is a dot, it's a single line
-            if line[-1] == ".":
-                handle_error(line)
-                continue
-            # otherwise, accumulate it
-            current_error = line
-            state = STATE_REPORT_ERROR
-            continue
-
-        warning_match = warning_rx.match(line)
-        if warning_match:
-            debug("Warning found: " + line)
-            # if last character is a dot, it's a single line
-            if line[-1] == ".":
-                handle_warning(line)
-                continue
-            # otherwise, accumulate it
-            current_warning = line
-            state = STATE_REPORT_WARNING
-            continue
-
-        # Second match for opening page numbers. We now use "search" which matches
-        # everywhere, not just at the beginning. We do so AFTER matching file names so we
-        # don't miss any.
-        pagenum_begin_match = pagenum_begin_rx.search(line)
-        if pagenum_begin_match:
-            debug("Matching [xx after some text")
-            extra = pagenum_begin_match.group(1)
-            debug("Reprocessing " + extra)
-            reprocess_extra = True
-            continue
-
-    # If there were parsing issues, output them to debug
-    if parsing:
-        warnings.append("(Log parsing issues. Disregard unless something else is wrong.)")
-        for l in parsing:
-            print(f"parseTeXlog: {l}")
-
-    return (errors, warnings, badboxes)
-
-
-# If invoked from the command line, parse provided log file
-
-if __spec__.name == "__main__":
-    print_debug = True
-    interactive = True
+    # open logfile into panel
     try:
-        logfilename = sys.argv[1]
-        if len(sys.argv) == 3:
-            extra_file_ext = sys.argv[2].split(" ")
-        data = open(logfilename, "rb").read()
-        root_dir = os.path.dirname(logfilename)
-        errors, warnings, badboxes = parse_tex_log(data, logfilename)
-        print("")
-        print("Errors:")
-        for err in errors:
-            print(err)
-        print("")
-        print("Warnings:")
-        for warn in warnings:
-            print(warn)
-        print("")
-        print("Bad boxes:")
-        for box in badboxes:
-            print(box)
-    except Exception as e:
-        import traceback
+        with open(logfile, encoding="utf-8") as fobj:
+            text = fobj.read()
+        text = text.replace("\r\n", "\n").replace("\r", "\n")
+        panel.run_command("append", {"characters": text})
+        return parse_log_view(panel)
+    finally:
+        window.destroy_output_panel("latextools_logfile")
 
-        traceback.print_exc()
+
+class LatextoolsDumpTexLog(sublime_plugin.WindowCommand):
+    """
+    This class implements the `latextools_dump_tex_log` command.
+
+    The debug command dumps all log entries, found in a tex log to ST's console.
+    """
+
+    def run(self):
+        view = self.window.active_view()
+        if not view:
+            print("Not a view, cancelling!")
+            return
+        syntax = view.syntax()
+        if not syntax:
+            print("View has no syntax assigned, cancelling!")
+            return
+        if syntax.name != "LaTeXTools Log":
+            print("View has wrong syntax assigned, cancelling!")
+            return
+        for item in chain(*parse_log_view(view)):
+            print(item)

--- a/plugin.py
+++ b/plugin.py
@@ -127,6 +127,9 @@ from .latextools.toc_quickpanel import (
 from .latextools.toggle_settings import (
     LatextoolsToggleKeysCommand
 )
+from .latextools.utils.tex_log import (
+    LatextoolsDumpTexLog
+)
 
 from .plugins.viewer.dbus_viewer import LatextoolsDbusViewerListener
 

--- a/tests/test_log_parser.py
+++ b/tests/test_log_parser.py
@@ -1,0 +1,249 @@
+import os
+from textwrap import dedent
+from unittesting import DeferrableViewTestCase
+
+from ..latextools.utils.tex_log import parse_log_view
+
+
+class ParseTexLogTestCase(DeferrableViewTestCase):
+    view_settings = {
+        "auto_indent": False,
+        "auto_match_enabled": False,
+        "draw_indent_guides": False,
+        "draw_white_space": "none",
+        "detect_indentation": False,
+        "disable_auto_complete": False,
+        "encoding": "UTF-8",
+        "gutter": False,
+        "line_numbers": False,
+        "rulers": [],
+        "syntax": "LaTeXTools Log.sublime-syntax",
+        "tab_size": 2,
+        "translate_tabs_to_spaces": False,
+        "word_wrap": False,
+    }
+
+    def assert_tex_log_items(self, content, expected_errors, expected_warnings, expected_badboxes):
+        self.setText(dedent(content))
+        errors, warnings, badboxes = parse_log_view(self.view)
+        self.assertEqual(expected_errors, errors)
+        self.assertEqual(expected_warnings, warnings)
+        self.assertEqual(expected_badboxes, badboxes)
+
+    def test_empty(self):
+        self.assert_tex_log_items(
+            # content
+            R"""
+            This is pdfTeX, Version 3.141592653-2.6-1.40.28 (TeX Live 2025) (preloaded format=pdflatex 2025.8.8)  12 OCT 2025 12:41
+            entering extended mode
+             restricted \write18 enabled.
+             %&-line parsing enabled.
+            **main.tex
+            (./main.tex
+            )
+            """,
+            expected_errors=[],
+            expected_warnings=[],
+            expected_badboxes=[],
+        )
+
+    def test_emergency_stop(self):
+        self.assert_tex_log_items(
+            R"""
+            (./main.tex
+            )
+            ! Emergency stop.
+            <*> \input customize.tex
+            """,
+            expected_errors=[],
+            expected_warnings=[],
+            expected_badboxes=[],
+        )
+
+    def test_wellformed_badboxes(self):
+        self.assert_tex_log_items(
+            R"""
+            (main.tex
+            Overfull \hbox (21.7862pt too wide) in paragraph at lines 19--19
+            []\OT1/cmr/bx/n/14.4 English guide-lines for pub-li-ca-tion - TI-TLE HERE
+            )
+            """,
+            expected_errors=[],
+            expected_warnings=[],
+            expected_badboxes=[
+                Rf"main.tex:19: Overfull \hbox (21.7862pt too wide) in paragraph at lines 19--19",
+            ],
+        )
+
+    def test_wellformed_exceptions(self):
+        self.assert_tex_log_items(
+            R"""
+            (./main.tex
+
+            ! Undefined control sequence.
+            l.8   \newinst
+                          {o}{:Rounded}
+
+            The control sequence at the end of the top line
+            of your error message was never \def'ed.
+
+            ! LaTeX Error: \begin{document} ended by \end{sequencediagram}.
+
+            See the LaTeX manual or LaTeX Companion for explanation.
+            Type  H <return>  for immediate help.
+             ...
+
+            l.9 \end{sequencediagram}
+
+            Your command was ignored.
+            Type  I <command> <return>  to replace it with another command,
+            or  <return>  to continue without it.
+            )
+            """,
+            expected_errors=[
+                R"main.tex:8: Undefined control sequence near \newinst{o}{:Rounded}",
+                R"main.tex:9: LaTeX Error: \begin{document} ended by \end{sequencediagram}",
+            ],
+            expected_warnings=[],
+            expected_badboxes=[],
+        )
+
+    def test_malformed_exceptions_without_hints(self):
+        self.assert_tex_log_items(
+            R"""
+            (./main.tex
+
+            ! Undefined control sequence.
+            l.8   \newinst
+                          {o}{:Rounded}
+            ! LaTeX Error: \begin{document} ended by \end{sequencediagram}.
+
+            See the LaTeX manual or LaTeX Companion for explanation.
+            Type  H <return>  for immediate help.
+             ...
+
+            l.9 \end{sequencediagram}
+            )
+            """,
+            expected_errors=[
+                R"main.tex:8: Undefined control sequence near \newinst{o}{:Rounded}",
+                R"main.tex:9: LaTeX Error: \begin{document} ended by \end{sequencediagram}",
+            ],
+            expected_warnings=[],
+            expected_badboxes=[],
+        )
+
+    def test_malformed_exceptions_only_titles(self):
+        self.assert_tex_log_items(
+            R"""
+            (./main.tex
+            ! Undefined control sequence.
+            ! LaTeX Error: \begin{document} ended by \end{sequencediagram}.
+            )
+            """,
+            expected_errors=[
+                R"main.tex: LaTeX Error: \begin{document} ended by \end{sequencediagram}",
+                R"main.tex: Undefined control sequence",
+            ],
+            expected_warnings=[],
+            expected_badboxes=[],
+        )
+
+    def test_nested_errors(self):
+        self.assert_tex_log_items(
+            R"""
+            (./main.tex
+            (./chapters/chapter01.tex
+            Package pkgname Error: An error message on input line 10.
+            ) (./chapters/chapter02.tex
+            Package pkgname Error: An error message on input line 20.
+            )
+            Package pkgname Error: An error message on input line 1.
+            )
+            """,
+            expected_errors=[
+                f"chapters{os.sep}chapter01.tex:10: An error message on input line 10",
+                f"chapters{os.sep}chapter02.tex:20: An error message on input line 20",
+                "main.tex:1: An error message on input line 1",
+            ],
+            expected_warnings=[],
+            expected_badboxes=[],
+        )
+
+    def test_linewrapped_errors_and_warnings(self):
+        self.assert_tex_log_items(
+            R"""
+            (./main.tex
+            LaTeX Warning: Citation `KatzShnider2008' on page 17 undefined on input line 12
+            29.
+            LaTeX Warning: Citation `KatzShnider2008' on page 17 undefined on input line
+             1230.
+            LaTeX Warning: Citation `Mickelssonâ€Ž1987' on page 18 undefined on input line
+            1261.
+            """,
+            expected_errors=[],
+            expected_warnings=[
+                "main.tex:1229: Citation `KatzShnider2008' on page 17 undefined"
+                " on input line 1229",
+                "main.tex:1230: Citation `KatzShnider2008' on page 17 undefined"
+                " on input line 1230",
+                "main.tex:1261: Citation `Mickelssonâ€Ž1987' on page 18 undefined on input line1261"
+            ],
+            expected_badboxes=[],
+        )
+
+    def test_multiline_errors_and_warnings(self):
+        self.assert_tex_log_items(
+            R"""
+            (./main.tex
+            Package hyperref Error: Option `pdfauthor' has already been used,
+            (hyperref)              setting the option has no effect
+            (hyperref)              on input line 13.
+            Package hyperref Warning: Option `pdfauthor' has already been used,
+            (hyperref)                setting the option has no effect
+            (hyperref)                on input line 33.
+            )
+            """,
+            expected_errors=[
+                "main.tex:13: Option `pdfauthor' has already been used,"
+                " setting the option has no effect on input line 13",
+            ],
+            expected_warnings=[
+                "main.tex:33: Option `pdfauthor' has already been used,"
+                " setting the option has no effect on input line 33",
+            ],
+            expected_badboxes=[],
+        )
+
+    def test_filepath_processing(self):
+        self.assert_tex_log_items(
+            R"""
+            (main.tex
+            (/absolute/path/to/A-TeX_File.tex
+            Package pkgname Error: An error message on input line 5.
+            )
+            (\\wsl.localhost\distro/A-TeX_File.tex
+            Package pkgname Error: An error message on input line 10.
+            )
+            (\\wsl$\localhost\distro\A-TeX_File.tex
+            Package pkgname Error: An error message on input line 20.
+            )
+            (D:\any\folder\name\a-file.tex
+            Package pkgname Error: An error message on input line 30.
+            )
+            ("D:\any quoted
+             folder\name\a file.tex"
+            Package pkgname Error: An error message on input line 40.
+            )
+            )
+            """,
+            expected_errors=[
+                f"D:{os.sep}any quoted folder{os.sep}name{os.sep}a file.tex:40: An error message on input line 40",
+                f"D:{os.sep}any{os.sep}folder{os.sep}name{os.sep}a-file.tex:30: An error message on input line 30",
+                f"{os.sep}{os.sep}wsl${os.sep}localhost{os.sep}distro{os.sep}A-TeX_File.tex:20: An error message on input line 20",
+                f"{os.sep}{os.sep}wsl.localhost{os.sep}distro{os.sep}A-TeX_File.tex:10: An error message on input line 10",
+                f"{os.sep}absolute{os.sep}path{os.sep}to{os.sep}A-TeX_File.tex:5: An error message on input line 5",
+            ],
+            expected_warnings=[],
+            expected_badboxes=[],
+        )


### PR DESCRIPTION
This PR replaces old `parse_tex_log()` function with a completely fresh approach.

1. Open logfile in hidden output panel
2. tokenize content with LaTeXTools Log.sublime-syntax
3. extract relevant log items (errors/warnings/badboxes) via find_by_selector()
4. associate them with source location (file:line)
5. output results in tuple, same as old function did.

Fixing parsing bugs, primarily means fixing syntax bugs in LaTeXTools Log.sublime-syntax, which should be a bit more maintainable and testable, compared to a home grown implementation of a python based parser.

---

fixes #104
fixes #146
fixes #175
fixes #238
fixes #263
fixes #563
fixes #746
fixes #854
fixes #922
fixes #995
fixes #1053
fixes #1096
fixes #1134
fixes #1196
fixes #1198
fixes #1210
fixes #1216
fixes #1233
fixes #1255
fixes #1287
fixes #1367
fixes #1399
fixes #1451
fixes #1516
fixes #1680