### PR TITLE
Fix traditional builder jobname handling

### DIFF
--- a/latextools/make_pdf.py
+++ b/latextools/make_pdf.py
@@ -161,7 +161,7 @@ class CmdThread(threading.Thread):
             cmd_coroutine.close()
 
         try:
-            log_filename = f"{self.caller.builder.base_name}.log"
+            log_filename = f"{self.caller.builder.job_name or self.caller.builder.base_name}.log"
             if self.caller.builder.aux_directory_full:
                 log_file = os.path.join(self.caller.builder.aux_directory_full, log_filename)
                 if not os.path.exists(log_file):

--- a/plugins/builder/pdf_builder.py
+++ b/plugins/builder/pdf_builder.py
@@ -335,7 +335,7 @@ class PdfBuilder(LaTeXToolsPlugin):
         """
         if self.aux_directory_full != self.output_directory_full:
             for ext in (".synctex.gz", ".pdf"):
-                asset_name = self.base_name + ext
+                asset_name = (self.job_name or self.base_name) + ext
 
                 dst_file = os.path.join(self.output_directory_full, asset_name)
                 try:

--- a/plugins/builder/traditional_builder.py
+++ b/plugins/builder/traditional_builder.py
@@ -108,10 +108,10 @@ class TraditionalBuilder(PdfBuilder):
                 # if documents are opened and locked by viewer on Windows.
                 cmd.append(f"-output-directory={self.aux_directory_full}")
 
-            if self.job_name != self.base_name:
-                cmd.append(f'-jobname="{self.job_name}"')
-
             cmd += map(lambda o: f"-latexoption={o}", self.options)
+
+            if self.job_name != self.base_name:
+                cmd.append(f'-jobname={self.job_name}')
 
         elif texify:
             # no need to output messages, if they are not consumed
@@ -120,10 +120,10 @@ class TraditionalBuilder(PdfBuilder):
             else:
                 cmd.append("--quiet")
 
-            if self.job_name != self.base_name:
-                cmd.append(f'--job-name="{self.job_name}"')
-
             cmd += map(lambda o: f'--tex-option="{o}"', self.options)
+
+            if self.job_name != self.base_name:
+                cmd.append(f'--job-name={self.job_name}')
 
         # texify wants the .tex extension; latexmk doesn't care either way
         yield (cmd + [self.tex_name], f"running {cmd[0]}...")


### PR DESCRIPTION
Resolves #1076

If job name is specified e.g. via TEX directives, before this commit ...

1. latexmk failed to build the document with error 10.
2. logfile and created pdf documents were not found.

This commit enables creating several pdf files using `jobname` directive.

# Example

Building _master.tex_ creates full document with all chapters included.

Building _chapters/chapter01.tex_ creates chapter01.pdf, only.

#### master.tex

```latex
\documentclass[a4paper]{book}
\begin{document}
\input{chapters/chapter01}
\input{chapters/chapter02}
\end{document}
```

#### chapters.tex

```latex
\documentclass[a4paper]{book}
\begin{document}
\input{chapters/\jobname}
\end{document}
```

#### chapters/chapter01.tex

```latex
%!TEX jobname = chapter01
%!TEX root = ../chapters.tex

\section{Chapter 01}
\label{chapter-01}

This is chapter 1.
```

#### chapters/chapter02.tex

```latex
%!TEX jobname = chapter02
%!TEX root = ../chapters.tex

\section{Chapter 02}
\label{chapter-02}

This is chapter 2.
```