### PR TITLE
Fix logfile parsing for filenames with whitespace

### DIFF
--- a/LaTeXTools Log.sublime-syntax
+++ b/LaTeXTools Log.sublime-syntax
@@ -8,8 +8,8 @@ first_line_match: '^This is (?:Lua(?:HB)?|pdfe?|Xe)?TeXk?, Version '
 
 variables:
   drive_char: '[a-zA-Z]'
-  file_name: '{{file_char}}+{{file_ext}}{{file_break}}'
-  file_char: '[\w.-]'  # note: assume sane path names
+  file_name: '{{file_char}}*?{{file_ext}}{{file_break}}'
+  file_char: '[\s\w.-]'  # note: assume sane path names
   file_ext: '\.{{file_ext_start}}{{file_ext_char}}*'
   file_ext_start: '[a-zA-Z]'
   file_ext_char: '[a-zA-Z0-9]'
@@ -108,7 +108,7 @@ contexts:
 
   block-path-begin-continuation:
     # possible incomplete relative path or filename, starting at eol
-    - match: '[\w-]+\.?\n'
+    - match: '[\s\w-]+\.?\n'
       set:
         - block-unquoted-path-meta
         - block-unquoted-path-expect-file
@@ -188,7 +188,7 @@ contexts:
 
   block-unquoted-path-expect-file:
     # file name or extentions beginning with period
-    - match: ^{{file_char}}*?{{file_ext}}{{file_break}}
+    - match: ^{{file_name}}
       pop: 2
     # file extension without period
     - match: ^{{file_ext_char}}+{{file_break}}
@@ -204,12 +204,10 @@ contexts:
         1: punctuation.separator.path.log
       pop: 1
     # consume very long file or folder name
-    - match: ^[\w-]{79}\n
-      set: block-unquoted-path-expect-segment
-    - match: ^[\w.-]{79}\n
+    - match: ^{{file_char}}{79}\n
       pop: 1
     # file name or exteions beginning with period
-    - match: ^{{file_char}}*?{{file_ext}}{{file_break}}
+    - match: ^{{file_name}}
       pop: 1
     # otherwise it is not a block
     - match: ^
@@ -221,7 +219,7 @@ contexts:
   block-unquoted-ext:
     - meta_scope: entity.name.section.filename.log
     # file name or exteions beginning with period
-    - match: ^{{file_char}}*?{{file_ext}}{{file_break}}
+    - match: ^{{file_name}}
       pop: 1
     # file extension without period
     - match: ^{{file_ext_char}}+{{file_break}}
@@ -236,7 +234,7 @@ contexts:
     # begin of normal block body
     - match: ^(?![{{file_char}}\\/]+{{file_break}})
       pop: 1
-    - match: (?=[ \t()])
+    - match: (?=\s*[\[\]\{\}\(\)])
       pop: 1
     - match: '[\\/]'
       scope: punctuation.separator.path.log

--- a/tests/syntax/syntax_test_latex.log
+++ b/tests/syntax/syntax_test_latex.log
@@ -136,6 +136,28 @@ A-TeX_File
 #   ^ punctuation.section.block.end.log
 #    ^ - meta.block
 
+# filename with spaces
+
+(test 1691.tex)
+# <- meta.block.log punctuation.section.block.begin.log
+#^^^^^^^^^^^^^^ meta.block.log
+#^^^^^^^^^^^^^ entity.name.section.filename.log
+#             ^ punctuation.section.block.end.log
+
+(test 1691.
+tex)
+# <- meta.block.log entity.name.section.filename.log
+#^^^ meta.block.log
+#^^ entity.name.section.filename.log
+#  ^ punctuation.section.block.end.log
+
+(test
+ 1691.tex)
+# <- meta.block.log entity.name.section.filename.log
+#^^^^^^^^^ meta.block.log
+#^^^^^^^^ entity.name.section.filename.log
+#        ^ punctuation.section.block.end.log
+
 # -----------------------------------------------------------------------------
 # File Paths
 # -----------------------------------------------------------------------------
@@ -523,6 +545,24 @@ _File.tex)
 #^^^^^^^^ entity.name.section.filename.log
 #        ^ punctuation.section.block.end.log
 #         ^ - meta.block
+
+(F:\LaTeX\test-1691\.aux\test 1691.aux
+# <- meta.block.log punctuation.section.block.begin.log
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.block.log entity.name.section.filename.log
+# ^^ punctuation.separator.path.log
+#        ^ punctuation.separator.path.log
+#                  ^ punctuation.separator.path.log
+#                       ^ punctuation.separator.path.log
+)
+# <- meta.block.log punctuation.section.block.end.log
+
+(F:\LaTeX\test-1691\test
+   1691
+.aux
+# <- meta.block.log entity.name.section.filename.log
+#^^^ meta.block.log entity.name.section.filename.log
+)
+# <- meta.block.log punctuation.section.block.end.log
 
 # -----------------------------------------------------------------------------
 # Block boundary tests

--- a/tests/test_log_parser.py
+++ b/tests/test_log_parser.py
@@ -235,10 +235,15 @@ class ParseTexLogTestCase(DeferrableViewTestCase):
              folder\name\a file.tex"
             Package pkgname Error: An error message on input line 40.
             )
+            (D:\any unquoted
+             folder\name\a file.tex
+            Package pkgname Error: An error message on input line 50.
+            )
             )
             """,
             expected_errors=[
                 f"D:{os.sep}any quoted folder{os.sep}name{os.sep}a file.tex:40: An error message on input line 40",
+                f"D:{os.sep}any unquoted folder{os.sep}name{os.sep}a file.tex:50: An error message on input line 50",
                 f"D:{os.sep}any{os.sep}folder{os.sep}name{os.sep}a-file.tex:30: An error message on input line 30",
                 f"{os.sep}{os.sep}wsl${os.sep}localhost{os.sep}distro{os.sep}A-TeX_File.tex:20: An error message on input line 20",
                 f"{os.sep}{os.sep}wsl.localhost{os.sep}distro{os.sep}A-TeX_File.tex:10: An error message on input line 10",


### PR DESCRIPTION
Fixes #1691

This commit adds support for unquoted filenames with whitespace appearing at the beginning of blocks. It's MikTeX, which creates such output.