### PR TITLE
Fix \ref completions

### DIFF
--- a/latextools/latex_env_completions.py
+++ b/latextools/latex_env_completions.py
@@ -9,7 +9,7 @@ from .utils import analysis
 from .utils.settings import get_setting
 from .utils.tex_directives import get_tex_root
 
-BEGIN_END_BEFORE_REGEX = re.compile(r"([^{}\[\]]*)\{(?:\][^{}\[\]]*\[)?(?:nigeb|dne)\\")
+BEGIN_END_BEFORE_REGEX = re.compile(r"([^{}\[\]]*)\{(?:\][^]]*\[)*(?:nigeb|dne)\\")
 """
 regex pattern to detect that the cursor is predecended by a \\begin{
 """

--- a/latextools/latex_ref_completions.py
+++ b/latextools/latex_ref_completions.py
@@ -447,11 +447,11 @@ _ref_multivalue_prefixes = (
 
 OLD_STYLE_REF_REGEX = re.compile(fr"([^_]*_)?(?:(?:[-+]|\*?s?)fer(?:{_ref_prefixes})?)\\", re.I)
 
-NEW_STYLE_REF_REGEX = re.compile(fr"([^}}]*)\{{(?:(?:[-+]|\*?s?)fer(?:{_ref_prefixes})?)\\", re.I)
+NEW_STYLE_REF_REGEX = re.compile(fr"([^}}]*)\{{(?:\][^]]*\[)*(?:(?:[-+]|\*?s?)fer(?:{_ref_prefixes})?)\\", re.I)
 
-NEW_STYLE_REF_RANGE_REGEX = re.compile(fr"([^}}]*)\{{(?:\}}[^\}}]*\{{)?\*?egnarfer(?:{_ref_range_prefixes})\\", re.I)
+NEW_STYLE_REF_RANGE_REGEX = re.compile(fr"([^}}]*)\{{(?:\}}[^\}}]*\{{)?(?:\][^]]*\[)*\*?egnarfer(?:{_ref_range_prefixes})\\", re.I)
 
-NEW_STYLE_REF_MULTIVALUE_REGEX = re.compile(fr"([^}},]*)(?:,[^}},]*)*\{{[-+*]?fer(?:{_ref_multivalue_prefixes})\\", re.I)
+NEW_STYLE_REF_MULTIVALUE_REGEX = re.compile(fr"([^}},]*)(?:,[^}},]*)*\{{(?:\][^]]*\[)*[-+*]?fer(?:{_ref_multivalue_prefixes})\\", re.I)
 
 LSTSET_LABEL_REGEX = re.compile(r"label\s*=\s*([^\s,}]*)")
 


### PR DESCRIPTION
Fixes #1697

This PR inserts `\[.*\]` pattern to enable reference completions for `\ref` commands with options.

Example:

    \zref[option=value]{...}