### PR TITLE
Fix autocompletions for local commands defined in xparse style (#1466)

### DIFF
--- a/latextools/latex_command_completions.py
+++ b/latextools/latex_command_completions.py
@@ -65,6 +65,19 @@ def get_own_commands(ana):
     return ana.filter_commands(["newcommand", "renewcommand"])
 
 
+def get_own_xparse_commands(ana):
+    return ana.filter_commands([
+        "DeclareDocumentCommand",
+        "NewDocumentCommand",
+        "RenewDocumentCommand",
+        "ProvideDocumentCommand",
+        "DeclareExpandableDocumentCommand",
+        "NewExpandableDocumentCommand",
+        "RenewExpandableDocumentCommand",
+        "ProvideExpandableDocumentCommand",
+    ])
+
+
 def get_own_command_completions(tex_root):
     res = []
 
@@ -99,6 +112,24 @@ def get_own_command_completions(tex_root):
                     completion_format=sublime.COMPLETION_FORMAT_SNIPPET,
                     annotation="local",
                     details=f"from {os.path.basename(c.file_name)}",
+                    kind=kind,
+                )
+            )
+
+        for c in get_own_xparse_commands(ana):
+            # xparse commands use an argument spec like {s m O{default}}, not
+            # the numeric optional argument count used by \newcommand.
+            # For now, complete only the command name and show the full
+            # xargs spec in the details.
+            if not c.args:
+                continue
+
+            res.append(
+                sublime.CompletionItem(
+                    trigger=c.args,
+                    completion=c.args,
+                    annotation="local",
+                    details = f"{c.args}{{{c.args2 or ''}}} from {os.path.basename(c.file_name)}",
                     kind=kind,
                 )
             )


### PR DESCRIPTION
Fixes #1466.

This commit adds autocompletion for local commands create in the xparse
style. In particular, it autocompletes commands created using

    \DeclareDocumentCommand{cmd}{xargs}{def}
    \NewDocumentCommand{cmd}{xargs}{def}
    \RenewDocumentCommand{cmd}{xargs}{def}
    \ProvideDocumentCommand{cmd}{xargs}{def}
    \DeclareExpandableDocumentCommand{cmd}{xargs}{def}
    \NewExpandableDocumentCommand{cmd}{xargs}{def}
    \RenewExpandableDocumentCommand{cmd}{xargs}{def}
    \ProvideExpandableDocumentCommand{cmd}{xargs}{def}

Example:

    \NewDocumentCommand{\TestCommand}{O{x}}{x=https://github.com/SublimeText/LaTeXTools/pull/1}

In the editor, write `\Test` following by tab. The command
`\TestCommand` should appear in the auto-completions.

Note that xargs has a more complicated specification language
for possible arguments to the command, as compared to the standard
`\newcommand`. It is thus difficult to render all possible
autocompletions for an xargs command. Instead, the xargs spec is
shown in the details of the autocomplete menu.