### PR TITLE
Fix empty texpath treatment

### DIFF
--- a/latextools/system_check.py
+++ b/latextools/system_check.py
@@ -138,7 +138,7 @@ class SystemCheckThread(threading.Thread):
         if build_env is not None:
             self.env.update({k: os.path.expandvars(v) for k, v in build_env.items()})
 
-        if (texpath := get_texpath(view)) is not None:
+        if (texpath := get_texpath(view)):
             self.env["PATH"] = texpath
 
         # prepand main tex document's location to all TeX related paths such as


### PR DESCRIPTION
Fixes #1702

This PR fixes system_check command to align empty `texpath` setting treatment with that from other plugin functions. An empty string value no longer overrides default $PATH environment variable.